### PR TITLE
[Breaking] Numeric input to use shift for precision when using arrow keys or dragging

### DIFF
--- a/src/NumericInput/index.js
+++ b/src/NumericInput/index.js
@@ -50,7 +50,7 @@ class NumericInput extends TextInput {
         if (Number.isFinite(args.step)) {
             this._step = args.step;
         } else if (Number.isFinite(args.precision)) {
-            this._step = 1 / Math.pow(10, args.precision);
+            this._step = 10 / Math.pow(10, args.precision);
         } else {
             this._step = 1;
         }

--- a/src/NumericInput/index.js
+++ b/src/NumericInput/index.js
@@ -17,7 +17,7 @@ const REGEX_COMMA = /,/g;
  * @property {number} [max=1] Gets / sets the maximum value this field can take.
  * @property {number} [precision=7] Gets / sets the maximum number of decimals a value can take.
  * @property {number} [step=1] Gets / sets the amount that the value will be increased or decreased when using the arrow keys and the slider input.
- * @property {number} [stepPrecision=0.01] Gets / sets the amount that the value will be increased or decreased when holding shift using the arrow keys and the slider input. Defaults to {step} * 0.1.
+ * @property {number} [stepPrecision=0.01] Gets / sets the amount that the value will be increased or decreased when holding shift using the arrow keys and the slider input. Defaults to {@link NumericInput#step} * 0.1.
  * @property {boolean} [hideSlider=true] Hide the input mouse drag slider.
  * @augments TextInput
  */

--- a/src/NumericInput/index.js
+++ b/src/NumericInput/index.js
@@ -16,7 +16,8 @@ const REGEX_COMMA = /,/g;
  * @property {number} [min=0] Gets / sets the minimum value this field can take.
  * @property {number} [max=1] Gets / sets the maximum value this field can take.
  * @property {number} [precision=7] Gets / sets the maximum number of decimals a value can take.
- * @property {number} [step=0.01] Gets / sets the amount that the value will be increased or decreased when using the arrow keys. Holding Shift will use 10x the step.
+ * @property {number} [step=1] Gets / sets the amount that the value will be increased or decreased when using the arrow keys and the slider input.
+ * @property {number} [stepPrecision=0.01] Gets / sets the amount that the value will be increased or decreased when holding shift using the arrow keys and the slider input. Defaults to {step} * 0.1.
  * @property {boolean} [hideSlider=true] Hide the input mouse drag slider.
  * @augments TextInput
  */
@@ -52,6 +53,12 @@ class NumericInput extends TextInput {
             this._step = 1 / Math.pow(10, args.precision);
         } else {
             this._step = 1;
+        }
+
+        if (Number.isFinite(args.stepPrecision)) {
+            this._stepPrecision = args.stepPrecision;
+        } else {
+            this._stepPrecision = this._step * 0.1;
         }
 
         this._oldValue = undefined;
@@ -122,8 +129,9 @@ class NumericInput extends TextInput {
         } else if (evt.constructor === MouseEvent) {
             movement = evt.movementX;
         }
-        // move one step every 100 pixels
-        this._sliderMovement += movement / 100 * this._step;
+
+        // move one step or stepPrecision every 100 pixels
+        this._sliderMovement += movement / 100 * (evt.shiftKey ? this._stepPrecision : this._step);
         this.value = this._sliderPrevValue + this._sliderMovement;
     }
 
@@ -138,8 +146,8 @@ class NumericInput extends TextInput {
 
         // increase / decrease value with arrow keys
         if (evt.keyCode === 38 || evt.keyCode === 40) {
-            const inc = (evt.shiftKey ? 10 : 1) * (evt.keyCode === 40 ? -1 : 1);
-            this.value += this.step * inc;
+            const inc = evt.keyCode === 40 ? -1 : 1;
+            this.value += (evt.shiftKey ? this._stepPrecision : this._step) * inc;
             return;
         }
 

--- a/src/VectorInput/index.js
+++ b/src/VectorInput/index.js
@@ -21,7 +21,8 @@ class VectorInput extends Element {
      * @param {number} [args.min] - The minimum value for each vector element.
      * @param {number} [args.max] - The maximum value for each vector element.
      * @param {number} [args.precision] - The decimal precision for each vector element.
-     * @param {number} [args.step] - The incremental step when using arrow keys for each vector element.
+     * @param {number} [args.step] - The incremental step when using arrow keys or dragger for each vector element.
+     * @param {number} [args.stepPrecision] - The incremental step when holding Shift and using arrow keys or dragger for each vector element.
      * @param {boolean} [args.renderChanges] - If true each vector element will flash on changes.
      * @param {string[]|string} [args.placeholder] - The placeholder string for each vector element.
      */
@@ -46,6 +47,7 @@ class VectorInput extends Element {
                 max: args.max,
                 precision: args.precision,
                 step: args.step,
+                stepPrecision: args.stepPrecision,
                 renderChanges: args.renderChanges,
                 placeholder: args.placeholder ? (Array.isArray(args.placeholder) ? args.placeholder[i] : args.placeholder) : null
             });


### PR DESCRIPTION
Related ticket: https://github.com/playcanvas/editor/issues/912 where some users (ie me!) would use the dragger for precision over large changes.

This commit adds holding the shift modifier to use a step precision value instead of step for dragging.

This is a breaking change where we've inverted the behaviour (that's not commonly used) for holding shift. It used to apply a 10x scale to step amount where arrows where used to change the values.

The approach we are going for now is that step should be a 'reasonable' to change the number value by default given its use case and holding shift will give precision.

The stepPrecision is defaulted to step * 0.1 but can be customised on a per input basis to be something else if we choose to.

This is a breaking change but it's not common to use the arrow keys to change values let alone, holding shift as a modifier so it should be fairly safe to do.

I opted for adding a stepPrecision property over a default scale (such as 0.1) to allow us to have more customisability on the Editor side in the cases where the factor doesn't fit the usecase.