### PR TITLE
Spinner component fix

### DIFF
--- a/src/components/Spinner/style.scss
+++ b/src/components/Spinner/style.scss
@@ -1,3 +1,12 @@
+@keyframes animation-spin {
+    from {
+        transform: rotate(0deg);
+    }
+    to {
+        transform: rotate(360deg);
+    }
+}
+
 .pcui-spinner {
     display: inline-block;
     margin: $element-margin;


### PR DESCRIPTION
The spinner components styling doesn't currently include the animation keyframes it requires.