### PR TITLE
Expose the TreeView component

### DIFF
--- a/src/components/TreeView/index.js
+++ b/src/components/TreeView/index.js
@@ -208,29 +208,60 @@ class TreeView extends Container {
      * @returns {TreeViewItem[]} The tree items.
      */
     _getChildrenRange(startChild, endChild) {
-        const rectStart = startChild.dom.getBoundingClientRect();
-        const rectEnd = endChild.dom.getBoundingClientRect();
-        const result = [];
+        let result = [];
 
-        if (rectStart.top < rectEnd.top) {
-            let current = startChild;
-            while (current && current !== endChild) {
-                current = this._findNextVisibleTreeItem(current);
-                if (current && current !== endChild) {
-                    result.push(current);
+        // select search results if we are currently filtering tree view items
+        if (this._filterResults.length) {
+            const filterResults = this.dom.querySelectorAll(`.${CLASS_ROOT}-item.${CLASS_FILTER_RESULT}`);
+
+            let startIndex = -1;
+            let endIndex = -1;
+
+            for (let i = 0; i < filterResults.length; i++) {
+                const item = filterResults[i].ui;
+
+                if (item === startChild) {
+                    startIndex = i;
+                } else if (item === endChild) {
+                    endIndex = i;
+                }
+
+                if (startIndex !== -1 && endIndex !== -1) {
+                    const start = (startIndex < endIndex ? startIndex : endIndex);
+                    const end = (startIndex < endIndex ? endIndex : startIndex);
+                    for (let j = start; j <= end; j++) {
+                        result.push(filterResults[j].ui);
+                    }
+
+                    break;
                 }
             }
         } else {
+            // if we are not filtering the tree view then find the next visible tree item
             let current = startChild;
-            while (current && current !== endChild) {
-                current = this._findPreviousVisibleTreeItem(current);
-                if (current && current !== endChild) {
-                    result.push(current);
+
+            const rectStart = startChild.dom.getBoundingClientRect();
+            const rectEnd = endChild.dom.getBoundingClientRect();
+
+            if (rectStart.top < rectEnd.top) {
+                while (current && current !== endChild) {
+                    current = this._findNextVisibleTreeItem(current);
+                    if (current && current !== endChild) {
+                        result.push(current);
+                    }
+                }
+            } else {
+                while (current && current !== endChild) {
+                    current = this._findPreviousVisibleTreeItem(current);
+                    if (current && current !== endChild) {
+                        result.push(current);
+                    }
                 }
             }
-        }
 
-        result.push(endChild);
+            result.push(endChild);
+
+        }
 
         return result;
     }

--- a/src/components/TreeView/index.stories.jsx
+++ b/src/components/TreeView/index.stories.jsx
@@ -27,14 +27,14 @@ export const Main = (args) => (
     <TreeView {...args}>
         <TreeViewItem text='Item 1'>
             <TreeViewItem text='Item 11' />
-        </TreeViewItem>
-        <TreeViewItem text='Item 2' />
-        <TreeViewItem text='Item 3'>
-            <TreeViewItem text='Item 31'>
-                <TreeViewItem text='Item 311' />
-                <TreeViewItem text='Item 321' />
+            <TreeViewItem text='Item 12' />
+            <TreeViewItem text='Item 13'>
+                <TreeViewItem text='Item 131'>
+                    <TreeViewItem text='Item 1311' />
+                    <TreeViewItem text='Item 1321' />
+                </TreeViewItem>
+                <TreeViewItem text='Item 132' />
             </TreeViewItem>
-            <TreeViewItem text='Item 32' />
         </TreeViewItem>
     </TreeView>
 );

--- a/src/components/TreeViewItem/index.js
+++ b/src/components/TreeViewItem/index.js
@@ -138,7 +138,7 @@ class TreeViewItem extends Container {
         if (!(element instanceof TreeViewItem)) return;
 
         this._numChildren++;
-        this.classRemove(CLASS_EMPTY);
+        if (this._parent !== this._treeView) this.classRemove(CLASS_EMPTY);
 
         if (this._treeView) {
             this._treeView._onAppendTreeViewItem(element);
@@ -375,7 +375,6 @@ class TreeViewItem extends Container {
 
     set open(value) {
         if (this.open === value) return;
-
         if (value) {
             if (!this.numChildren) return;
 

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -16,6 +16,8 @@ import SliderInput from './SliderInput/component';
 import Spinner from './Spinner/component';
 import TextAreaInput from './TextAreaInput/component';
 import TextInput from './TextInput/component';
+import TreeView from './TreeView/component';
+import TreeViewItem from './TreeViewItem/component';
 import VectorInput from './VectorInput/component';
 
 // import pcui-hidden last
@@ -40,5 +42,7 @@ export {
     Spinner,
     TextAreaInput,
     TextInput,
+    TreeView,
+    TreeViewItem,
     VectorInput
 };

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,8 @@ import SliderInput from './components/SliderInput';
 import Spinner from './components/Spinner';
 import TextAreaInput from './components/TextAreaInput';
 import TextInput from './components/TextInput';
+import TreeView from './components/TreeView';
+import TreeViewItem from './components/TreeViewItem';
 import VectorInput from './components/VectorInput';
 
 // import pcui-hidden last
@@ -55,5 +57,6 @@ export {
     Spinner,
     TextAreaInput,
     TextInput,
+    TreeViewItem,
     VectorInput
 };


### PR DESCRIPTION
This exposes the TreeView and TreeViewItem components so that it's possible to build a complete tree view using the pcui build.

Fixes #47 

It also removes the open/close toggle from root TreeViewItems as they should remain open at all times (mirroring the editor functionality). The storybook example as been updated to show a tree view with a single item at its root.

Fixes #24 