### PR TITLE
Add rollup target umdStandalone

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -28,6 +28,25 @@ const umd = {
     ]
 };
 
+const umdStandalone = {
+    input: 'src/index.js',
+    output: {
+        file: 'dist/umd-standalone.js',
+        format: 'umd',
+        name: 'pcui'
+    },
+    plugins: [
+        del({
+            targets: 'dist/umd-standalone.js'
+        }),
+        sass({
+            insert: !process.env.EXTRACT_CSS,
+            output: false
+        }),
+        resolve()
+    ]
+};
+
 const module = {
     input: 'src/index.jsx',
     external: ['@playcanvas/observer', 'react', 'prop-types'],
@@ -40,7 +59,12 @@ const module = {
     },
     plugins: [
         del({
-            targets: ['dist/*', '!dist/index.js', '!dist/bundle']
+            targets: [
+                'dist/*',
+                '!dist/index.js',
+                '!dist/umd-standalone.js',
+                '!dist/bundle'
+            ]
         }),
         sass({
             insert: !process.env.EXTRACT_CSS,
@@ -100,4 +124,9 @@ const bundle = {
     ]
 };
 
-export default [umd, module, bundle];
+export default [
+    umd,
+    umdStandalone,
+    module,
+    bundle
+];


### PR DESCRIPTION
The current UMD `index.js` is running into this error, if someone just wants to use the build artifact as it were with webpack (previously called `pcui.js`):

![image](https://user-images.githubusercontent.com/5236548/132831739-f9ae6065-4df7-4d75-ba61-e6f3bc784c7e.png)

This PR adds a `umd-standalone.js` which is the same as UMD target while not excluding its dependencies.