### PR TITLE
Fix the TextInput component text alignment

### DIFF
--- a/src/components/TextAreaInput/style.scss
+++ b/src/components/TextAreaInput/style.scss
@@ -1,5 +1,6 @@
 .pcui-text-area-input {
     min-height: 48px;
+    height: auto;
 
     > textarea {
         resize: none;

--- a/src/components/TextInput/style.scss
+++ b/src/components/TextInput/style.scss
@@ -4,7 +4,7 @@
     border-radius: 2px;
     box-sizing: border-box;
     margin: $element-margin;
-    min-height: 24px;
+    height: 24px;
     background-color: $bcg-dark;
     vertical-align: top;
     transition: color 100ms, background-color 100ms, box-shadow 100ms;

--- a/src/components/TextInput/style.scss
+++ b/src/components/TextInput/style.scss
@@ -4,6 +4,7 @@
     border-radius: 2px;
     box-sizing: border-box;
     margin: $element-margin;
+    min-height: 24px;
     height: 24px;
     background-color: $bcg-dark;
     vertical-align: top;


### PR DESCRIPTION
The TextInput component text sometimes becomes misaligned, depending on the font used. This fix ensures it stays vertically centred.
Before:
![image](https://user-images.githubusercontent.com/1721533/102377645-d3845a00-3fbc-11eb-8aa4-0c695104a934.png)

After:
![image](https://user-images.githubusercontent.com/1721533/102377757-ef87fb80-3fbc-11eb-9b20-058856c8c3e0.png)
