### PR TITLE
When filtering SelectInput options, reorder them based on their best match

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playcanvas/pcui",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "author": "PlayCanvas <support@playcanvas.com>",
   "homepage": "https://playcanvas.github.io/pcui",
   "description": "This library enables the creation of reliable and visually pleasing user interfaces by providing fully styled components that you can use directly on your site. The components are useful in a wide range of use cases, from creating simple forms to building graphical user interfaces for complex web tools.",


### PR DESCRIPTION
Currently when we filter the visible options for a SelectInput, we score each option based on the search string and then we show / hide each option. 

This PR changes that to reorder the options based on their best match score which also removes any options that are not in the search results.

The result should be that more relevant matches appear higher in the list.