### PR TITLE
Fix selectable labels to allow text selection

### DIFF
--- a/src/components/Label/style.scss
+++ b/src/components/Label/style.scss
@@ -11,6 +11,10 @@
     user-select: none;
 }
 
+.pcui-label.pcui-default-mousedown {
+    user-select: initial;
+}
+
 .pcui-label.pcui-multiple-values {
     position: relative;
     color: transparent;


### PR DESCRIPTION
Labels with the pcui-default-mousedown class should allow text selection.