### PR TITLE
Hide slider on read only numeric input

### DIFF
--- a/src/components/NumericInput/style.scss
+++ b/src/components/NumericInput/style.scss
@@ -43,3 +43,9 @@
         display: none;
     }
 }
+
+.pcui-numeric-input.pcui-disabled, .pcui-numeric-input.pcui-readonly {
+    .pcui-numeric-input-slider-control {
+        display: none;
+    }
+}


### PR DESCRIPTION
Hide the numeric input slider when the component is readonly or disabled.

Enabled:
![image](https://user-images.githubusercontent.com/1721533/95755368-3ba48000-0c9c-11eb-8ca1-e412f98d4a67.png)

Disabled / Read Only:
![image](https://user-images.githubusercontent.com/1721533/95755439-51b24080-0c9c-11eb-9ed5-617bb07a8404.png)
