### PR TITLE
Change slider handle behaviour

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playcanvas/pcui",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "author": "PlayCanvas <support@playcanvas.com>",
   "homepage": "https://playcanvas.github.io/pcui",
   "description": "This library enables the creation of reliable and visually pleasing user interfaces by providing fully styled components that you can use directly on your site. The components are useful in a wide range of use cases, from creating simple forms to building graphical user interfaces for complex web tools.",


### PR DESCRIPTION
This PR removes the accumulator logic which causes the handle to jump after undo / redo of a value change. 

Now the slider will not move the handle on initial grab (unless the cursor is in a completely different position). Instead it will allow a small offset from the center of the handle and allow dragging the handle from that point instead.