### PR TITLE
Update observer and observer-list to latest Editor version

### DIFF
--- a/src/binding/observer-list.js
+++ b/src/binding/observer-list.js
@@ -156,6 +156,12 @@ ObserverList.prototype.add = function (item) {
     }
 
     this.emit('add', item, index, pos);
+    if (this.index) {
+        const id = item.get(this.index);
+        if (id) {
+            this.emit(`add[${id}]`, item, index, pos);
+        }
+    }
 
     return pos;
 };

--- a/src/binding/observer.js
+++ b/src/binding/observer.js
@@ -331,7 +331,7 @@ Observer.prototype.set = function (path, value, silent, remote, force) {
         } else {
             node._data[key] = [];
             value.forEach((val) => {
-                this._doInsert(node, key, val);
+                this._doInsert(node, key, val, undefined, true);
             });
 
             state = obj.silence();
@@ -731,7 +731,7 @@ Observer.prototype.insert = function (path, value, ind, silent, remote) {
     return true;
 };
 
-Observer.prototype._doInsert = function (node, key, value, ind) {
+Observer.prototype._doInsert = function (node, key, value, ind, allowDuplicates) {
     const arr = node._data[key];
 
     if (typeof(value) === 'object' && ! (value instanceof Observer) && value !== null) {
@@ -743,11 +743,12 @@ Observer.prototype._doInsert = function (node, key, value, ind) {
     }
 
     const path = node._path ? `${node._path}.${key}` : key;
-    if (value !== null && (!this._pathsWithDuplicates || !this._pathsWithDuplicates[path])) {
+    if (value !== null && !allowDuplicates && (!this._pathsWithDuplicates || !this._pathsWithDuplicates[path])) {
         if (arr.indexOf(value) !== -1) {
             return;
         }
     }
+
 
     if (ind === undefined) {
         arr.push(value);


### PR DESCRIPTION
This PR updates the Observer and ObserverList classes with the latest code from the Editor. 

Then we need to switch the Editor to use these classes directly from pcui-binding (or get rid of pcui-binding altogether and include them all in pcui).