### PR TITLE
Remove second parameter from parseFloat

### DIFF
--- a/src/NumericInput/index.js
+++ b/src/NumericInput/index.js
@@ -213,7 +213,7 @@ class NumericInput extends TextInput {
 
         // fix precision
         if (this.precision !== null) {
-            value = parseFloat(Number(value).toFixed(this.precision), 10);
+            value = parseFloat(Number(value).toFixed(this.precision));
         }
 
         return value;
@@ -238,7 +238,7 @@ class NumericInput extends TextInput {
 
     get value() {
         const val = super.value;
-        return val !== '' ? parseFloat(val, 10) : null;
+        return val !== '' ? parseFloat(val) : null;
     }
 
     set value(value) {

--- a/src/SliderInput/index.js
+++ b/src/SliderInput/index.js
@@ -286,7 +286,7 @@ class SliderInput extends Element {
 
         const range = this._sliderMax - this._sliderMin;
         let value = (x * range) + this._sliderMin;
-        value = parseFloat(value.toFixed(this.precision), 10);
+        value = parseFloat(value.toFixed(this.precision));
 
         this.value = value;
     }


### PR DESCRIPTION
[`parseFloat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseFloat) does not take a second parameter, so this PR removes it from the `PCUI` sourcebase.