### PR TITLE
Remove style imports

### DIFF
--- a/clean-scss.js
+++ b/clean-scss.js
@@ -1,0 +1,12 @@
+const glob = require('glob');
+const fs = require('fs');
+
+glob('./src/**/*.scss', (err, files) => {
+    files.forEach((file) => {
+        const css = fs.readFileSync(file).toString();
+        const newCss = css.replace(/\/\/ #ifndef EXTRACT_CSS[\n\r]([\S\s]*?)\/\/ #endif EXTRACT_CSS/gm, '');
+        if (css !== newCss) {
+            fs.writeFileSync(file, newCss);
+        }
+    });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@playcanvas/pcui",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "build": "rollup -c",
     "lint": "eslint --ext .js src",
-    "cleanCss": "node clean-scss.js",
+    "clean:css": "node clean-scss.js",
     "storybook": "jsdoc -r -X src > ./.storybook/utils/jsdoc-ast.json && start-storybook -p 9009 -s public",
     "docs:local": "cd docs && bundle exec jekyll build --config _config_local.yml && mkdir _site/storybook && cd .. && ENVIRONMENT=production build-storybook --no-dll -o ./docs/_site/storybook",
     "docs:build": "cd docs && bundle exec jekyll build --config _config.yml && mkdir _site/storybook && cd .. && ENVIRONMENT=production build-storybook --no-dll -o ./docs/_site/storybook",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "build": "rollup -c",
     "lint": "eslint --ext .js src",
+    "cleanCss": "node clean-scss.js",
     "storybook": "jsdoc -r -X src > ./.storybook/utils/jsdoc-ast.json && start-storybook -p 9009 -s public",
     "docs:local": "cd docs && bundle exec jekyll build --config _config_local.yml && mkdir _site/storybook && cd .. && ENVIRONMENT=production build-storybook --no-dll -o ./docs/_site/storybook",
     "docs:build": "cd docs && bundle exec jekyll build --config _config.yml && mkdir _site/storybook && cd .. && ENVIRONMENT=production build-storybook --no-dll -o ./docs/_site/storybook",
@@ -65,6 +66,7 @@
     "@testing-library/user-event": "^7.1.2",
     "babel-loader": "^8.2.2",
     "eslint": "^7.25.0",
+    "glob": "^7.1.7",
     "jsdoc": "^3.6.5",
     "json-loader": "^0.5.7",
     "playcanvas": "^1.41.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playcanvas/pcui",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "author": "PlayCanvas <support@playcanvas.com>",
   "homepage": "https://playcanvas.github.io/pcui",
   "description": "This library enables the creation of reliable and visually pleasing user interfaces by providing fully styled components that you can use directly on your site. The components are useful in a wide range of use cases, from creating simple forms to building graphical user interfaces for complex web tools.",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -22,7 +22,7 @@ const umd = {
         }),
         sass({
             insert: !process.env.EXTRACT_CSS,
-            output: !!process.env.EXTRACT_CSS
+            output: false
         }),
         resolve()
     ]
@@ -44,7 +44,7 @@ const module = {
         }),
         sass({
             insert: !process.env.EXTRACT_CSS,
-            output: !!process.env.EXTRACT_CSS
+            output: false
         }),
         resolve(),
         babel({
@@ -75,7 +75,7 @@ const bundle = {
         }),
         sass({
             insert: !process.env.EXTRACT_CSS,
-            output: !!process.env.EXTRACT_CSS
+            output: false
         }),
         resolve(),
         babel({

--- a/src/ArrayInput/style.scss
+++ b/src/ArrayInput/style.scss
@@ -1,4 +1,6 @@
+// #ifndef EXTRACT_CSS
 @import '../scss/variables.scss';
+// #endif EXTRACT_CSS
 
 .pcui-array-input {
     margin: $element-margin;

--- a/src/BooleanInput/style.scss
+++ b/src/BooleanInput/style.scss
@@ -1,5 +1,7 @@
+// #ifndef EXTRACT_CSS
 @import '../scss/variables.scss';
 @import '../scss/fonts.scss';
+// #endif EXTRACT_CSS
 
 // boolean input
 .pcui-boolean-input {

--- a/src/Button/style.scss
+++ b/src/Button/style.scss
@@ -1,4 +1,6 @@
+// #ifndef EXTRACT_CSS
 @import '../scss/pcui.scss';
+// #endif EXTRACT_CSS
 
 // buttons
 .pcui-button {

--- a/src/Container/style.scss
+++ b/src/Container/style.scss
@@ -1,4 +1,6 @@
+// #ifndef EXTRACT_CSS
 @import '../scss/variables.scss';
+// #endif EXTRACT_CSS
 
 // container element
 .pcui-container {

--- a/src/ContextMenu/style.scss
+++ b/src/ContextMenu/style.scss
@@ -1,4 +1,6 @@
+// #ifndef EXTRACT_CSS
 @import '../scss/variables.scss';
+// #endif EXTRACT_CSS
 
 .pcui-contextmenu {
     box-sizing: border-box;

--- a/src/Divider/style.scss
+++ b/src/Divider/style.scss
@@ -1,4 +1,6 @@
+// #ifndef EXTRACT_CSS
 @import '../scss/variables.scss';
+// #endif EXTRACT_CSS
 
 .pcui-divider {
     height: 1px;

--- a/src/Element/style.scss
+++ b/src/Element/style.scss
@@ -1,5 +1,7 @@
+// #ifndef EXTRACT_CSS
 @import '../scss/variables.scss';
 @import '../scss/fonts.scss';
+// #endif EXTRACT_CSS
 
 @-webkit-keyframes pcui-flash-animation {
     from { outline-color: $text-active; }

--- a/src/GridView/style.scss
+++ b/src/GridView/style.scss
@@ -1,4 +1,6 @@
+// #ifndef EXTRACT_CSS
 @import '../scss/pcui-common';
+// #endif EXTRACT_CSS
 
 .pcui-gridview {
     @extend .pcui-flex;

--- a/src/GridViewItem/style.scss
+++ b/src/GridViewItem/style.scss
@@ -1,5 +1,7 @@
+// #ifndef EXTRACT_CSS
 @import '../scss/variables.scss';
 @import '../scss/pcui-common';
+// #endif EXTRACT_CSS
 
 .pcui-gridview-item {
     @extend .pcui-flex;

--- a/src/InfoBox/style.scss
+++ b/src/InfoBox/style.scss
@@ -1,5 +1,7 @@
+// #ifndef EXTRACT_CSS
 @import '../scss/variables.scss';
 @import '../scss/fonts.scss';
+// #endif EXTRACT_CSS
 
 .pcui-infobox {
     box-sizing: border-box;

--- a/src/Label/style.scss
+++ b/src/Label/style.scss
@@ -1,4 +1,6 @@
+// #ifndef EXTRACT_CSS
 @import '../scss/pcui.scss';
+// #endif EXTRACT_CSS
 
 .pcui-label {
     display: inline-block;

--- a/src/LabelGroup/style.scss
+++ b/src/LabelGroup/style.scss
@@ -1,5 +1,7 @@
+// #ifndef EXTRACT_CSS
 @import '../scss/variables';
 @import '../scss/pcui-common';
+// #endif EXTRACT_CSS
 
 .pcui-label-group {
     @extend .pcui-flex;

--- a/src/NumericInput/style.scss
+++ b/src/NumericInput/style.scss
@@ -1,4 +1,6 @@
+// #ifndef EXTRACT_CSS
 @import '../scss/variables.scss';
+// #endif EXTRACT_CSS
 
 .pcui-numeric-input-slider-control {
     display: none;

--- a/src/Overlay/style.scss
+++ b/src/Overlay/style.scss
@@ -1,5 +1,7 @@
+// #ifndef EXTRACT_CSS
 @import '../scss/variables.scss';
 @import '../scss/pcui-common';
+// #endif EXTRACT_CSS
 
 .pcui-overlay {
     position: absolute;

--- a/src/Panel/style.scss
+++ b/src/Panel/style.scss
@@ -1,4 +1,6 @@
+// #ifndef EXTRACT_CSS
 @import '../scss/pcui.scss';
+// #endif EXTRACT_CSS
 
 // panel element
 .pcui-panel {

--- a/src/Progress/style.scss
+++ b/src/Progress/style.scss
@@ -1,4 +1,6 @@
+// #ifndef EXTRACT_CSS
 @import '../scss/variables.scss';
+// #endif EXTRACT_CSS
 
 .pcui-progress {
     height: 4px;

--- a/src/SelectInput/style.scss
+++ b/src/SelectInput/style.scss
@@ -1,4 +1,6 @@
+// #ifndef EXTRACT_CSS
 @import '../scss/pcui.scss';
+// #endif EXTRACT_CSS
 
 .pcui-select-input {
     @extend .pcui-flex;

--- a/src/SliderInput/style.scss
+++ b/src/SliderInput/style.scss
@@ -1,4 +1,6 @@
+// #ifndef EXTRACT_CSS
 @import "../scss/pcui.scss";
+// #endif EXTRACT_CSS
 
 .pcui-slider {
     @extend .noSelect;

--- a/src/Spinner/style.scss
+++ b/src/Spinner/style.scss
@@ -1,4 +1,6 @@
+// #ifndef EXTRACT_CSS
 @import '../scss/variables.scss';
+// #endif EXTRACT_CSS
 
 @keyframes animation-spin {
     from {

--- a/src/TextAreaInput/style.scss
+++ b/src/TextAreaInput/style.scss
@@ -1,5 +1,7 @@
+// #ifndef EXTRACT_CSS
 @import '../scss/fonts.scss';
 @import '../scss/pcui-common';
+// #endif EXTRACT_CSS
 
 .pcui-text-area-input {
     min-height: 48px;

--- a/src/TextInput/style.scss
+++ b/src/TextInput/style.scss
@@ -1,4 +1,6 @@
+// #ifndef EXTRACT_CSS
 @import '../scss/pcui.scss';
+// #endif EXTRACT_CSS
 
 .pcui-text-input {
     display: inline-block;

--- a/src/TreeView/style.scss
+++ b/src/TreeView/style.scss
@@ -1,4 +1,6 @@
+// #ifndef EXTRACT_CSS
 @import '../scss/pcui.scss';
+// #endif EXTRACT_CSS
 
 .pcui-treeview {
     @extend .noSelect;

--- a/src/VectorInput/style.scss
+++ b/src/VectorInput/style.scss
@@ -1,4 +1,6 @@
+// #ifndef EXTRACT_CSS
 @import '../scss/pcui.scss';
+// #endif EXTRACT_CSS
 
 .pcui-vector-input {
     @extend .pcui-flex;


### PR DESCRIPTION
Added #ifndef #endif statements for import statements of individual scss files so that they can be removed when clean-css runs.

When pcui is built with EXTRACT_CSS=true then the application that uses the library should run `npm run cleanCss` before compiling its own css from the individual scss files.