### PR TITLE
Fixes for drag-scrolling near edges of TreeView

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@playcanvas/pcui",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playcanvas/pcui",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "author": "PlayCanvas <support@playcanvas.com>",
   "homepage": "https://playcanvas.github.io/pcui",
   "description": "This library enables the creation of reliable and visually pleasing user interfaces by providing fully styled components that you can use directly on your site. The components are useful in a wide range of use cases, from creating simple forms to building graphical user interfaces for complex web tools.",

--- a/src/TreeView/index.js
+++ b/src/TreeView/index.js
@@ -666,14 +666,20 @@ class TreeView extends Container {
         const rect = this.dom.getBoundingClientRect();
         this._dragScroll = 0;
         let top = rect.top;
+
         let bottom = rect.bottom;
-        if (this._dragScrollElement.dom !== this.dom) {
-            top += this._dragScrollElement.dom.scrollTop;
-            bottom += this._dragScrollElement.dom.scrollTop;
+        if (this._dragScrollElement !== this) {
+            const dragScrollRect = this._dragScrollElement.dom.getBoundingClientRect();
+            top = Math.max(top + this._dragScrollElement.dom.scrollTop, dragScrollRect.top);
+            bottom = Math.min(bottom + this._dragScrollElement.dom.scrollTop, dragScrollRect.bottom);
         }
-        if (evt.clientY - top < 32 && this._dragScrollElement.dom.scrollTop > 0) {
+
+        top = Math.max(0, top);
+        bottom = Math.min(bottom, document.body.clientHeight);
+
+        if (evt.pageY < top + 32 && this._dragScrollElement.dom.scrollTop > 0) {
             this._dragScroll = -1;
-        } else if (bottom - evt.clientY < 32 && this._dragScrollElement.dom.scrollHeight - (rect.height + this._dragScrollElement.dom.scrollTop) > 0) {
+        } else if (evt.pageY > bottom - 32 && this._dragScrollElement.dom.scrollHeight > this._dragScrollElement.height + this._dragScrollElement.dom.scrollTop) {
             this._dragScroll = 1;
         }
     }


### PR DESCRIPTION
This PR adds a dragScrollElement to the TreeView (which defaults to the TreeView itself) which is an Element that should be scrolled instead of the Treeview when the user is dragging an element towards the top / bottom of the Treeview. 