### PR TITLE
TreeView component react fix

### DIFF
--- a/src/components/TreeView/component.jsx
+++ b/src/components/TreeView/component.jsx
@@ -20,8 +20,19 @@ class TreeView extends BaseComponent {
             this.loadChildren(child.props.children, childElement);
         });
     }
+    componentDidUpdate(props) {
+        this.parentElement.removeChild(this.element.dom);
+        this.element = new TreeViewElement({...props});
+        this.loadChildren(props.children, this.element);
+        this.parentElement.appendChild(this.element.dom);
+    }
+    parentElementRendered(element) {
+        if (!element) return;
+        this.parentElement = element;
+        this.parentElement.appendChild(this.element.dom);
+    }
     render() {
-        return <div ref={(nodeElement) => {nodeElement && nodeElement.appendChild(this.element.dom)}} />
+        return <div ref={this.parentElementRendered.bind(this)} />
     }
 }
 


### PR DESCRIPTION
Fixes #84 

The TreeView wasn't responding to updates to it's props value and therefore wasn't updating it's TreeViewItems when a user changed the tree's hierarchy. This PR fixes that by listening to component property updates and rebuilding the pcui TreeView with these updated properties.