### PR TITLE
Do not manually call removeChild for elements with destroyed parent

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playcanvas/pcui",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "author": "PlayCanvas <support@playcanvas.com>",
   "homepage": "https://playcanvas.github.io/pcui",
   "description": "This library enables the creation of reliable and visually pleasing user interfaces by providing fully styled components that you can use directly on your site. The components are useful in a wide range of use cases, from creating simple forms to building graphical user interfaces for complex web tools.",

--- a/src/components/Element/index.js
+++ b/src/components/Element/index.js
@@ -405,7 +405,7 @@ class Element extends Events {
             // didn't work because of an override or other condition
             this._parent = null;
 
-            if (this._dom && this._dom.parentElement) {
+            if (!parent._destroyed && this._dom && this._dom.parentElement) {
                 this._dom.parentElement.removeChild(this._dom);
             }
 

--- a/src/components/Element/index.js
+++ b/src/components/Element/index.js
@@ -405,6 +405,10 @@ class Element extends Events {
             // didn't work because of an override or other condition
             this._parent = null;
 
+            // Do not manually call removeChild for elements whose parent has already been destroyed.
+            // For example when we destroy a TreeViewItem that has many child nodes, that will trigger every child Element to call dom.parentElement.removeChild(dom).
+            // But we don't need to remove all these DOM elements from their parents since the root DOM element is destroyed anyway.
+            // This has a big impact on destroy speed in certain cases.
             if (!parent._destroyed && this._dom && this._dom.parentElement) {
                 this._dom.parentElement.removeChild(this._dom);
             }


### PR DESCRIPTION
Do not manually call removeChild for elements whose parent has already been destroyed.

For example when we destroy a TreeViewItem that has many child nodes, that will trigger every child Element to call `dom.parentElement.removeChild(dom)`.

But we don't need to remove all these DOM elements from their parents since the root DOM element is destroyed anyway.

This has a big impact on destroy speed in certain cases.