### PR TITLE
Radio Button PCUI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@playcanvas/pcui",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@playcanvas/pcui",
-      "version": "2.3.3",
+      "version": "2.3.4",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.17.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@playcanvas/pcui",
-      "version": "2.3.1",
+      "version": "2.3.3",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playcanvas/pcui",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "author": "PlayCanvas <support@playcanvas.com>",
   "homepage": "https://playcanvas.github.io/pcui",
   "description": "This library enables the creation of reliable and visually pleasing user interfaces by providing fully styled components that you can use directly on your site. The components are useful in a wide range of use cases, from creating simple forms to building graphical user interfaces for complex web tools.",

--- a/src/GridView/index.js
+++ b/src/GridView/index.js
@@ -3,6 +3,7 @@ import GridViewItem from '../GridViewItem';
 import './style.scss';
 
 const CLASS_ROOT = 'pcui-gridview';
+const CLASS_VERTICAL = CLASS_ROOT + '-vertical';
 
 /**
  * @name GridView
@@ -11,6 +12,9 @@ const CLASS_ROOT = 'pcui-gridview';
  * @classdesc Represents a container that shows a flexible wrappable
  * list of items that looks like a grid. Contains GridViewItem's.
  * @property {GridViewItem[]} selected Gets the selected grid view items.
+ * @property {boolean} vertical If true the gridview layout will be vertical
+ * @property {boolean} multiSelect=true If true, the layout will allow for multiple options to be selected.
+ * @property {boolean} allowDeselect=true If true and multiSelect is set to false, the layout will allow options to be deselected.
  */
 class GridView extends Container {
     /**
@@ -18,13 +22,21 @@ class GridView extends Container {
      *
      * @param {object} [args] - The arguments
      * @param {Function} [args.filterFn] - A filter function to filter gridview items with signature (GridViewItem) => boolean.
+     * @param {boolean} [args.vertical] - Whether or not the layout will be vertically aligned
+     * @param {boolean} [args.multiSelect] - Whether or not the layout will allow for multiple items to be selected at once.
+     * @param {boolean} [args.allowDeselect] - Whether or not the layout will allow for options to be deselected.
      */
     constructor(args) {
         if (!args) args = {};
 
         super(args);
 
-        this.class.add(CLASS_ROOT);
+        this._vertical = args.vertical;
+        if (this._vertical) {
+            this.class.add(CLASS_VERTICAL);
+        } else {
+            this.class.add(CLASS_ROOT);
+        }
 
         this.on('append', this._onAppendGridViewItem.bind(this));
         this.on('remove', this._onRemoveGridViewItem.bind(this));
@@ -33,15 +45,26 @@ class GridView extends Container {
         this._filterAnimationFrame = null;
         this._filterCanceled = false;
 
+        // Default options for GridView layout
+        this._multiSelect = args.multiSelect;
+        this._allowDeselect = args.allowDeselect;
+
         this._selected = [];
     }
 
     _onAppendGridViewItem(item) {
         if (!(item instanceof GridViewItem)) return;
 
-        let evtClick = item.on('click', evt => this._onClickItem(evt, item));
+        let evtClick;
+        if (this._clickFn)
+            evtClick = item.on('click', evt => this._clickFn(evt, item));
+        else
+            evtClick = item.on('click', evt => this._onClickItem(evt, item));
         let evtSelect = item.on('select', () => this._onSelectItem(item));
-        let evtDeselect = item.on('deselect', () => this._onDeselectItem(item));
+
+        let evtDeselect;
+        if (this._allowDeselect)
+            evtDeselect = item.on('deselect', () => this._onDeselectItem(item));
 
         if (this._filterFn && !this._filterFn(item)) {
             item.hidden = true;
@@ -54,8 +77,10 @@ class GridView extends Container {
             evtSelect.unbind();
             evtSelect = null;
 
-            evtDeselect.unbind();
-            evtDeselect = null;
+            if (this._allowDeselect) {
+                evtDeselect.unbind();
+                evtDeselect = null;
+            }
         });
     }
 
@@ -69,9 +94,9 @@ class GridView extends Container {
     }
 
     _onClickItem(evt, item) {
-        if (evt.ctrlKey || evt.metaKey) {
+        if ((evt.ctrlKey || evt.metaKey) && this._multiSelect) {
             item.selected = !item.selected;
-        } else if (evt.shiftKey) {
+        } else if (evt.shiftKey && this._multiSelect) {
             const lastSelected = this._selected[this._selected.length - 1];
             if (lastSelected) {
                 const comparePosition = lastSelected.dom.compareDocumentPosition(item.dom);
@@ -230,6 +255,10 @@ class GridView extends Container {
 
     get selected() {
         return this._selected.slice();
+    }
+
+    get vertical() {
+        return this._vertical;
     }
 }
 

--- a/src/GridView/style.scss
+++ b/src/GridView/style.scss
@@ -8,3 +8,10 @@
     flex-wrap: wrap;
     align-content: flex-start;
 }
+
+.pcui-gridview-vertical {
+    @extend .pcui-flex;
+    flex-direction: column;
+    flex-wrap: wrap;
+    align-content: flex-start;
+}

--- a/src/GridViewItem/index.js
+++ b/src/GridViewItem/index.js
@@ -39,8 +39,6 @@ class GridViewItem extends Container {
         this.allowSelect = args.allowSelect !== undefined ? args.allowSelect : true;
         this._selected = false;
 
-        // args.type = 'radio'; // TODO: delete
-
         if (args.type == 'radio') {
             this.class.add(CLASS_ROOT_RADIO);
 
@@ -123,8 +121,6 @@ class GridViewItem extends Container {
     }
 
     set selected(value) {
-        const selectedClass = this._type == 'radio' ? CLASS_SELECTED_RADIO : CLASS_SELECTED;
-
         if (value) {
             this.focus();
         }
@@ -134,19 +130,19 @@ class GridViewItem extends Container {
         this._selected = value;
 
         if (value) {
-            this.classAdd(selectedClass);
-
             // Update radio button if it exists
             if (this._radioButton)
                 this._radioButton.value = value;
+            else
+                this.classAdd(CLASS_SELECTED);
 
             this.emit('select', this);
         } else {
-            this.classRemove(selectedClass);
-
             // Update radio button if it exists
             if (this._radioButton)
                 this._radioButton.value = false;
+            else
+                this.classRemove(CLASS_SELECTED);
 
             this.emit('deselect', this);
         }

--- a/src/GridViewItem/index.js
+++ b/src/GridViewItem/index.js
@@ -2,10 +2,13 @@ import Container from '../Container';
 import Label from '../Label';
 import BindingObserversToElement from '../BindingObserversToElement';
 import './style.scss';
+import RadioButton from '../RadioButton';
 
 const CLASS_ROOT = 'pcui-gridview-item';
+const CLASS_ROOT_RADIO = 'pcui-gridview-radio-container';
 const CLASS_SELECTED = CLASS_ROOT + '-selected';
 const CLASS_TEXT = CLASS_ROOT + '-text';
+const CLASS_RADIO_BUTTON = CLASS_ROOT + 'radiobtn';
 
 /**
  * @name GridViewItem
@@ -20,6 +23,12 @@ const CLASS_TEXT = CLASS_ROOT + '-text';
  * @property {GridViewItem} nextSibling - Returns the next visible sibling grid view item.
  */
 class GridViewItem extends Container {
+    /**
+     * Creates new pcui.GridViewItem
+     *
+     * @param {object} args - The arguments
+     * @param {string} [args.type] - The type of gridview item, can be null or 'radio'
+     */
     constructor(args) {
         args = Object.assign({
             tabIndex: 0
@@ -27,24 +36,49 @@ class GridViewItem extends Container {
 
         super(args);
 
-        this.class.add(CLASS_ROOT);
-
         this.allowSelect = args.allowSelect !== undefined ? args.allowSelect : true;
         this._selected = false;
+
+        // args.type = 'radio'; // TODO: delete
+
+        if (args.type == 'radio') {
+            this.class.add(CLASS_ROOT_RADIO);
+
+            this._radioButton = new RadioButton({
+                class: CLASS_RADIO_BUTTON,
+                binding: new BindingObserversToElement()
+            });
+
+            this._radioButtonClickEvt = this._radioButtonClick.bind(this);
+
+            // Remove radio button click event listener
+            this._radioButton.dom.removeEventListener('click', this._radioButton._onClick);
+            this._radioButton.dom.addEventListener('click', this._radioButtonClickEvt);
+
+            this.append(this._radioButton);
+        } else {
+            this.class.add(CLASS_ROOT);
+        }
 
         this._labelText = new Label({
             class: CLASS_TEXT,
             binding: new BindingObserversToElement()
         });
+
         this.append(this._labelText);
 
         this.text = args.text;
+        this._type = args.type;
 
         this._domEvtFocus = this._onFocus.bind(this);
         this._domEvtBlur = this._onBlur.bind(this);
 
         this.dom.addEventListener('focus', this._domEvtFocus);
         this.dom.addEventListener('blur', this._domEvtBlur);
+    }
+
+    _radioButtonClick() {
+        this._radioButton.value = this.selected;
     }
 
     _onFocus() {
@@ -89,6 +123,8 @@ class GridViewItem extends Container {
     }
 
     set selected(value) {
+        const selectedClass = this._type == 'radio' ? CLASS_SELECTED_RADIO : CLASS_SELECTED;
+
         if (value) {
             this.focus();
         }
@@ -98,10 +134,20 @@ class GridViewItem extends Container {
         this._selected = value;
 
         if (value) {
-            this.classAdd(CLASS_SELECTED);
+            this.classAdd(selectedClass);
+
+            // Update radio button if it exists
+            if (this._radioButton)
+                this._radioButton.value = value;
+
             this.emit('select', this);
         } else {
-            this.classRemove(CLASS_SELECTED);
+            this.classRemove(selectedClass);
+
+            // Update radio button if it exists
+            if (this._radioButton)
+                this._radioButton.value = false;
+
             this.emit('deselect', this);
         }
     }

--- a/src/GridViewItem/style.scss
+++ b/src/GridViewItem/style.scss
@@ -1,7 +1,7 @@
 // #ifndef EXTRACT_CSS
 @import '../scss/variables.scss';
 @import '../scss/pcui-common';
-@import '../RadioButton/style';  // Import radio button
+@import '../RadioButton/style';
 // #endif EXTRACT_CSS
 
 // Gridview Regular Item

--- a/src/GridViewItem/style.scss
+++ b/src/GridViewItem/style.scss
@@ -1,8 +1,10 @@
 // #ifndef EXTRACT_CSS
 @import '../scss/variables.scss';
 @import '../scss/pcui-common';
+@import '../RadioButton/style';  // Import radio button
 // #endif EXTRACT_CSS
 
+// Gridview Regular Item
 .pcui-gridview-item {
     @extend .pcui-flex;
 
@@ -15,7 +17,7 @@
     &:not(.pcui-disabled) {
         cursor: pointer;
 
-        &:not(.pcui-gridview-item-selected):hover {
+        &:not(.pcui-gridview-item-selected):not(.pcui-gridview-radiobtn):not(.pcui-gridview-radiobtn-selected):hover {
             background-color: $bcg-darker;
         }
     }
@@ -32,4 +34,24 @@
     text-overflow: ellipsis;
     margin: 0;
     padding: 0 2px;
+}
+
+// GridView Radio Buttons
+.pcui-gridview-radio-container {
+    @extend .pcui-flex;
+
+    box-sizing: border-box;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    flex-shrink: 0;
+    width: 104px;
+
+    :not(.pcui-disabled) {
+        cursor: pointer;
+    }
+}
+
+.pcui-gridview-radiobtn {
+    @extend .pcui-radio-button;
 }

--- a/src/RadioButton/component.jsx
+++ b/src/RadioButton/component.jsx
@@ -1,0 +1,17 @@
+import Element from './index';
+import BaseComponent from '../BaseComponent/index.jsx';
+
+class RadioButton extends BaseComponent {
+    constructor(props) {
+        super(props);
+        this.elementClass = Element;
+    }
+
+    render() {
+        return super.render();
+    }
+}
+
+RadioButton.ctor = Element;
+
+export default RadioButton;

--- a/src/RadioButton/index.js
+++ b/src/RadioButton/index.js
@@ -1,0 +1,160 @@
+import Element from '../Element';
+import * as pcuiClass from '../class';
+
+import './style.scss';
+
+const CLASS_RADIO_BUTTON = 'pcui-radio-button';
+const CLASS_RADIO_BUTTON_SELECTED = CLASS_RADIO_BUTTON + '-selected';
+
+/**
+ * @name RadioButton
+ * @class
+ * @classdesc A radio button element.
+ * @property {boolean} renderChanges If true the input will flash when changed.
+ * @augments Element
+ * @mixes IBindable
+ * @mixes IFocusable
+ */
+class RadioButton extends Element {
+    /**
+     * Creates a new pcui.RadioButton.
+     *
+     * @param {object} args - The arguments.
+     */
+    constructor(args) {
+        args = Object.assign({
+            tabIndex: 0
+        }, args);
+
+        super(args.dom ? args.dom : document.createElement('div'), args);
+
+        this._text = args.text || '';
+
+        this.class.add(CLASS_RADIO_BUTTON);
+        this.class.add(pcuiClass.NOT_FLEXIBLE);
+
+        this._domEventKeyDown = this._onKeyDown.bind(this);
+        this._domEventFocus = this._onFocus.bind(this);
+        this._domEventBlur = this._onBlur.bind(this);
+
+        this.dom.addEventListener('keydown', this._domEventKeyDown);
+        this.dom.addEventListener('focus', this._domEventFocus);
+        this.dom.addEventListener('blur', this._domEventBlur);
+
+        this._value = null;
+        if (args.value !== undefined) {
+            this.value = args.value;
+        }
+
+        this.renderChanges = args.renderChanges;
+    }
+
+    _onClick(evt) {
+        if (this.enabled) {
+            this.focus();
+        }
+
+        if (this.enabled && !this.readOnly) {
+            this.value = !this.value;
+        }
+
+        return super._onClick(evt);
+    }
+
+    _onKeyDown(evt) {
+        if (evt.keyCode === 27) {
+            this.blur();
+            return;
+        }
+
+        if (!this.enabled || this.readOnly) return;
+
+        if (evt.keyCode === 32) {
+            evt.stopPropagation();
+            evt.preventDefault();
+            this.value = !this.value;
+        }
+    }
+
+    _onFocus() {
+        this.emit('focus');
+    }
+
+    _onBlur() {
+        this.emit('blur');
+    }
+
+    _updateValue(value) {
+        this.class.remove(pcuiClass.MULTIPLE_VALUES);
+
+        if (value === this.value) return false;
+
+        this._value = value;
+
+        if (value) {
+            this.class.add(CLASS_RADIO_BUTTON_SELECTED);
+        } else {
+            this.class.remove(CLASS_RADIO_BUTTON_SELECTED);
+        }
+
+        if (this.renderChanges) {
+            this.flash();
+        }
+
+        this.emit('change', value);
+
+        return true;
+    }
+
+    focus() {
+        this.dom.focus();
+    }
+
+    blur() {
+        this.dom.blur();
+    }
+
+    destroy() {
+        if (this._destroyed) return;
+
+        this.dom.removeEventListener('keydown', this._domEventKeyDown);
+        this.dom.removeEventListener('focus', this._domEventFocus);
+        this.dom.removeEventListener('blur', this._domEventBlur);
+
+        super.destroy();
+    }
+
+    set value(value) {
+        const changed = this._updateValue(value);
+        if (changed && this._binding) {
+            this._binding.setValue(value);
+        }
+    }
+
+    get value() {
+        return this._value;
+    }
+
+    /* eslint accessor-pairs: 0 */
+    set values(values) {
+        let different = false;
+        const value = values[0];
+        for (let i = 1; i < values.length; i++) {
+            if (values[i] !== value) {
+                different = true;
+                break;
+            }
+        }
+
+        if (different) {
+            this._updateValue(null);
+            this.class.add(pcuiClass.MULTIPLE_VALUES);
+        } else {
+            this._updateValue(values[0]);
+        }
+    }
+}
+
+Element.register('boolean', RadioButton, { renderChanges: true });
+
+export default RadioButton;

--- a/src/RadioButton/index.stories.jsx
+++ b/src/RadioButton/index.stories.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import Component from './component';
+import { action } from '@storybook/addon-actions';
+import { getDocsForClass, getStorybookDocs } from '../../.storybook/utils/docscript'
+
+var name = 'RadioButton';
+var config = {
+    title: `Input/${name}`,
+    docs: getDocsForClass(name)
+};
+
+export default {
+    title: config.title,
+    component: Component,
+    parameters: {
+        docs: {
+            description: {
+                component: config.docs.description
+            }
+        }
+    },
+    argTypes: getStorybookDocs(config.docs)
+};
+
+export const Main = (args) => <Component onChange={action('select')} {...args} />;

--- a/src/RadioButton/style.scss
+++ b/src/RadioButton/style.scss
@@ -1,0 +1,97 @@
+// #ifndef EXTRACT_CSS
+@import '../scss/variables.scss';
+@import '../scss/fonts.scss';
+// #endif EXTRACT_CSS
+
+// radio button
+.pcui-radio-button {
+    display: inline-block;
+    position: relative;
+
+    background-color: $bcg-darker;
+    color: #fff;
+
+    width: 17px;
+    height: 17px;
+    border-radius: 50%;
+
+    overflow: hidden;
+
+    margin: $element-margin;
+    transition: opacity 100ms, background-color 100ms, box-shadow 100ms;
+
+    // outer ring
+    &:before {
+        content: '';
+        position: absolute;
+        display: block;
+        left: 50%;
+        top: 50%;
+
+        width: 16px;
+        min-width: 16px;
+        height: 16px;
+
+        transform: translate(-50%, -50%);
+        border-radius: 50%;
+
+        background-color: $bcg-darker;
+    }
+
+    // inner circle (hidden in initial state)
+    &:after {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+
+        width: 11px;
+        min-width: 11px;
+        height: 11px;
+
+        transform: translate(-50%, -50%);
+        border-radius: 50%;
+
+        background-color: white;
+    }
+}
+
+// selected
+.pcui-radio-button-selected {
+
+    // outer ring
+    &:before {
+        width: 16px;
+        min-width: 16px;
+        height: 16px;
+
+        box-sizing: border-box;
+        border: 1px solid white;
+    }
+
+    // inner circle
+    &:after {
+        content: '';
+        display: block;
+    }
+}
+
+// readonly
+.pcui-radio-button.pcui-readonly {
+    opacity: $element-opacity-readonly;
+}
+
+// disabled state
+.pcui-radio-button.pcui-disabled {
+    opacity: $element-opacity-disabled;
+}
+
+// hover
+.pcui-radio-button:not(.pcui-disabled):not(.pcui-readonly) {
+    &:hover {
+        cursor: pointer;
+
+        &:before {
+            background-color: $bcg-darkest;
+        }
+    }
+}


### PR DESCRIPTION
**Description:**

Adds a `RadioButton` component to PCUI along with additional changes to the `GridView` component in order to leverage the selection logic to accommodate for radio functionality (only one button selectable at a time). The implementation considers radio buttons as an alternative styling for `GridViewItem` components and adds additional properties onto `GridView` to allow for vertical layout, optional multiple selections and a toggle to allow items to be deselected. 

With the right combination of values for these new properties, the `GridView` component can now behave as a Radio selection panel while keeping its current behaviour as its default functionality.

**Demonstration:**

<img width="1111" alt="image" src="https://user-images.githubusercontent.com/34693834/178458925-3d17c456-8283-444d-b2a7-d0b2a8a53040.png">_Figure 1: StoryBook component docs for `RadioButton`_

<img width="1048" alt="image" src="https://user-images.githubusercontent.com/34693834/178459155-dd7111f0-2168-4f2b-8d51-4b446510cf52.png">_Figure 2: StoryBook component docs for `GridView` using Radio Functionality_


**Components Edited:**

- `Input/RadioButton` (new)
- `Layout/GridView` (edit)
- `GridViewItem` (edit)