### PR TITLE
SelectInput: remove createLabelText default value

### DIFF
--- a/src/components/SelectInput/index.ts
+++ b/src/components/SelectInput/index.ts
@@ -92,7 +92,6 @@ class SelectInput extends Element implements Element.IBindable, Element.IFocusab
         allowInput: false,
         allowCreate: false,
         createFn: null,
-        createLabelText: 'Create',
         type: 'string',
         renderChanges: false
     };


### PR DESCRIPTION
Remove the default value for the create label text argument in the SelectInput component to maintain feature parity with the previous version of PCUI. This label should no longer show up on every SelectInput created with default arguments.