### PR TITLE
SliderInput handle position fix

### DIFF
--- a/src/components/SliderInput/index.js
+++ b/src/components/SliderInput/index.js
@@ -255,8 +255,12 @@ class SliderInput extends Element {
         }
     }
 
+    _getDomSliderBarRect() {
+        return this._domSlider.children[0].getBoundingClientRect();
+    }
+
     _jumpHandle(pageX) {
-        const rect = this._domSlider.getBoundingClientRect();
+        const rect = this._getDomSliderBarRect();
         const handle = this._domHandle.getBoundingClientRect();
         const isInside = pageX > handle.left && pageX < handle.right;
         const maxValue = rect.right - rect.left;
@@ -280,7 +284,7 @@ class SliderInput extends Element {
     }
 
     _onSlideMove() {
-        const rect = this._domSlider.getBoundingClientRect();
+        const rect = this._getDomSliderBarRect();
         const x = Math.max(0, Math.min(1, this._accumValue / rect.width));
 
         const range = this._sliderMax - this._sliderMin;


### PR DESCRIPTION
Currently the handle position is calculated using the dom rect of the slider element. However this doesn't correctly represent the location and width of the slider bar that the handle moves across as the slider bar has an 8px horizontal margin:
![image](https://user-images.githubusercontent.com/1721533/102480469-37a82c00-4058-11eb-991e-aeb7ee96593f.png)

The slider bar element rect should be used to calculate the handles position rather than that of the parent slider element.