### PR TITLE
Remove Babel class properties plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.14.0",
-        "@babel/plugin-proposal-class-properties": "^7.13.0",
         "@babel/preset-env": "^7.14.1",
         "@babel/preset-react": "^7.13.13",
         "@playcanvas/eslint-config": "^1.0.16",

--- a/package.json
+++ b/package.json
@@ -36,15 +36,10 @@
     ]
   },
   "eslintConfig": {
-    "extends": "@playcanvas/eslint-config",
-    "parserOptions": {
-      "ecmaVersion": 9,
-      "sourceType": "module"
-    }
+    "extends": "@playcanvas/eslint-config"
   },
   "devDependencies": {
     "@babel/core": "^7.14.0",
-    "@babel/plugin-proposal-class-properties": "^7.13.0",
     "@babel/preset-env": "^7.14.1",
     "@babel/preset-react": "^7.13.13",
     "@playcanvas/eslint-config": "^1.0.16",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -49,8 +49,7 @@ const module = {
         nodeResolve(),
         babel({
             include: ['**/*.jsx'],
-            presets: ['@babel/env', '@babel/preset-react'],
-            plugins: ['@babel/plugin-proposal-class-properties']
+            presets: ['@babel/env', '@babel/preset-react']
         }),
         del({
             targets: 'dist/index.mjs',


### PR DESCRIPTION
* Remove `@babel/plugin-proposal-class-properties` because it's now enabled by default in `@babel/preset-env`.
* Remove redundant parser options for ESLint config (these options are handled in the PlayCanvas ESLint config now).