### PR TITLE
ArrayInput element type fallback

### DIFF
--- a/src/components/ArrayInput/index.js
+++ b/src/components/ArrayInput/index.js
@@ -265,7 +265,7 @@ class ArrayInput extends Element {
             });
         }
 
-        const element = this._args.inputClass ? new this._args.inputClass(args) : new NumericInput(args);
+        const element = this._args.inputClass ? new this._args.inputClass(args) : Element.create(this._elementType, args);
         container.append(element);
 
         element.renderChanges = this.renderChanges;


### PR DESCRIPTION
If no inputClass arg is supplied to the ArrayInput component, it should use the supplied type to create it's input elements.