### PR TITLE
Remove .font-regular from pcui.Element and instead inherit the style in CSS

### DIFF
--- a/src/components/Button/style.scss
+++ b/src/components/Button/style.scss
@@ -1,6 +1,7 @@
 // buttons
 .pcui-button {
     @extend .noSelect;
+    font-family: inherit;
     display: inline-block;
     border: 1px solid $bcg-darkest;
     border-radius: 2px;

--- a/src/components/Element/index.js
+++ b/src/components/Element/index.js
@@ -169,7 +169,6 @@ class Element extends Events {
 
         // add element class
         this._dom.classList.add(CLASS_ELEMENT);
-        this._dom.classList.add('font-regular');
 
         // add user classes
         if (args.class) {

--- a/src/components/Element/style.scss
+++ b/src/components/Element/style.scss
@@ -17,6 +17,8 @@
 }
 
 .pcui-element {
+    @extend .font-regular;
+
     border: 0 solid $border-primary;
 
     &.flash {


### PR DESCRIPTION
This is one step required to remove the !important class from Editor font CSS blocks.