### PR TITLE
Document the pcui site build process

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,48 @@
+
+# PCUI docs guide
+
+### Updating component pages (Optional if you’ve added a new component)
+
+Open `./docs/create-component-pages.js`
+
+Add your new component to the components array (including the category and component name).
+
+`cd ./docs`
+
+`node create-component-pages.js`
+
+Commit any changes to the pcui repo.
+
+### Testing docs locally
+
+If you haven't cloned the (playcanvas.github.io)[https://github.com/playcanvas/playcanvas.github.io] repo, install it locally to a projects folder which will now be referenced as `<projects_folder>`.
+
+In the puci directory run:
+
+`npm run docs:local`
+
+`rm -rf ~/<projects_folder>/playcanvas.github.io/pcui/`
+
+`cp -r ./docs/_site/ ~/<projects_folder>/playcanvas.github.io/pcui/`
+
+`cd ~/<projects_folder>/playcanvas.github.io`
+
+`python -m SimpleHTTPServer 4000`
+
+Visit [localhost:4000/pcui]
+
+### Publishing docs
+
+In the puci main directory run:
+
+`npm run docs:build`
+
+`rm -rf ~/<projects_folder>/playcanvas.github.io/pcui/`
+
+`cp -r ./docs/_site/ ~/<projects_folder>/playcanvas.github.io/pcui/`
+
+`cd ~/<projects_folder>/playcanvas.github.io`
+
+Commit changes to the (playcanvas.github.io)[https://github.com/playcanvas/playcanvas.github.io] repo & create a PR
+
+Upon the PR merging into the master branch of the repo, http://playcanvas.github.io/pcui will be updated.

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ Commit any changes to the pcui repo.
 
 ### Testing docs locally
 
-If you haven't cloned the (playcanvas.github.io)[https://github.com/playcanvas/playcanvas.github.io] repo, install it locally to a projects folder which will now be referenced as `<projects_folder>`.
+If you haven't cloned the [playcanvas.github.io](https://github.com/playcanvas/playcanvas.github.io) repo, install it locally to a projects folder which will now be referenced as `<projects_folder>`.
 
 In the puci directory run:
 
@@ -29,7 +29,7 @@ In the puci directory run:
 
 `python -m SimpleHTTPServer 4000`
 
-Visit [localhost:4000/pcui]
+Visit http://localhost:4000/pcui
 
 ### Publishing docs
 
@@ -43,6 +43,6 @@ In the puci main directory run:
 
 `cd ~/<projects_folder>/playcanvas.github.io`
 
-Commit changes to the (playcanvas.github.io)[https://github.com/playcanvas/playcanvas.github.io] repo & create a PR
+Commit changes to the [playcanvas.github.io](https://github.com/playcanvas/playcanvas.github.io) repo & create a PR
 
 Upon the PR merging into the master branch of the repo, http://playcanvas.github.io/pcui will be updated.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -45,14 +45,16 @@ aux_links:
 # Excluded items can be processed by explicitly listing the directories or
 # their entries' file path in the `include:` list.
 #
-# exclude:
-#   - .sass-cache/
-#   - .jekyll-cache/
-#   - gemfiles/
-#   - Gemfile
-#   - Gemfile.lock
-#   - node_modules/
-#   - vendor/bundle/
-#   - vendor/cache/
-#   - vendor/gems/
-#   - vendor/ruby/
+exclude:
+  - .sass-cache/
+  - .jekyll-cache/
+  - gemfiles/
+  - Gemfile
+  - Gemfile.lock
+  - node_modules/
+  - vendor/bundle/
+  - vendor/cache/
+  - vendor/gems/
+  - vendor/ruby/
+  - create-component-pages.js
+  - README.md

--- a/docs/_config_local.yml
+++ b/docs/_config_local.yml
@@ -45,14 +45,16 @@ aux_links:
 # Excluded items can be processed by explicitly listing the directories or
 # their entries' file path in the `include:` list.
 #
-# exclude:
-#   - .sass-cache/
-#   - .jekyll-cache/
-#   - gemfiles/
-#   - Gemfile
-#   - Gemfile.lock
-#   - node_modules/
-#   - vendor/bundle/
-#   - vendor/cache/
-#   - vendor/gems/
-#   - vendor/ruby/
+exclude:
+  - .sass-cache/
+  - .jekyll-cache/
+  - gemfiles/
+  - Gemfile
+  - Gemfile.lock
+  - node_modules/
+  - vendor/bundle/
+  - vendor/cache/
+  - vendor/gems/
+  - vendor/ruby/
+  - create-component-pages.js
+  - README.md

--- a/docs/create-component-pages.js
+++ b/docs/create-component-pages.js
@@ -1,0 +1,58 @@
+var components = [
+    ['input', 'boolean-input'],
+    ['input', 'button'],
+    ['input', 'numeric-input'],
+    ['input', 'select-input'],
+    ['input', 'slider-input'],
+    ['input', 'text-area-input'],
+    ['input', 'text-input'],
+    ['input', 'vector-input'],
+    ['text', 'code'],
+    ['text', 'info-box'],
+    ['text', 'label'],
+    ['layout', 'container'],
+    ['layout', 'divider'],
+    ['layout', 'overlay'],
+    ['layout', 'panel'],
+    ['layout', 'tree-view'],
+    ['misc', 'progress'],
+    ['misc', 'spinner'],
+    ['input', 'context-menu']
+];
+
+var createUpperName = (name) => {
+    var nameparts = name.split('-');
+    var result = '';
+    nameparts.forEach(part => {
+        result = result + part.substring(0, 1).toUpperCase() + part.substring(1, part.length);
+    });
+    return result;
+};
+
+components.forEach(item => {
+    var group = item[0];
+    var name = item[1];
+    var upperName = createUpperName(name);
+    var lowerName = upperName.toLowerCase();
+    var string = `---
+layout: page
+title: ${upperName} 
+permalink: /components/${name}/
+parent: Components
+---
+<iframe src="/pcui/storybook/iframe.html?id=${group}-${lowerName}--main&viewMode=docs" style="height: 100% !important;" class="component-iframe" onload="resize()"></iframe>
+
+<script>
+function resize() {
+    var iframe = document.querySelector('.component-iframe');
+    iframe.setAttribute('style', 'height: ' + iframe.contentDocument.body.offsetHeight + 'px !important; opacity: 1;');
+    iframe.contentDocument.querySelector('.sbdocs-wrapper').setAttribute('style', 'padding-top: 20px;');
+}
+</script>`;
+
+    fs = require('fs');
+    fs.writeFile(`pages/4-components/${upperName}.markdown`, string, function (err) {
+    if (err) return console.log(err);
+    console.log(`written ${upperName}.markdown`);
+    });
+});

--- a/docs/pages/4-components/ContextMenu.markdown
+++ b/docs/pages/4-components/ContextMenu.markdown
@@ -1,0 +1,15 @@
+---
+layout: page
+title: ContextMenu 
+permalink: /components/context-menu/
+parent: Components
+---
+<iframe src="/pcui/storybook/iframe.html?id=input-contextmenu--main&viewMode=docs" style="height: 100% !important;" class="component-iframe" onload="resize()"></iframe>
+
+<script>
+function resize() {
+    var iframe = document.querySelector('.component-iframe');
+    iframe.setAttribute('style', 'height: ' + iframe.contentDocument.body.offsetHeight + 'px !important; opacity: 1;');
+    iframe.contentDocument.querySelector('.sbdocs-wrapper').setAttribute('style', 'padding-top: 20px;');
+}
+</script>

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lint": "eslint --ext .js src",
     "storybook": "jsdoc -r -X src > ./.storybook/utils/jsdoc-ast.json && start-storybook -p 9009 -s public",
     "docs:local": "cd docs && bundle exec jekyll build --config _config_local.yml && mkdir _site/storybook && cd .. && ENVIRONMENT=production build-storybook --no-dll -o ./docs/_site/storybook",
-    "docs:build": "cd docs & bundle exec jekyll build && mkdir _site/storybook && cd .. && ENVIRONMENT=production build-storybook --no-dll -o ./docs/_site/storybook",
+    "docs:build": "cd docs && bundle exec jekyll build --config _config.yml && mkdir _site/storybook && cd .. && ENVIRONMENT=production build-storybook --no-dll -o ./docs/_site/storybook",
     "pcui:publish": "npm run build && cp ./package.json dist && cp ./LICENSE dist && cp README.md dist && npm publish dist"
   },
   "browserslist": {


### PR DESCRIPTION
Adds a readme which explains how to add new components to the pcui docs site, test the docs site locally and the publish it to http://playcanvas.github.io/pcui.

Also includes the node script which is used to create new component docs pages.