### PR TITLE
Include pcui-hidden in pcui-react build

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -18,6 +18,9 @@ import TextAreaInput from './TextAreaInput/component';
 import TextInput from './TextInput/component';
 import VectorInput from './VectorInput/component';
 
+// import pcui-hidden last
+import '../scss/_pcui-hidden.scss';
+
 export {
     BooleanInput,
     Button,


### PR DESCRIPTION
This fixes `.pcui-hidden` not hiding anything.