### PR TITLE
Numeric Input updates

### DIFF
--- a/src/components/NumericInput/index.js
+++ b/src/components/NumericInput/index.js
@@ -170,11 +170,23 @@ class NumericInput extends TextInput {
                 // replace commas with dots (for some international keyboards)
                 value = value.replace(REGEX_COMMA, '.');
 
+                // remove spaces
+                value = value.replace(/\s/g, '');
+
                 // sanitize input to only allow short mathmatical expressions to be evaluated
                 value = value.match(/^[*/+\-0-9().]+$/);
                 if (value !== null && value[0].length < 20) {
+                    var expression = value[0];
+                    var operators = ['+', '-', '/', '*'];
+                    operators.forEach(operator => {
+                        var expressionArr = expression.split(operator);
+                        expressionArr.forEach((_, i) => {
+                            expressionArr[i] = expressionArr[i].replace(/^0+/, '');
+                        });
+                        expression = expressionArr.join(operator);
+                    });
                     // eslint-disable-next-line
-                    value = Function('"use strict";return (' + value[0] + ')')();
+                    value = Function('"use strict";return (' + expression + ')')();
                 }
             }
         } catch (error) {

--- a/src/components/NumericInput/index.js
+++ b/src/components/NumericInput/index.js
@@ -44,16 +44,14 @@ class NumericInput extends TextInput {
         this._min = args.min !== undefined ? args.min : null;
         this._max = args.max !== undefined ? args.max : null;
         this._allowNull = args.allowNull || false;
-        this._precision = args.precision !== undefined ? args.precision : 7;
+        this._precision = Number.isFinite(args.precision) ? args.precision : 7;
 
-        if (args.step !== undefined) {
+        if (Number.isFinite(args.step)) {
             this._step = args.step;
+        } else if (Number.isFinite(args.precision)) {
+            this._step = 1 / Math.pow(10, args.precision);
         } else {
-            if (this._precision !== null) {
-                this._step = 1 / Math.pow(10, this._precision);
-            } else {
-                this._step  = 1;
-            }
+            this._step  = 1;
         }
 
         this._oldValue = undefined;
@@ -75,13 +73,14 @@ class NumericInput extends TextInput {
             this._domEvtSliderMouseDown = () => {
                 this._sliderControl.dom.requestPointerLock();
                 this._sliderPrevValue = this.value;
+                this._sliderMovement = 0.0;
             };
 
             this._domEvtSliderMouseUp = () => {
                 document.exitPointerLock();
                 if (this._binding) {
                     const undoValue = this._sliderPrevValue;
-                    const redoValue = this.value;
+                    const redoValue = this._sliderPrevValue + this._sliderMovement;
                     const undo = () => {
                         var history = this._binding._bindingElementToObservers._history;
                         this._binding._bindingElementToObservers._history = null;
@@ -124,8 +123,8 @@ class NumericInput extends TextInput {
             movement = evt.movementX;
         }
         // move one step every 100 pixels
-        movement = movement / 100 * this._step;
-        this.value += movement;
+        this._sliderMovement += movement / 100 * this._step;
+        this.value = this._sliderPrevValue + this._sliderMovement;
     }
 
     _onInputChange(evt) {

--- a/src/components/NumericInput/index.js
+++ b/src/components/NumericInput/index.js
@@ -173,7 +173,7 @@ class NumericInput extends TextInput {
                 // remove spaces
                 value = value.replace(/\s/g, '');
 
-                // sanitize input to only allow short mathmatical expressions to be evaluated
+                // sanitize input to only allow short mathematical expressions to be evaluated
                 value = value.match(/^[*/+\-0-9().]+$/);
                 if (value !== null && value[0].length < 20) {
                     var expression = value[0];


### PR DESCRIPTION
- Accumulates any slider value adjustments when the mouse is down to ensure small movements still affect the input value.
- Numeric sliders with no precision argument will now use a default step value of 1 rather than basing the step value on the default precision value of 7.
- Numerical expressions that contain leading zeros are now supported
- Numerical expressions that contain spaces are now supported

Fixes #27 
Fixes #26 