### PR TITLE
Fix numeric inputs not using precision when viewing multiple values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@playcanvas/pcui",
-  "version": "1.1.11",
+  "version": "1.1.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playcanvas/pcui",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "author": "PlayCanvas <support@playcanvas.com>",
   "homepage": "https://playcanvas.github.io/pcui",
   "description": "This library enables the creation of reliable and visually pleasing user interfaces by providing fully styled components that you can use directly on your site. The components are useful in a wide range of use cases, from creating simple forms to building graphical user interfaces for complex web tools.",

--- a/src/components/NumericInput/index.js
+++ b/src/components/NumericInput/index.js
@@ -271,7 +271,7 @@ class NumericInput extends TextInput {
                 this._sliderControl.class.add(CLASS_NUMERIC_INPUT_SLIDER_CONTROL_HIDDEN);
             }
         } else {
-            this._updateValue(values[0]);
+            this._updateValue(this._normalizeValue(values[0]));
             if (this._sliderControl) {
                 this._sliderControl.class.remove(CLASS_NUMERIC_INPUT_SLIDER_CONTROL_HIDDEN);
             }

--- a/src/components/NumericInput/index.js
+++ b/src/components/NumericInput/index.js
@@ -271,7 +271,7 @@ class NumericInput extends TextInput {
                 this._sliderControl.class.add(CLASS_NUMERIC_INPUT_SLIDER_CONTROL_HIDDEN);
             }
         } else {
-            this._updateValue(this._normalizeValue(values[0]));
+            this._updateValue(value);
             if (this._sliderControl) {
                 this._sliderControl.class.remove(CLASS_NUMERIC_INPUT_SLIDER_CONTROL_HIDDEN);
             }


### PR DESCRIPTION
When setting the `values` property of a NumericInput if we determined that all the values are equal we would then show the first value but we wouldn't adjust its precision, which resulted in showing multiple decimals sometimes. 

Now we use the normalized value so we should not see multiple decimals when using the `values` property.