### PR TITLE
Resizable TextAreaInput component

### DIFF
--- a/src/components/TextAreaInput/index.js
+++ b/src/components/TextAreaInput/index.js
@@ -2,11 +2,13 @@ import './style.scss';
 import TextInput from '../TextInput';
 
 const CLASS_TEXT_AREA_INPUT = 'pcui-text-area-input';
+const CLASS_TEXT_AREA_INPUT_RESIZABLE = CLASS_TEXT_AREA_INPUT + '-resizable';
 
 /**
  * @name TextAreaInput
  * @classdesc The TextAreaInput wraps a textarea element. It has the same interface as pcui.TextInput.
  * @augments TextInput
+ * @property {boolean} [resizable=false] Sets whether the size of the text area input can be modified by the user.
  */
 class TextAreaInput extends TextInput {
     /**
@@ -22,6 +24,9 @@ class TextAreaInput extends TextInput {
         super(args);
 
         this.class.add(CLASS_TEXT_AREA_INPUT);
+        if (args.resizable) {
+            this.class.add(CLASS_TEXT_AREA_INPUT_RESIZABLE);
+        }
     }
 
     _onInputKeyDown(evt) {

--- a/src/components/TextAreaInput/index.js
+++ b/src/components/TextAreaInput/index.js
@@ -3,12 +3,16 @@ import TextInput from '../TextInput';
 
 const CLASS_TEXT_AREA_INPUT = 'pcui-text-area-input';
 const CLASS_TEXT_AREA_INPUT_RESIZABLE = CLASS_TEXT_AREA_INPUT + '-resizable';
+const CLASS_TEXT_AREA_INPUT_RESIZABLE_NONE = CLASS_TEXT_AREA_INPUT_RESIZABLE + '-none';
+const CLASS_TEXT_AREA_INPUT_RESIZABLE_BOTH = CLASS_TEXT_AREA_INPUT_RESIZABLE + '-both';
+const CLASS_TEXT_AREA_INPUT_RESIZABLE_HORIZONTAL = CLASS_TEXT_AREA_INPUT_RESIZABLE + '-horizontal';
+const CLASS_TEXT_AREA_INPUT_RESIZABLE_VERTICAL = CLASS_TEXT_AREA_INPUT_RESIZABLE + '-vertical';
 
 /**
  * @name TextAreaInput
  * @classdesc The TextAreaInput wraps a textarea element. It has the same interface as pcui.TextInput.
  * @augments TextInput
- * @property {boolean} [resizable=false] Sets whether the size of the text area input can be modified by the user.
+ * @property {string} [resizable=none] Sets whether the size of the text area input can be modified by the user. Can be one of 'none', 'both', 'horizontal' or 'vertical'.
  */
 class TextAreaInput extends TextInput {
     /**
@@ -24,8 +28,20 @@ class TextAreaInput extends TextInput {
         super(args);
 
         this.class.add(CLASS_TEXT_AREA_INPUT);
-        if (args.resizable) {
-            this.class.add(CLASS_TEXT_AREA_INPUT_RESIZABLE);
+        switch (args.resizable) {
+            case 'both':
+                this.class.add(CLASS_TEXT_AREA_INPUT_RESIZABLE_BOTH);
+                break;
+            case 'horizontal':
+                this.class.add(CLASS_TEXT_AREA_INPUT_RESIZABLE_HORIZONTAL);
+                break;
+            case 'vertical':
+                this.class.add(CLASS_TEXT_AREA_INPUT_RESIZABLE_VERTICAL);
+                break;
+            case 'none':
+            default:
+                this.class.add(CLASS_TEXT_AREA_INPUT_RESIZABLE_NONE);
+                break;
         }
     }
 

--- a/src/components/TextAreaInput/style.scss
+++ b/src/components/TextAreaInput/style.scss
@@ -1,5 +1,5 @@
 .pcui-text-area-input {
-    height: 48px;
+    min-height: 48px;
 
     > textarea {
         resize: none;
@@ -14,5 +14,10 @@
         box-shadow: none;
         @extend .fixedFont;
     }
+}
 
+.pcui-text-area-input.pcui-text-area-input-resizable {
+    > textarea {
+        resize: both;
+    }
 }

--- a/src/components/TextAreaInput/style.scss
+++ b/src/components/TextAreaInput/style.scss
@@ -13,13 +13,31 @@
         outline: none;
         box-shadow: none;
         @extend .fixedFont;
+        min-height: 44px;
+        min-width: 172px;
     }
 }
 
-.pcui-text-area-input.pcui-text-area-input-resizable {
+.pcui-text-area-input.pcui-text-area-input-resizable-none {
+    > textarea {
+        resize: none;
+    }
+}
+
+.pcui-text-area-input.pcui-text-area-input-resizable-both {
     > textarea {
         resize: both;
-        min-height: 44px;
-        min-width: 172px;
+    }
+}
+
+.pcui-text-area-input.pcui-text-area-input-resizable-horizontal {
+    > textarea {
+        resize: horizontal;
+    }
+}
+
+.pcui-text-area-input.pcui-text-area-input-resizable-vertical {
+    > textarea {
+        resize: vertical;
     }
 }

--- a/src/components/TextAreaInput/style.scss
+++ b/src/components/TextAreaInput/style.scss
@@ -19,5 +19,7 @@
 .pcui-text-area-input.pcui-text-area-input-resizable {
     > textarea {
         resize: both;
+        min-height: 44px;
+        min-width: 172px;
     }
 }

--- a/src/components/TextInput/style.scss
+++ b/src/components/TextInput/style.scss
@@ -4,7 +4,7 @@
     border-radius: 2px;
     box-sizing: border-box;
     margin: $element-margin;
-    height: 24px;
+    min-height: 24px;
     background-color: $bcg-dark;
     vertical-align: top;
     transition: color 100ms, background-color 100ms, box-shadow 100ms;


### PR DESCRIPTION
Fixes #42 

This allows the TextAreaInput component to be resizable using the resizable arg:

![image](https://user-images.githubusercontent.com/1721533/102343586-a7ec7a00-3f92-11eb-97dd-3b78f8e728bc.png)


![image](https://user-images.githubusercontent.com/1721533/102239215-8639b700-3eee-11eb-9ef7-3ce75279e334.png)

