### PR TITLE
Add newChildIndex to the reparent function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@playcanvas/pcui",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playcanvas/pcui",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "author": "PlayCanvas <support@playcanvas.com>",
   "homepage": "https://playcanvas.github.io/pcui",
   "description": "This library enables the creation of reliable and visually pleasing user interfaces by providing fully styled components that you can use directly on your site. The components are useful in a wide range of use cases, from creating simple forms to building graphical user interfaces for complex web tools.",


### PR DESCRIPTION
When we reparent treeview items we need to know which child index will the reparented item have under the new parent. This PR adds a newChildIndex property to the data passed to the reparent function.