### PR TITLE
React panel rendering fix

### DIFF
--- a/src/components/Element/component.tsx
+++ b/src/components/Element/component.tsx
@@ -61,15 +61,6 @@ class Component <P extends Element.Args, S> extends React.Component <P, S> {
                 content: containerElement,
                 parent: undefined
             });
-            // @ts-ignore
-            const childrenProps = this.props.children;
-
-            if (containerElement && childrenProps) {
-                const children: any = React.Children.toArray(childrenProps);
-                children.forEach((child: any) => {
-                    this.element.append(new child.type.ctor(child.props));
-                });
-            }
         }
         if (this.onClick) {
             this.element.on('click', this.onClick);

--- a/src/components/Panel/component.tsx
+++ b/src/components/Panel/component.tsx
@@ -21,12 +21,20 @@ class Component extends BaseComponent <Element.Args, any> {
     }
 
     render() {
+        let elements: any = React.Children.toArray(this.props.children);
+
+        if (elements.length === 1) {
+            elements = React.cloneElement(elements[0], { parent: this.element });
+        } else if (elements.length > 0) {
+            elements = elements.map((element: any) => React.cloneElement(element, { parent: this.element }));
+        }
         return <div ref={(nodeElement) => {
             this.nodeElement = nodeElement;
         }}>
             <div ref={(containerElement) => {
                 this.containerElement = containerElement;
             }} >
+                {elements}
             </div>
         </div>;
     }


### PR DESCRIPTION
Update how panels render their children to handle both PCUI components and basic HTML elements. Currently the base element class manually instantiates and appends any PCUI components, however it cant handle basic elements. This PR instead uses the react render method to render out any children, no matter their type.