### PR TITLE
Updates to the docs & storybook

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -22,7 +22,7 @@ module.exports = {
           use: ['style-loader', 'css-loader', {
               loader: 'sass-loader',
               options: {
-                  additionalData: `@import '${__dirname}/../src/scss/pcui.scss';`,
+                  additionalData: `@import '${__dirname}/../src/scss/pcui-storybook.scss';`,
               }
           }],
       }

--- a/.storybook/utils/docscript.js
+++ b/.storybook/utils/docscript.js
@@ -30,19 +30,19 @@ export function getPropertiesForClass(name) {
             var defaultValue = null;
             var controlType = null;
             switch (prop.type.names[0]) {
-                case 'Array.<String>':
+                case 'Array.<string>':
                     defaultValue = [];
                     controlType = 'array';
                     break;
-                case 'Number':
+                case 'number':
                     defaultValue = 0;
                     controlType = 'number';
                     break;
-                case 'String':
+                case 'string':
                     defaultValue = '';
                     controlType = 'text';
                     break;
-                case 'Boolean':
+                case 'boolean':
                     defaultValue = false;
                     controlType = 'boolean';
                     break;

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -9,11 +9,7 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     eventmachine (1.2.7)
-    eventmachine (1.2.7-x64-mingw32)
-    eventmachine (1.2.7-x86-mingw32)
     ffi (1.13.1)
-    ffi (1.13.1-x64-mingw32)
-    ffi (1.13.1-x86-mingw32)
     forwardable-extended (2.6.0)
     http_parser.rb (0.6.0)
     i18n (1.8.5)
@@ -33,7 +29,7 @@ GEM
       rouge (~> 3.0)
       safe_yaml (~> 1.0)
       terminal-table (~> 1.8)
-    jekyll-feed (0.15.0)
+    jekyll-feed (0.15.1)
       jekyll (>= 3.7, < 5.0)
     jekyll-sass-converter (2.1.0)
       sassc (> 2.0.1, < 3.0)
@@ -70,23 +66,12 @@ GEM
     safe_yaml (1.0.5)
     sassc (2.4.0)
       ffi (~> 1.9)
-    sassc (2.4.0-x64-mingw32)
-      ffi (~> 1.9)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
-    thread_safe (0.3.6)
-    tzinfo (1.2.7)
-      thread_safe (~> 0.1)
-    tzinfo-data (1.2020.1)
-      tzinfo (>= 1.0.0)
     unicode-display_width (1.7.0)
-    wdm (0.1.1)
 
 PLATFORMS
   ruby
-  x64-mingw32
-  x86-mingw32
-  x86-mswin32
 
 DEPENDENCIES
   jekyll (~> 4.1.1)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -33,6 +33,10 @@ color_scheme: pcui
 plugins:
   - jekyll-feed
 
+aux_links:
+  "PCUI on GitHub":
+    - "//github.com/playcanvas/pcui"
+
 # Exclude from processing.
 # The following items will not be processed, by default.
 # Any item listed under the `exclude:` key here will be automatically added to

--- a/docs/_config_local.yml
+++ b/docs/_config_local.yml
@@ -33,6 +33,10 @@ color_scheme: pcui
 plugins:
   - jekyll-feed
 
+aux_links:
+  "PCUI on GitHub":
+    - "//github.com/playcanvas/pcui"
+
 # Exclude from processing.
 # The following items will not be processed, by default.
 # Any item listed under the `exclude:` key here will be automatically added to

--- a/docs/index.markdown
+++ b/docs/index.markdown
@@ -7,6 +7,8 @@ layout: home
 
 # PCUI - User interface components for the web
 
+![PCUI splash](https://camo.githubusercontent.com/556633abd49f5d713e6f5f47eaeb7edf5170f9b0/68747470733a2f2f666f72756d2d66696c65732d706c617963616e7661732d636f6d2e73332e6475616c737461636b2e65752d776573742d312e616d617a6f6e6177732e636f6d2f6f726967696e616c2f32582f372f376535316465386165363966613439396463616432393265666432316437373232646366326462642e6a706567)
+
 This library enables the creation of reliable and visually pleasing user interfaces by providing fully styled components that you can use directly on your site. The components are useful in a wide range of use cases, from creating simple forms to building graphical user interfaces for complex web tools.
 
 Next, learn how to [begin using](/pcui/getting-started) the library.

--- a/src/scss/pcui-storybook.scss
+++ b/src/scss/pcui-storybook.scss
@@ -1,0 +1,27 @@
+@import './variables.scss';
+@import './fonts.scss';
+@import './pcui-common.scss';
+@import './pcui-flex.scss';
+@import './pcui-grid.scss';
+@import './pcui-scrollable.scss';
+@import './pcui-canvas.scss';
+@import './pcui-label-group.scss';
+@import './pcui-color-input.scss';
+@import './pcui-gradient-input.scss';
+@import './pcui-asset-input.scss';
+@import './pcui-asset-list.scss';
+@import './pcui-entity-input.scss';
+@import './pcui-toggle-input.scss';
+@import './pcui-asset-thumbnail.scss';
+@import './pcui-array-input.scss';
+@import './pcui-grid-view.scss';
+@import './pcui-drop-manager.scss';
+@import './pcui-drop-target.scss';
+@import './pcui-inspector.scss';
+@import './pcui-tooltip.scss';
+@import './pcui-table.scss';
+@import './pcui-hidden.scss'; // this should be last
+
+.css-kdwx3d {
+    background-color: #374346;
+}


### PR DESCRIPTION
- Adds a link back to the github page at the top right of all docs pages.
- Adds the promo image to the docs homepage
- Component documentation now uses the dark playcanvas background for examples
- Fixed an issue where storybook controls weren't displaying after the jsdocs update

![image](https://user-images.githubusercontent.com/1721533/95450243-eb58b580-095d-11eb-8057-c543eef09646.png)

![image](https://user-images.githubusercontent.com/1721533/95450295-fad7fe80-095d-11eb-9cc7-9bc8794bce88.png)
