### PR TITLE
Set selected from passed in args on TreeViewItem

### DIFF
--- a/src/TreeViewItem/index.js
+++ b/src/TreeViewItem/index.js
@@ -107,6 +107,10 @@ class TreeViewItem extends Container {
         if (args.text) {
             this.text = args.text;
         }
+        
+        if (args.selected) {
+            this.selected = args.selected;
+        }
 
         this._numChildren = 0;
 


### PR DESCRIPTION
TreeViewItem doesn't currently get initialized as selected if there is a passed in selected prop in React. I made a change to allow for this.