### PR TITLE
Label component default text

### DIFF
--- a/src/components/Label/component.jsx
+++ b/src/components/Label/component.jsx
@@ -15,7 +15,7 @@ class Label extends BaseComponent {
 Label.propTypes = {};
 Label.ctor = Element;
 Label.defaultProps = {
-    text: 'Hello World'
+    text: ''
 };
 
 export default Label;


### PR DESCRIPTION
Remove the default text from the Label propTypes as this will sometimes show up before before a user sets the Label value.