### PR TITLE
Add an icon property to the TreeViewItem class

### DIFF
--- a/src/TreeView/component.jsx
+++ b/src/TreeView/component.jsx
@@ -15,7 +15,7 @@ class TreeView extends BaseComponent {
             children = [children];
         }
         children.forEach((child) => {
-            var childElement = new TreeViewItemElement({ text: child.props.text, open: false });
+            var childElement = new TreeViewItemElement({ text: child.props.text, icon: child.props.icon, open: false });
             if (child.props.onSelected) {
                 childElement.on('select', child.props.onSelected);
             }

--- a/src/TreeView/index.stories.jsx
+++ b/src/TreeView/index.stories.jsx
@@ -26,7 +26,7 @@ export default {
 export const Main = (args) => (
     <TreeView {...args}>
         <TreeViewItem text='Item 1'>
-            <TreeViewItem text='Item 11' />
+            <TreeViewItem text='Item 11' icon='E401' />
             <TreeViewItem text='Item 12' />
             <TreeViewItem text='Item 13'>
                 <TreeViewItem text='Item 131'>

--- a/src/TreeView/style.scss
+++ b/src/TreeView/style.scss
@@ -75,7 +75,7 @@
     }
 
     &:after {
-        content: '\E360';
+        content: attr(data-icon);
         @extend .font-icon;
         display: inline-block;
         vertical-align: sub;

--- a/src/TreeViewItem/index.js
+++ b/src/TreeViewItem/index.js
@@ -52,6 +52,7 @@ const CLASS_RENAME = CLASS_ROOT + '-rename';
  * @property {boolean} allowDrag=true Whether this tree item can be dragged. Only considered if the parent treeview has allowDrag true.
  * @property {boolean} allowDrop=true Whether dropping is allowed on the tree item.
  * @property {string} text The text shown by the TreeViewItem.
+ * @property {string} icon The icon shown before the text in the TreeViewItem.
  * @property {number} The number of direct children.
  * @property {Label} textLabel Gets the internal label that shows the text.
  * @property {Label} iconLabel Gets the internal label that shows the icon.
@@ -92,6 +93,8 @@ class TreeViewItem extends Container {
             class: CLASS_ICON
         });
         this._containerContents.append(this._labelIcon);
+
+        this.icon = args.icon || 'E360';
 
         this._labelText = new Label({
             class: CLASS_TEXT
@@ -501,6 +504,22 @@ class TreeViewItem extends Container {
 
         return sibling && sibling.ui;
     }
+
+    set icon(value) {
+        if (this._icon === value || !value.match(/^E[0-9]{0,4}$/)) return;
+        this._icon = value;
+        if (value) {
+            // set data-icon attribute but first convert the value to a code point
+            this._labelIcon.dom.setAttribute('data-icon', String.fromCodePoint(parseInt(value, 16)));
+        } else {
+            this._labelIcon.dom.removeAttribute('data-icon');
+        }
+    }
+
+    get icon() {
+        return this._icon;
+    }
+
 }
 
 export default TreeViewItem;

--- a/src/TreeViewItem/index.js
+++ b/src/TreeViewItem/index.js
@@ -519,7 +519,6 @@ class TreeViewItem extends Container {
     get icon() {
         return this._icon;
     }
-
 }
 
 export default TreeViewItem;


### PR DESCRIPTION
This PR creates an icon property on the TreeViewItem class so that users as define their own icon to display. This works much like the way icons are defined for buttons.

Fixes #165 