### PR TITLE
Remove TypeScript namespaces from the codebase

### DIFF
--- a/src/binding/BindingBase/index.ts
+++ b/src/binding/BindingBase/index.ts
@@ -1,34 +1,32 @@
-import Element from '../../components/Element/index';
+import { IBindable } from '../../components/Element/index';
 import { Events, History, Observer } from '@playcanvas/observer';
 
-namespace BindingBase {
-    export interface Args {
-        /**
-         * The IBindable element.
-         */
-        element?: Element.IBindable,
-        /**
-         * The history object which will be used to record undo / redo actions.
-         * If none is provided then no history will be recorded.
-         */
-        history?: History,
-        /**
-         * A prefix that will be used for the name of every history action.
-         */
-        historyPrefix?: string,
-        /**
-         * A postfix that will be used for the name of every history action.
-         */
-        historyPostfix?: string,
-        /**
-         * The name of each history action.
-         */
-        historyName?: string,
-        /**
-         * Whether to combine history actions.
-         */
-        historyCombine?: boolean
-    }
+export interface BindingBaseArgs {
+    /**
+     * The IBindable element.
+     */
+    element?: IBindable,
+    /**
+     * The history object which will be used to record undo / redo actions.
+     * If none is provided then no history will be recorded.
+     */
+    history?: History,
+    /**
+     * A prefix that will be used for the name of every history action.
+     */
+    historyPrefix?: string,
+    /**
+     * A postfix that will be used for the name of every history action.
+     */
+    historyPostfix?: string,
+    /**
+     * The name of each history action.
+     */
+    historyName?: string,
+    /**
+     * Whether to combine history actions.
+     */
+    historyCombine?: boolean
 }
 
 /**
@@ -41,7 +39,7 @@ class BindingBase extends Events {
 
     protected _applyingChange: boolean;
 
-    protected _element?: Element.IBindable;
+    protected _element?: IBindable;
 
     protected _history?: History;
 
@@ -60,7 +58,7 @@ class BindingBase extends Events {
      *
      * @param args
      */
-    constructor(args: BindingBase.Args) {
+    constructor(args: BindingBaseArgs) {
         super();
 
         // the observers we are binding to
@@ -175,11 +173,11 @@ class BindingBase extends Events {
     /**
      * The element
      */
-    set element(value: Element.IBindable | undefined) {
+    set element(value: IBindable | undefined) {
         this._element = value;
     }
 
-    get element(): Element.IBindable | undefined {
+    get element(): IBindable | undefined {
         return this._element;
     }
 

--- a/src/binding/BindingObserversToElement/index.ts
+++ b/src/binding/BindingObserversToElement/index.ts
@@ -1,13 +1,11 @@
-import BindingBase from '../BindingBase';
+import BindingBase, { BindingBaseArgs } from '../BindingBase';
 import { Observer } from '@playcanvas/observer';
 
-namespace BindingObserversToElement {
-    export interface Args extends BindingBase.Args {
-        /**
-         * Custom update function
-         */
-        customUpdate?: any
-    }
+export interface BindingObserversToElementArgs extends BindingBaseArgs {
+    /**
+     * Custom update function
+     */
+    customUpdate?: any
 }
 
 /**

--- a/src/binding/BindingTwoWay/index.ts
+++ b/src/binding/BindingTwoWay/index.ts
@@ -1,21 +1,19 @@
-import BindingBase from '../BindingBase';
+import BindingBase, { BindingBaseArgs } from '../BindingBase';
 import BindingElementToObservers from '../BindingElementToObservers';
 import BindingObserversToElement from '../BindingObserversToElement';
-import Element from '../../components/Element/index';
 import { Observer } from '@playcanvas/observer';
+import { IBindable } from '../../components/Element';
 
-namespace BindingTwoWay {
-    export interface Args extends BindingBase.Args {
-        /**
-         * BindingElementToObservers instance.
-         */
-        bindingElementToObservers?: BindingElementToObservers;
+export interface BindingTwoWayArgs extends BindingBaseArgs {
+    /**
+     * BindingElementToObservers instance.
+     */
+    bindingElementToObservers?: BindingElementToObservers;
 
-        /**
-         * BindingObserversToElement instance.
-         */
-        bindingObserversToElement?: BindingObserversToElement;
-    }
+    /**
+     * BindingObserversToElement instance.
+     */
+    bindingObserversToElement?: BindingObserversToElement;
 }
 
 /**
@@ -34,7 +32,7 @@ class BindingTwoWay extends BindingBase {
      *
      * @param args
      */
-    constructor(args: BindingTwoWay.Args = {}) {
+    constructor(args: BindingTwoWayArgs = {}) {
         super(args);
 
         this._bindingElementToObservers = args.bindingElementToObservers || new BindingElementToObservers(args);
@@ -103,13 +101,13 @@ class BindingTwoWay extends BindingBase {
         this._bindingElementToObservers.removeValues(values);
     }
 
-    set element(value: Element.IBindable | undefined) {
+    set element(value: IBindable | undefined) {
         this._element = value;
         this._bindingElementToObservers.element = value;
         this._bindingObserversToElement.element = value;
     }
 
-    get element() : Element.IBindable | undefined {
+    get element() : IBindable | undefined {
         return this._element;
     }
 

--- a/src/binding/index.ts
+++ b/src/binding/index.ts
@@ -1,11 +1,14 @@
-import BindingBase from './BindingBase';
+import BindingBase, { BindingBaseArgs } from './BindingBase';
 import BindingElementToObservers from './BindingElementToObservers';
-import BindingObserversToElement from './BindingObserversToElement';
-import BindingTwoWay from './BindingTwoWay';
+import BindingObserversToElement, { BindingObserversToElementArgs } from './BindingObserversToElement';
+import BindingTwoWay, { BindingTwoWayArgs } from './BindingTwoWay';
 
 export {
     BindingBase,
+    BindingBaseArgs,
     BindingElementToObservers,
     BindingObserversToElement,
-    BindingTwoWay
+    BindingObserversToElementArgs,
+    BindingTwoWay,
+    BindingTwoWayArgs
 };

--- a/src/components/ArrayInput/component.tsx
+++ b/src/components/ArrayInput/component.tsx
@@ -4,8 +4,8 @@ import BaseComponent from '../Element/component';
 /**
  * Element that allows editing an array of values.
  */
-class Component extends BaseComponent <Element.Args, any> {
-    constructor(props: Element.Args) {
+class Component extends BaseComponent <ElementArgs, any> {
+    constructor(props: ElementArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/ArrayInput/component.tsx
+++ b/src/components/ArrayInput/component.tsx
@@ -1,11 +1,11 @@
-import Element from './index';
+import Element, { ArrayInputArgs } from './index';
 import BaseComponent from '../Element/component';
 
 /**
  * Element that allows editing an array of values.
  */
-class Component extends BaseComponent <ElementArgs, any> {
-    constructor(props: ElementArgs) {
+class Component extends BaseComponent <ArrayInputArgs, any> {
+    constructor(props: ArrayInputArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/ArrayInput/index.ts
+++ b/src/components/ArrayInput/index.ts
@@ -1,6 +1,6 @@
 import * as utils from '../../helpers/utils';
 
-import Element from '../Element';
+import Element, { ElementArgs, IBindable, IBindableArgs, IFocusable } from '../Element';
 import Container from '../Container';
 import Panel from '../Panel';
 import NumericInput from '../NumericInput';
@@ -13,36 +13,34 @@ const CLASS_ARRAY_CONTAINER = CLASS_ARRAY_INPUT + '-items';
 const CLASS_ARRAY_ELEMENT = CLASS_ARRAY_INPUT + '-item';
 const CLASS_ARRAY_DELETE = CLASS_ARRAY_ELEMENT + '-delete';
 
-namespace ArrayInput {
-    export interface Args extends Element.Args, Element.IBindableArgs {
-        /**
-         * The type of values that the array can hold.
-         */
-        type?: string;
-        /**
-         * Arguments for each array Element.
-         */
-        elementArgs?: Array<any>;
-        /**
-         * If true then editing the number of elements that the array has will not be allowed.
-         */
-        fixedSize?: boolean;
-        /**
-         * If true then the array will be rendered using panels.
-         */
-        usePanels?: boolean;
-        /**
-         * Used to specify the default values for each element in the array. Can be left null.
-         */
-        getDefaultFn?: () => any;
-    }
+export interface ArrayInputArgs extends ElementArgs, IBindableArgs {
+    /**
+     * The type of values that the array can hold.
+     */
+    type?: string;
+    /**
+     * Arguments for each array Element.
+     */
+    elementArgs?: Array<any>;
+    /**
+     * If true then editing the number of elements that the array has will not be allowed.
+     */
+    fixedSize?: boolean;
+    /**
+     * If true then the array will be rendered using panels.
+     */
+    usePanels?: boolean;
+    /**
+     * Used to specify the default values for each element in the array. Can be left null.
+     */
+    getDefaultFn?: () => any;
 }
 
 /**
  * Element that allows editing an array of values.
  */
-class ArrayInput extends Element implements Element.IFocusable, Element.IBindable {
-    static readonly defaultArgs: ArrayInput.Args = {
+class ArrayInput extends Element implements IFocusable, IBindable {
+    static readonly defaultArgs: ArrayInputArgs = {
         ...Element.defaultArgs,
         getDefaultFn: null,
         usePanels: false
@@ -106,7 +104,7 @@ class ArrayInput extends Element implements Element.IFocusable, Element.IBindabl
 
     protected _renderChanges: boolean;
 
-    constructor(args: ArrayInput.Args = ArrayInput.defaultArgs) {
+    constructor(args: ArrayInputArgs = ArrayInput.defaultArgs) {
         args = { ...ArrayInput.defaultArgs, ...args };
 
         // remove binding because we want to set it later

--- a/src/components/BooleanInput/component.tsx
+++ b/src/components/BooleanInput/component.tsx
@@ -4,8 +4,8 @@ import BaseComponent from '../Element/component';
 /**
  * A checkbox element.
  */
-class Component extends BaseComponent <Element.Args, any> {
-    constructor(props: Element.Args = Element.defaultArgs) {
+class Component extends BaseComponent <ElementArgs, any> {
+    constructor(props: ElementArgs = Element.defaultArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/BooleanInput/component.tsx
+++ b/src/components/BooleanInput/component.tsx
@@ -1,11 +1,11 @@
-import Element from './index';
+import Element, { BooleanInputArgs } from './index';
 import BaseComponent from '../Element/component';
 
 /**
  * A checkbox element.
  */
-class Component extends BaseComponent <ElementArgs, any> {
-    constructor(props: ElementArgs = Element.defaultArgs) {
+class Component extends BaseComponent <BooleanInputArgs, any> {
+    constructor(props: BooleanInputArgs = Element.defaultArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/BooleanInput/index.ts
+++ b/src/components/BooleanInput/index.ts
@@ -1,4 +1,4 @@
-import Element from '../Element/index';
+import Element, { ElementArgs, IBindable, IBindableArgs, IFocusable } from '../Element/index';
 import Input from '../Input/index';
 import * as pcuiClass from '../../class';
 
@@ -6,20 +6,18 @@ const CLASS_BOOLEAN_INPUT = 'pcui-boolean-input';
 const CLASS_BOOLEAN_INPUT_TICKED = CLASS_BOOLEAN_INPUT + '-ticked';
 const CLASS_BOOLEAN_INPUT_TOGGLE = CLASS_BOOLEAN_INPUT + '-toggle';
 
-namespace BooleanInput {
-    export interface Args extends Element.Args, Element.IBindableArgs {
-        /**
-         * The type of checkbox. Currently can be null or 'toggle'.
-         */
-        type?: string
-    }
+export interface BooleanInputArgs extends ElementArgs, IBindableArgs {
+    /**
+     * The type of checkbox. Currently can be null or 'toggle'.
+     */
+    type?: string
 }
 
 /**
  * A checkbox element.
  */
-class BooleanInput extends Input implements Element.IBindable, Element.IFocusable {
-    static readonly defaultArgs: BooleanInput.Args = {
+class BooleanInput extends Input implements IBindable, IFocusable {
+    static readonly defaultArgs: BooleanInputArgs = {
         ...Element.defaultArgs,
         renderChanges: false,
         value: false,
@@ -35,7 +33,7 @@ class BooleanInput extends Input implements Element.IBindable, Element.IFocusabl
 
     protected _value: any;
 
-    constructor(args: BooleanInput.Args = BooleanInput.defaultArgs) {
+    constructor(args: BooleanInputArgs = BooleanInput.defaultArgs) {
         args = { ...BooleanInput.defaultArgs, ...args };
         super(args.dom, args);
 

--- a/src/components/Button/component.tsx
+++ b/src/components/Button/component.tsx
@@ -5,8 +5,8 @@ import BaseComponent from '../Element/component';
 /**
  * User input with click interaction
  */
-class Component extends BaseComponent <Element.Args, any> {
-    constructor(props: Element.Args = Element.defaultArgs) {
+class Component extends BaseComponent <ElementArgs, any> {
+    constructor(props: ElementArgs = Element.defaultArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/Button/component.tsx
+++ b/src/components/Button/component.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import Element from './index';
+import Element, { ButtonArgs } from './index';
 import BaseComponent from '../Element/component';
 
 /**
  * User input with click interaction
  */
-class Component extends BaseComponent <ElementArgs, any> {
-    constructor(props: ElementArgs = Element.defaultArgs) {
+class Component extends BaseComponent <ButtonArgs, any> {
+    constructor(props: ButtonArgs = Element.defaultArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/Button/index.ts
+++ b/src/components/Button/index.ts
@@ -1,33 +1,31 @@
-import Element from '../Element/index';
+import Element, { ElementArgs } from '../Element/index';
 
 const CLASS_BUTTON = 'pcui-button';
 
-namespace Button {
-    export interface Args extends Element.Args {
-        /**
-         * If unsafe is true, text will be set on the dom's innerHTML rather than textContent.
-         */
-        unsafe?: boolean;
-        /**
-         * Sets the text of the button.
-         */
-        text?: string,
-        /**
-         * The CSS code for an icon for the button. e.g. 'E401' (notice we omit the '\\' character).
-         */
-        icon?: string,
-        /**
-         * Gets / sets the 'size' type of the button. Can be 'small'.
-         */
-        size?: 'small'
-    }
+export interface ButtonArgs extends ElementArgs {
+    /**
+     * If unsafe is true, text will be set on the dom's innerHTML rather than textContent.
+     */
+    unsafe?: boolean;
+    /**
+     * Sets the text of the button.
+     */
+    text?: string,
+    /**
+     * The CSS code for an icon for the button. e.g. 'E401' (notice we omit the '\\' character).
+     */
+    icon?: string,
+    /**
+     * Gets / sets the 'size' type of the button. Can be 'small'.
+     */
+    size?: 'small'
 }
 
 /**
  * User input with click interaction.
  */
 class Button extends Element {
-    static readonly defaultArgs: Button.Args = {
+    static readonly defaultArgs: ButtonArgs = {
         ...Element.defaultArgs,
         text: '',
         icon: '',
@@ -46,7 +44,7 @@ class Button extends Element {
 
     protected _size: string | null;
 
-    constructor(args: Button.Args = Button.defaultArgs) {
+    constructor(args: ButtonArgs = Button.defaultArgs) {
         args = { ...Button.defaultArgs, ...args };
         super(args.dom, args);
 

--- a/src/components/Canvas/component.tsx
+++ b/src/components/Canvas/component.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import Element from './index';
+import Element, { CanvasArgs } from './index';
 import BaseComponent from '../Element/component';
 
 /**
  * Represents a Canvas
  */
-class Component extends BaseComponent <ElementArgs, any> {
-    constructor(props: ElementArgs = Element.defaultArgs) {
+class Component extends BaseComponent <CanvasArgs, any> {
+    constructor(props: CanvasArgs = Element.defaultArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/Canvas/component.tsx
+++ b/src/components/Canvas/component.tsx
@@ -5,8 +5,8 @@ import BaseComponent from '../Element/component';
 /**
  * Represents a Canvas
  */
-class Component extends BaseComponent <Element.Args, any> {
-    constructor(props: Element.Args = Element.defaultArgs) {
+class Component extends BaseComponent <ElementArgs, any> {
+    constructor(props: ElementArgs = Element.defaultArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/Canvas/index.ts
+++ b/src/components/Canvas/index.ts
@@ -1,27 +1,25 @@
-import Element from '../Element/index';
+import Element, { ElementArgs } from '../Element/index';
 
-namespace Canvas {
-    export interface Args extends Element.Args {
-        /**
-         * Tab index of the canvas.
-         */
-        tabindex?: any;
-        /**
-         * Whether the canvas should use the device pixel ratio.
-         */
-        useDevicePixelRatio?: boolean;
-        /**
-         * The id to be given to the canvas in the dom.
-         */
-        id?: string
-    }
+export interface CanvasArgs extends ElementArgs {
+    /**
+     * Tab index of the canvas.
+     */
+    tabindex?: any;
+    /**
+     * Whether the canvas should use the device pixel ratio.
+     */
+    useDevicePixelRatio?: boolean;
+    /**
+     * The id to be given to the canvas in the dom.
+     */
+    id?: string
 }
 
 /**
  * Represents a Canvas
  */
 class Canvas extends Element {
-    static readonly defaultArgs: Canvas.Args = {
+    static readonly defaultArgs: CanvasArgs = {
         ...Element.defaultArgs,
         dom: 'canvas'
     };
@@ -32,7 +30,7 @@ class Canvas extends Element {
 
     protected _ratio: number;
 
-    constructor(args: Canvas.Args = Canvas.defaultArgs) {
+    constructor(args: CanvasArgs = Canvas.defaultArgs) {
         args = { ...Canvas.defaultArgs, ...args };
         super(args.dom, args);
 

--- a/src/components/Code/component.tsx
+++ b/src/components/Code/component.tsx
@@ -4,10 +4,10 @@ import BaseComponent from '../Element/component';
 /**
  * Represents a code block.
  */
-class Component extends BaseComponent <Element.Args, any> {
-    static defaultProps: Element.Args;
+class Component extends BaseComponent <ElementArgs, any> {
+    static defaultProps: ElementArgs;
 
-    constructor(props: Element.Args) {
+    constructor(props: ElementArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/Code/component.tsx
+++ b/src/components/Code/component.tsx
@@ -1,13 +1,13 @@
-import Element from './index';
+import Element, { CodeArgs } from './index';
 import BaseComponent from '../Element/component';
 
 /**
  * Represents a code block.
  */
-class Component extends BaseComponent <ElementArgs, any> {
-    static defaultProps: ElementArgs;
+class Component extends BaseComponent <CodeArgs, any> {
+    static defaultProps: CodeArgs;
 
-    constructor(props: ElementArgs) {
+    constructor(props: CodeArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/Code/index.ts
+++ b/src/components/Code/index.ts
@@ -1,24 +1,22 @@
 import Element from '../Element/index';
-import Container from '../Container';
+import Container, { ContainerArgs } from '../Container';
 import Label from '../Label';
 
 const CLASS_ROOT = 'pcui-code';
 const CLASS_INNER = CLASS_ROOT + '-inner';
 
-namespace Code {
-    export interface Args extends Container.Args {
-        /**
-         * Sets the text to display in the code block.
-         */
-        text?: string
-    }
+export interface CodeArgs extends ContainerArgs {
+    /**
+     * Sets the text to display in the code block.
+     */
+    text?: string
 }
 
 /**
  * Represents a code block.
  */
 class Code extends Container {
-    static readonly defaultArgs: Code.Args = {
+    static readonly defaultArgs: CodeArgs = {
         ...Container.defaultArgs
     };
 
@@ -26,7 +24,7 @@ class Code extends Container {
 
     protected _text: string;
 
-    constructor(args: Code.Args = Code.defaultArgs) {
+    constructor(args: CodeArgs = Code.defaultArgs) {
         args = { ...Code.defaultArgs, ...args };
         super(args);
         this.class.add(CLASS_ROOT);

--- a/src/components/ColorPicker/component.tsx
+++ b/src/components/ColorPicker/component.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import Element from './index';
+import Element, { ColorPickerArgs } from './index';
 import BaseComponent from '../Element/component';
 
 /**
  * Represents a color picker
  */
-class ColorPicker extends BaseComponent <ElementArgs, any> {
-    constructor(props: ElementArgs) {
+class ColorPicker extends BaseComponent <ColorPickerArgs, any> {
+    constructor(props: ColorPickerArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/ColorPicker/component.tsx
+++ b/src/components/ColorPicker/component.tsx
@@ -5,8 +5,8 @@ import BaseComponent from '../Element/component';
 /**
  * Represents a color picker
  */
-class ColorPicker extends BaseComponent <Element.Args, any> {
-    constructor(props: Element.Args) {
+class ColorPicker extends BaseComponent <ElementArgs, any> {
+    constructor(props: ElementArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/ColorPicker/index.ts
+++ b/src/components/ColorPicker/index.ts
@@ -1,4 +1,4 @@
-import Element from '../Element/index';
+import Element, { ElementArgs } from '../Element/index';
 import Overlay from '../Overlay/index';
 import NumericInput from '../NumericInput/index';
 import TextInput from '../TextInput/index';
@@ -8,25 +8,23 @@ const CLASS_COLOR_INPUT = 'pcui-color-input';
 const CLASS_NOT_FLEXIBLE = 'pcui-not-flexible';
 const CLASS_MULTIPLE_VALUES = 'pcui-multiple-values';
 
-namespace ColorPicker {
-    export interface Args extends Element.Args {
-        renderChanges?: boolean;
-        /**
-         * An optional array of 4 integers containing the RGBA values the picker should be initialized to.
-         */
-        value?: Array<number>;
-        /**
-         * Number of color channels; default is 3, changing to 4 adds the option to change the alpha value.
-         */
-        channels?: number;
-    }
+export interface ColorPickerArgs extends ElementArgs {
+    renderChanges?: boolean;
+    /**
+     * An optional array of 4 integers containing the RGBA values the picker should be initialized to.
+     */
+    value?: Array<number>;
+    /**
+     * Number of color channels; default is 3, changing to 4 adds the option to change the alpha value.
+     */
+    channels?: number;
 }
 
 /**
  * Represents a color picker
  */
 class ColorPicker extends Element {
-    static readonly defaultArgs: ColorPicker.Args = {
+    static readonly defaultArgs: ColorPickerArgs = {
         ...Element.defaultArgs,
         channels: 3,
         value: [0, 0, 255, 1],
@@ -108,7 +106,7 @@ class ColorPicker extends Element {
 
     renderChanges: any;
 
-    constructor(args: ColorPicker.Args = ColorPicker.defaultArgs) {
+    constructor(args: ColorPickerArgs = ColorPicker.defaultArgs) {
         args = { ...ColorPicker.defaultArgs, ...args };
         super(args.dom, args);
 

--- a/src/components/Container/component.tsx
+++ b/src/components/Container/component.tsx
@@ -6,8 +6,8 @@ import BaseComponent from '../Element/component';
  * A container is the basic building block for Elements that are grouped together.
  * A container can contain any other element including other containers.
  */
-class Component extends BaseComponent <Element.Args, any> {
-    constructor(props: Element.Args = Element.defaultArgs) {
+class Component extends BaseComponent <ElementArgs, any> {
+    constructor(props: ElementArgs = Element.defaultArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/Container/component.tsx
+++ b/src/components/Container/component.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import Element from './index';
+import Element, { ContainerArgs } from './index';
 import BaseComponent from '../Element/component';
 
 /**
  * A container is the basic building block for Elements that are grouped together.
  * A container can contain any other element including other containers.
  */
-class Component extends BaseComponent <ElementArgs, any> {
-    constructor(props: ElementArgs = Element.defaultArgs) {
+class Component extends BaseComponent <ContainerArgs, any> {
+    constructor(props: ContainerArgs = Element.defaultArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/Container/index.ts
+++ b/src/components/Container/index.ts
@@ -1,4 +1,4 @@
-import Element from '../Element/index';
+import Element, { ElementArgs, IFlexArgs, IParentArgs } from '../Element/index';
 import * as pcuiClass from '../../class';
 
 const RESIZE_HANDLE_SIZE = 4;
@@ -18,38 +18,36 @@ const CLASS_CONTAINER = 'pcui-container';
 const CLASS_DRAGGED = CLASS_CONTAINER + '-dragged';
 const CLASS_DRAGGED_CHILD = CLASS_DRAGGED + '-child';
 
-namespace Container {
-    export interface Args extends Element.Args, Element.IParentArgs, Element.IFlexArgs {
-        /**
-         * Sets whether the Element is resizable and where the resize handle is located. Can
-         * be one of 'top', 'bottom', 'right', 'left'. Set to null to disable resizing.
-         */
-        resizable?: string,
-        /**
-         * Sets the minimum size the Element can take when resized in pixels.
-         */
-        resizeMin?: number,
-        /**
-         * Sets the maximum size the Element can take when resized in pixels.
-         */
-        resizeMax?: number,
-        /**
-         * Called when the container has been resized.
-         */
-        onResize?: () => void,
-        /**
-         * Sets whether the Element should be scrollable.
-         */
-        scrollable?: boolean,
-        /**
-         * Sets whether the Element supports the grid layout.
-         */
-        grid?: boolean,
-        /**
-         * Sets the Elements align items property.
-         */
-        alignItems?: string
-    }
+export interface ContainerArgs extends ElementArgs, IParentArgs, IFlexArgs {
+    /**
+     * Sets whether the Element is resizable and where the resize handle is located. Can
+     * be one of 'top', 'bottom', 'right', 'left'. Set to null to disable resizing.
+     */
+    resizable?: string,
+    /**
+     * Sets the minimum size the Element can take when resized in pixels.
+     */
+    resizeMin?: number,
+    /**
+     * Sets the maximum size the Element can take when resized in pixels.
+     */
+    resizeMax?: number,
+    /**
+     * Called when the container has been resized.
+     */
+    onResize?: () => void,
+    /**
+     * Sets whether the Element should be scrollable.
+     */
+    scrollable?: boolean,
+    /**
+     * Sets whether the Element supports the grid layout.
+     */
+    grid?: boolean,
+    /**
+     * Sets the Elements align items property.
+     */
+    alignItems?: string
 }
 
 /**
@@ -57,7 +55,7 @@ namespace Container {
  * A container can contain any other element including other containers.
  */
 class Container extends Element {
-    static readonly defaultArgs: Container.Args = {
+    static readonly defaultArgs: ContainerArgs = {
         ...Element.defaultArgs,
         resizable: null,
         dom: 'div'
@@ -134,7 +132,7 @@ class Container extends Element {
 
     protected _draggedHeight: any;
 
-    constructor(args: Container.Args = Container.defaultArgs) {
+    constructor(args: ContainerArgs = Container.defaultArgs) {
         args = { ...Container.defaultArgs, ...args };
         super(args.dom, args);
 

--- a/src/components/ContextMenu/component.tsx
+++ b/src/components/ContextMenu/component.tsx
@@ -5,8 +5,8 @@ import BaseComponent from '../Element/component';
 /**
  * Represents a context menu. LEGACY: This is a legacy component and will be removed in the future. Use Menu instead.
  */
-class ContextMenu extends BaseComponent <Element.Args, any> {
-    constructor(props: Element.Args) {
+class ContextMenu extends BaseComponent <ElementArgs, any> {
+    constructor(props: ElementArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/ContextMenu/component.tsx
+++ b/src/components/ContextMenu/component.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import Element from './index';
+import Element, { ContextMenuArgs } from './index';
 import BaseComponent from '../Element/component';
 
 /**
  * Represents a context menu. LEGACY: This is a legacy component and will be removed in the future. Use Menu instead.
  */
-class ContextMenu extends BaseComponent <ElementArgs, any> {
-    constructor(props: ElementArgs) {
+class ContextMenu extends BaseComponent <ContextMenuArgs, any> {
+    constructor(props: ContextMenuArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/ContextMenu/index.ts
+++ b/src/components/ContextMenu/index.ts
@@ -8,36 +8,34 @@ const CLASS_ContextMenu_parent = CLASS_ContextMenu + '-parent';
 const CLASS_ContextMenu_child = CLASS_ContextMenu + '-child';
 const CLASS_ContextMenu_parent_active = CLASS_ContextMenu_parent + '-active';
 
-namespace ContextMenu {
-    export interface Args {
-        /**
-         * The array of items used to populate the array. Example item: \{ 'text': 'Hello World', 'onClick': () => console.log('Hello World') \}.
-         */
-        items?: any;
-        /**
-         * The dom element to attach this context menu to.
-         */
-        dom?: HTMLElement,
-        /**
-         * The dom element that will trigger the context menu to open when right clicked. If undefined args.dom will be used.
-         */
-        triggerElement?: HTMLElement
-    }
+export interface ContextMenuArgs {
+    /**
+     * The array of items used to populate the array. Example item: \{ 'text': 'Hello World', 'onClick': () => console.log('Hello World') \}.
+     */
+    items?: any;
+    /**
+     * The dom element to attach this context menu to.
+     */
+    dom?: HTMLElement,
+    /**
+     * The dom element that will trigger the context menu to open when right clicked. If undefined args.dom will be used.
+     */
+    triggerElement?: HTMLElement
 }
 
 /**
  * Represents a context menu. LEGACY: This is a legacy component and will be removed in the future. Use Menu instead.
  */
 class ContextMenu {
-    static readonly defaultArgs: ContextMenu.Args = {};
+    static readonly defaultArgs: ContextMenuArgs = {};
 
     protected _menu: Container;
 
     protected _contextMenuEvent: void;
 
-    protected _args: ContextMenu.Args;
+    protected _args: ContextMenuArgs;
 
-    constructor(args: ContextMenu.Args = ContextMenu.defaultArgs) {
+    constructor(args: ContextMenuArgs = ContextMenu.defaultArgs) {
         args = { ...ContextMenu.defaultArgs, ...args };
         this._menu = new Container({ dom: args.dom });
         // @ts-ignore

--- a/src/components/Divider/component.tsx
+++ b/src/components/Divider/component.tsx
@@ -5,8 +5,8 @@ import BaseComponent from '../Element/component';
 /**
  * Represents a vertical division between two elements
  */
-class Component extends BaseComponent <BaseElement.Args, any> {
-    constructor(props: BaseElement.Args) {
+class Component extends BaseComponent <BaseElementArgs, any> {
+    constructor(props: BaseElementArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/Divider/component.tsx
+++ b/src/components/Divider/component.tsx
@@ -1,12 +1,11 @@
-import Element from './index';
-import BaseElement from '../Element/index';
+import Element, { DividerArgs } from './index';
 import BaseComponent from '../Element/component';
 
 /**
  * Represents a vertical division between two elements
  */
-class Component extends BaseComponent <BaseElementArgs, any> {
-    constructor(props: BaseElementArgs) {
+class Component extends BaseComponent <DividerArgs, any> {
+    constructor(props: DividerArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/Divider/index.ts
+++ b/src/components/Divider/index.ts
@@ -1,20 +1,18 @@
-import Element from '../Element/index';
+import Element, { ElementArgs } from '../Element/index';
 
 const CLASS_ROOT = 'pcui-divider';
 
-namespace Divider {
-    export interface Args extends Element.Args {}
-}
+export interface DividerArgs extends ElementArgs {}
 
 /**
  * Represents a vertical division between two elements
  */
 class Divider extends Element {
-    static readonly defaultArgs: Divider.Args = {
+    static readonly defaultArgs: DividerArgs = {
         ...Element.defaultArgs
     };
 
-    constructor(args: Element.Args = Divider.defaultArgs) {
+    constructor(args: ElementArgs = Divider.defaultArgs) {
         args = { ...Divider.defaultArgs, ...args };
         super(args.dom ? args.dom : document.createElement('div'), args);
 

--- a/src/components/Element/component.tsx
+++ b/src/components/Element/component.tsx
@@ -5,7 +5,7 @@ import Element from './index';
  * The base class for all UI elements. Wraps a dom element with the PCUI interface.
  */
 
-class Component <P extends Element.Args, S> extends React.Component <P, S> {
+class Component <P extends ElementArgs, S> extends React.Component <P, S> {
     static defaultArgs = Element.defaultArgs;
 
     static ctor: any;

--- a/src/components/Element/component.tsx
+++ b/src/components/Element/component.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Element from './index';
+import Element, { ElementArgs } from './index';
 
 /**
  * The base class for all UI elements. Wraps a dom element with the PCUI interface.

--- a/src/components/Element/index.ts
+++ b/src/components/Element/index.ts
@@ -26,178 +26,176 @@ const SIMPLE_CSS_PROPERTIES = [
 // Stores Element types by name and default arguments
 const ELEMENT_REGISTRY: any = {};
 
-namespace Element {
-    export interface IBindable {
-        /**
-         * Gets / sets the value of the Element.
-         */
-        set value(values: any),
-        get value(): any,
-        /**
-         * Gets / sets multiple values to the Element. It is up to the Element to determine how to display them.
-         */
-        set values(values: Array<any>),
-        get values(): Array<any>,
-        /**
-         * Gets / sets whether the input should flash on changes.
-         */
-        set renderChanges(value: boolean),
-        get renderChanges(): boolean,
-    }
+export interface IBindable {
+    /**
+     * Gets / sets the value of the Element.
+     */
+    set value(values: any),
+    get value(): any,
+    /**
+     * Gets / sets multiple values to the Element. It is up to the Element to determine how to display them.
+     */
+    set values(values: Array<any>),
+    get values(): Array<any>,
+    /**
+     * Gets / sets whether the input should flash on changes.
+     */
+    set renderChanges(value: boolean),
+    get renderChanges(): boolean,
+}
 
-    export interface IBindableArgs {
-        /**
-         * Sets the value of the Element.
-         */
-        value?: any,
-        /**
-         * Sets multiple values to the Element. It is up to the Element to determine how to display them.
-         */
-        values?: Array<any>,
-        /**
-         * If true each input will flash on changes.
-         */
-        renderChanges?: boolean
-    }
+export interface IBindableArgs {
+    /**
+     * Sets the value of the Element.
+     */
+    value?: any,
+    /**
+     * Sets multiple values to the Element. It is up to the Element to determine how to display them.
+     */
+    values?: Array<any>,
+    /**
+     * If true each input will flash on changes.
+     */
+    renderChanges?: boolean
+}
 
-    export interface IPlaceholder {
-        /**
-         * Gets / sets the placeholder text of the input.
-         */
-        set placeholder(value: string),
-        get placeholder(): string
-    }
+export interface IPlaceholder {
+    /**
+     * Gets / sets the placeholder text of the input.
+     */
+    set placeholder(value: string),
+    get placeholder(): string
+}
 
-    export interface IPlaceholderArgs {
-        /**
-         * Sets the placeholder label that appears on the right of the input.
-         */
-        placeholder?: string,
-    }
+export interface IPlaceholderArgs {
+    /**
+     * Sets the placeholder label that appears on the right of the input.
+     */
+    placeholder?: string,
+}
 
-    export interface IFocusable {
-        /**
-         * Focus on the element. If the input contains text and select is provided, the text will be selected on focus.
-         */
-        focus(select?: boolean): void
+export interface IFocusable {
+    /**
+     * Focus on the element. If the input contains text and select is provided, the text will be selected on focus.
+     */
+    focus(select?: boolean): void
 
-        /**
-         * Unfocus the element
-         */
-        blur(): void
-    }
+    /**
+     * Unfocus the element
+     */
+    blur(): void
+}
 
-    export interface IParentArgs {
-        /**
-         * The children of the current component.
-         */
-        children?: React.ReactNode
-    }
+export interface IParentArgs {
+    /**
+     * The children of the current component.
+     */
+    children?: React.ReactNode
+}
 
-    export interface IFlexArgs {
-        /**
-         * Sets whether the Element supports flex layout.
-         */
-        flex?: boolean,
-        /**
-         * Sets whether the Element supports the flex shrink property.
-         */
-        flexShrink?: number,
-        /**
-         * Sets whether the Element supports the flex grow property.
-         */
-        flexGrow?: number,
-        /**
-         * Sets the Elements flex direction property.
-         */
-        flexDirection?: string,
-    }
+export interface IFlexArgs {
+    /**
+     * Sets whether the Element supports flex layout.
+     */
+    flex?: boolean,
+    /**
+     * Sets whether the Element supports the flex shrink property.
+     */
+    flexShrink?: number,
+    /**
+     * Sets whether the Element supports the flex grow property.
+     */
+    flexGrow?: number,
+    /**
+     * Sets the Elements flex direction property.
+     */
+    flexDirection?: string,
+}
 
-    export interface Args {
-        /**
-         * The HTMLElement to create this Element with. If not provided this Element will create one.
-         */
-        dom?: HTMLElement | string;
-        /**
-         * A binding to use with this Element.
-         */
-        binding?: BindingBase;
-        /**
-         * If provided and the element is clickable, this function will be called each time the element is clicked.
-         */
-        onClick?: () => void,
-        /**
-         * If provided and the element is changeable, this function will be called each time the element value is changed.
-         */
-        onChange?: (value: any) => void,
-        /**
-         * If provided and the element is removable, this function will be called each time the element is removed.
-         */
-        onRemove?: () => void,
-        /**
-         * Sets the parent Element.
-         */
-        parent?: any,
-        /**
-         * Links the observer attribute at the path location in the given observer to this Element.
-         */
-        link?: { observer: any, path: string },
-        /**
-         * The id attribute of this Element's HTMLElement.
-         */
-        id?: string,
-        /**
-         * The class attribute of this Element's HTMLElement.
-         */
-        class?: string | Array<string>,
-        /**
-         * Sets whether this Element is at the root of the hierarchy.
-         */
-        isRoot?: boolean,
-        /**
-         * Sets whether it is possible to interact with this Element and its children.
-         */
-        enabled?: boolean,
-        /**
-         * Sets whether this Element is hidden.
-         */
-        hidden?: boolean,
-        /**
-         * If true, this Element will ignore its parent's enabled value when determining whether this Element is enabled.
-         */
-        ignoreParent?: boolean,
-        /**
-         * Sets the initial width of the element.
-         */
-        width?: number | null,
-        /**
-         * Sets the initial height of the element.
-         */
-        height?: number | null,
-        /**
-         * Gets / sets the tabIndex of the Element.
-         */
-        tabIndex?: number,
-        /**
-         * Gets / sets whether the Element is in an error state.
-         */
-        error?: boolean,
-        /**
-         * Sets an initial value for Element.dom.style.
-         */
-        style?: string,
-        /**
-         * Whether this Element is read only or not.
-         */
-        readOnly?: boolean
-    }
+export interface ElementArgs {
+    /**
+     * The HTMLElement to create this Element with. If not provided this Element will create one.
+     */
+    dom?: HTMLElement | string;
+    /**
+     * A binding to use with this Element.
+     */
+    binding?: BindingBase;
+    /**
+     * If provided and the element is clickable, this function will be called each time the element is clicked.
+     */
+    onClick?: () => void,
+    /**
+     * If provided and the element is changeable, this function will be called each time the element value is changed.
+     */
+    onChange?: (value: any) => void,
+    /**
+     * If provided and the element is removable, this function will be called each time the element is removed.
+     */
+    onRemove?: () => void,
+    /**
+     * Sets the parent Element.
+     */
+    parent?: any,
+    /**
+     * Links the observer attribute at the path location in the given observer to this Element.
+     */
+    link?: { observer: any, path: string },
+    /**
+     * The id attribute of this Element's HTMLElement.
+     */
+    id?: string,
+    /**
+     * The class attribute of this Element's HTMLElement.
+     */
+    class?: string | Array<string>,
+    /**
+     * Sets whether this Element is at the root of the hierarchy.
+     */
+    isRoot?: boolean,
+    /**
+     * Sets whether it is possible to interact with this Element and its children.
+     */
+    enabled?: boolean,
+    /**
+     * Sets whether this Element is hidden.
+     */
+    hidden?: boolean,
+    /**
+     * If true, this Element will ignore its parent's enabled value when determining whether this Element is enabled.
+     */
+    ignoreParent?: boolean,
+    /**
+     * Sets the initial width of the element.
+     */
+    width?: number | null,
+    /**
+     * Sets the initial height of the element.
+     */
+    height?: number | null,
+    /**
+     * Gets / sets the tabIndex of the Element.
+     */
+    tabIndex?: number,
+    /**
+     * Gets / sets whether the Element is in an error state.
+     */
+    error?: boolean,
+    /**
+     * Sets an initial value for Element.dom.style.
+     */
+    style?: string,
+    /**
+     * Whether this Element is read only or not.
+     */
+    readOnly?: boolean
 }
 
 /**
  * The base class for all UI elements.
  */
 class Element extends Events {
-    public static defaultArgs: Element.Args = {
+    public static defaultArgs: ElementArgs = {
         hidden: false,
         readOnly: false,
         ignoreParent: false
@@ -330,7 +328,7 @@ class Element extends Events {
 
     protected _domContent: any;
 
-    constructor(dom: HTMLElement | string, args: Element.Args = Element.defaultArgs) {
+    constructor(dom: HTMLElement | string, args: ElementArgs = Element.defaultArgs) {
         args = { ...Element.defaultArgs, ...args };
         super();
 
@@ -665,7 +663,7 @@ class Element extends Events {
      * @param type - The type of the Element (registered by pcui.Element#register).
      * @param args - Arguments for the Element.
      */
-    static create(type: string, args: Element.Args): any {
+    static create(type: string, args: ElementArgs): any {
         const entry = ELEMENT_REGISTRY[type];
         if (!entry) {
             console.error('Invalid type passed to pcui.Element#create', type);

--- a/src/components/GradientPicker/component.tsx
+++ b/src/components/GradientPicker/component.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import Element from './index';
+import Element, { GradientPickerArgs } from './index';
 import BaseComponent from '../Element/component';
 
 /**
  * Represents a gradient picker
  */
-class GradientPicker extends BaseComponent <ElementArgs, any> {
-    constructor(props: ElementArgs) {
+class GradientPicker extends BaseComponent <GradientPickerArgs, any> {
+    constructor(props: GradientPickerArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/GradientPicker/component.tsx
+++ b/src/components/GradientPicker/component.tsx
@@ -5,8 +5,8 @@ import BaseComponent from '../Element/component';
 /**
  * Represents a gradient picker
  */
-class GradientPicker extends BaseComponent <Element.Args, any> {
-    constructor(props: Element.Args) {
+class GradientPicker extends BaseComponent <ElementArgs, any> {
+    constructor(props: ElementArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/GradientPicker/index.ts
+++ b/src/components/GradientPicker/index.ts
@@ -1,4 +1,4 @@
-import Element from '../Element/index';
+import Element, { ElementArgs } from '../Element/index';
 import Overlay from '../Overlay';
 import Button from '../Button';
 import SelectInput from '../SelectInput';
@@ -20,25 +20,23 @@ const REGEX_KEYS = /keys/;
 const REGEX_TYPE = /type/;
 const CLASS_GRADIENT = 'pcui-gradient';
 
-namespace GradientPicker {
-    export interface Args extends Element.Args {
-        renderChanges?: boolean;
-        /**
-         * An optional array of 4 integers containing the RGBA values the picker should be initialized to.
-         */
-        value?: Array<number>;
-        /**
-         * Number of color channels; default is 3, changing to 4 adds the option to change the alpha value.
-         */
-        channels?: number;
-    }
+export interface GradientPickerArgs extends ElementArgs {
+    renderChanges?: boolean;
+    /**
+     * An optional array of 4 integers containing the RGBA values the picker should be initialized to.
+     */
+    value?: Array<number>;
+    /**
+     * Number of color channels; default is 3, changing to 4 adds the option to change the alpha value.
+     */
+    channels?: number;
 }
 
 /**
  * Represents a gradient picker
  */
 class GradientPicker extends Element {
-    static readonly defaultArgs: GradientPicker.Args = {
+    static readonly defaultArgs: GradientPickerArgs = {
         ...Element.defaultArgs,
         renderChanges: true,
         dom: 'div'
@@ -125,7 +123,7 @@ class GradientPicker extends Element {
      *
      * @param {object} args - The arguments. Extends the Element arguments. Any settable property can also be set through the constructor.
      */
-    constructor(args: GradientPicker.Args = GradientPicker.defaultArgs) {
+    constructor(args: GradientPickerArgs = GradientPicker.defaultArgs) {
         args = { ...GradientPicker.defaultArgs, ...args };
         super(args.dom, args);
 

--- a/src/components/GridView/component.tsx
+++ b/src/components/GridView/component.tsx
@@ -7,8 +7,8 @@ import BaseComponent from '../Element/component';
  * Represents a container that shows a flexible wrappable
  * list of items that looks like a grid. Contains GridViewItem's.
  */
-class GridView extends BaseComponent <GridViewElement.Args, any> {
-    constructor(props: GridViewElement.Args) {
+class GridView extends BaseComponent <GridViewElementArgs, any> {
+    constructor(props: GridViewElementArgs) {
         super(props);
         // @ts-ignore
         this.element = new GridViewElement({ ...props });

--- a/src/components/GridView/component.tsx
+++ b/src/components/GridView/component.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import GridViewElement from './index';
+import GridViewElement, { GridViewArgs } from './index';
 import GridViewItemElement from '../GridViewItem/index';
 import BaseComponent from '../Element/component';
 
@@ -7,8 +7,8 @@ import BaseComponent from '../Element/component';
  * Represents a container that shows a flexible wrappable
  * list of items that looks like a grid. Contains GridViewItem's.
  */
-class GridView extends BaseComponent <GridViewElementArgs, any> {
-    constructor(props: GridViewElementArgs) {
+class GridView extends BaseComponent <GridViewArgs, any> {
+    constructor(props: GridViewArgs) {
         super(props);
         // @ts-ignore
         this.element = new GridViewElement({ ...props });

--- a/src/components/GridView/index.ts
+++ b/src/components/GridView/index.ts
@@ -1,28 +1,26 @@
-import Container from '../Container';
+import Container, { ContainerArgs } from '../Container';
 import GridViewItem from '../GridViewItem';
 
 const CLASS_ROOT = 'pcui-gridview';
 const CLASS_VERTICAL = CLASS_ROOT + '-vertical';
 
-namespace GridView {
-    export interface Args extends Container.Args {
-        /**
-         * If true the gridview layout will be vertical.
-         */
-        vertical?: boolean;
-        /**
-         * If true, the layout will allow for multiple options to be selected.
-         */
-        multiSelect?: boolean;
-        /**
-         * If true and multiSelect is set to false, the layout will allow options to be deselected.
-         */
-        allowDeselect?: boolean;
-        /**
-         * A filter function to filter gridview items with signature (GridViewItem) => boolean.
-         */
-        filterFn?: (item: GridViewItem) => boolean;
-    }
+export interface GridViewArgs extends ContainerArgs {
+    /**
+     * If true the gridview layout will be vertical.
+     */
+    vertical?: boolean;
+    /**
+     * If true, the layout will allow for multiple options to be selected.
+     */
+    multiSelect?: boolean;
+    /**
+     * If true and multiSelect is set to false, the layout will allow options to be deselected.
+     */
+    allowDeselect?: boolean;
+    /**
+     * A filter function to filter gridview items with signature (GridViewItem) => boolean.
+     */
+    filterFn?: (item: GridViewItem) => boolean;
 }
 
 /**
@@ -30,7 +28,7 @@ namespace GridView {
  * list of items that looks like a grid. Contains GridViewItems.
  */
 class GridView extends Container {
-    static readonly defaultArgs: GridView.Args = {
+    static readonly defaultArgs: GridViewArgs = {
         ...Container.defaultArgs,
         multiSelect: true,
         allowDeselect: true
@@ -52,7 +50,7 @@ class GridView extends Container {
 
     protected _clickFn: any;
 
-    constructor(args: GridView.Args = GridView.defaultArgs) {
+    constructor(args: GridViewArgs = GridView.defaultArgs) {
         args = { ...GridView.defaultArgs, ...args };
         super(args);
 

--- a/src/components/GridViewItem/component.tsx
+++ b/src/components/GridViewItem/component.tsx
@@ -1,11 +1,11 @@
-import Element from './index';
+import Element, { GridViewItemArgs } from './index';
 import BaseComponent from '../Element/component';
 
 /**
  *  Represents a grid view item used in GridView.
  */
-class GridViewItem extends BaseComponent <ElementArgs, any> {
-    constructor(props: ElementArgs) {
+class GridViewItem extends BaseComponent <GridViewItemArgs, any> {
+    constructor(props: GridViewItemArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/GridViewItem/component.tsx
+++ b/src/components/GridViewItem/component.tsx
@@ -4,8 +4,8 @@ import BaseComponent from '../Element/component';
 /**
  *  Represents a grid view item used in GridView.
  */
-class GridViewItem extends BaseComponent <Element.Args, any> {
-    constructor(props: Element.Args) {
+class GridViewItem extends BaseComponent <ElementArgs, any> {
+    constructor(props: ElementArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/GridViewItem/index.ts
+++ b/src/components/GridViewItem/index.ts
@@ -1,5 +1,5 @@
-import Element from '../Element/index';
-import Container from '../Container/index';
+import { IFocusable } from '../Element/index';
+import Container, { ContainerArgs } from '../Container/index';
 import Label from '../Label/index';
 import BindingObserversToElement from '../../binding/BindingObserversToElement/index';
 import RadioButton from '../RadioButton/index';
@@ -10,32 +10,30 @@ const CLASS_SELECTED = CLASS_ROOT + '-selected';
 const CLASS_TEXT = CLASS_ROOT + '-text';
 const CLASS_RADIO_BUTTON = 'pcui-gridview-radiobtn';
 
-namespace GridViewItem {
-    export interface Args extends Container.Args {
-        /**
-         * The type of the gridview item, can be null or 'radio'
-         */
-        type?: string;
-        /**
-         * If true allow selecting the item. Defaults to true.
-         */
-        allowSelect?: boolean;
-        /**
-         * Whether the item is selected.
-         */
-        selected?: boolean;
-        /**
-         * The text of the item.
-         */
-        text?: string;
-    }
+export interface GridViewItemArgs extends ContainerArgs {
+    /**
+     * The type of the gridview item, can be null or 'radio'
+     */
+    type?: string;
+    /**
+     * If true allow selecting the item. Defaults to true.
+     */
+    allowSelect?: boolean;
+    /**
+     * Whether the item is selected.
+     */
+    selected?: boolean;
+    /**
+     * The text of the item.
+     */
+    text?: string;
 }
 
 /**
  *  Represents a grid view item used in GridView.
  */
-class GridViewItem extends Container implements Element.IFocusable {
-    static readonly defaultArgs: GridViewItem.Args = {
+class GridViewItem extends Container implements IFocusable {
+    static readonly defaultArgs: GridViewItemArgs = {
         ...Container.defaultArgs,
         allowSelect: true,
         text: '',
@@ -58,7 +56,7 @@ class GridViewItem extends Container implements Element.IFocusable {
 
     protected _allowSelect: any;
 
-    constructor(args: GridViewItem.Args = GridViewItem.defaultArgs) {
+    constructor(args: GridViewItemArgs = GridViewItem.defaultArgs) {
         args = { ...GridViewItem.defaultArgs, ...args };
         super(args);
 

--- a/src/components/InfoBox/component.tsx
+++ b/src/components/InfoBox/component.tsx
@@ -5,8 +5,8 @@ import BaseComponent from '../Element/component';
 /**
  * Represents an information box.
  */
-class InfoBox extends BaseComponent <Element.Args, any> {
-    constructor(props: Element.Args) {
+class InfoBox extends BaseComponent <ElementArgs, any> {
+    constructor(props: ElementArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/InfoBox/component.tsx
+++ b/src/components/InfoBox/component.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import Element from './index';
+import Element, { InfoBoxArgs } from './index';
 import BaseComponent from '../Element/component';
 
 /**
  * Represents an information box.
  */
-class InfoBox extends BaseComponent <ElementArgs, any> {
-    constructor(props: ElementArgs) {
+class InfoBox extends BaseComponent <InfoBoxArgs, any> {
+    constructor(props: InfoBoxArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/InfoBox/index.ts
+++ b/src/components/InfoBox/index.ts
@@ -1,34 +1,32 @@
 import Element from '../Element/index';
-import Container from '../Container';
+import Container, { ContainerArgs } from '../Container';
 
 const CLASS_INFOBOX = 'pcui-infobox';
 
-namespace InfoBox {
-    export interface Args extends Container.Args {
-        /**
-         * The CSS code for an icon for the info box. e.g. 'E401' (notice we omit the '\\' character).
-         */
-        icon?: string;
-        /**
-         * Gets / sets the 'title' of the info box.
-         */
-        title?: string;
-        /**
-         * Gets / sets the 'text' of the info box.
-         */
-        text?: string;
-        /**
-         * If true then the innerHTML property will be used to set the title/text. Otherwise textContent will be used instead.
-         */
-        unsafe?: boolean;
-    }
+export interface InfoBoxArgs extends ContainerArgs {
+    /**
+     * The CSS code for an icon for the info box. e.g. 'E401' (notice we omit the '\\' character).
+     */
+    icon?: string;
+    /**
+     * Gets / sets the 'title' of the info box.
+     */
+    title?: string;
+    /**
+     * Gets / sets the 'text' of the info box.
+     */
+    text?: string;
+    /**
+     * If true then the innerHTML property will be used to set the title/text. Otherwise textContent will be used instead.
+     */
+    unsafe?: boolean;
 }
 
 /**
  * Represents an information box.
  */
 class InfoBox extends Container {
-    static readonly defaultArgs: InfoBox.Args = {
+    static readonly defaultArgs: InfoBoxArgs = {
         ...Container.defaultArgs,
         unsafe: false,
         icon: '',
@@ -48,7 +46,7 @@ class InfoBox extends Container {
 
     protected _text: any;
 
-    constructor(args: InfoBox.Args = InfoBox.defaultArgs) {
+    constructor(args: InfoBoxArgs = InfoBox.defaultArgs) {
         args = { ...InfoBox.defaultArgs, ...args };
         super(args);
 

--- a/src/components/Input/index.ts
+++ b/src/components/Input/index.ts
@@ -1,10 +1,8 @@
-import Element from '../Element/index';
+import Element, { ElementArgs, IBindable } from '../Element/index';
 
-namespace Input {
-    export interface Args extends Element.Args {}
-}
+export interface InputArgs extends ElementArgs {}
 
-class Input extends Element implements Element.IBindable {
+class Input extends Element implements IBindable {
     protected _renderChanges: boolean;
 
     set value(value: any) {

--- a/src/components/Label/component.tsx
+++ b/src/components/Label/component.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import Element from './index';
+import Element, { LabelArgs } from './index';
 import BaseComponent from '../Element/component';
 
 /**
  * The Label is a simple span element that displays some text.
  */
-class Component extends BaseComponent <ElementArgs, any> {
-    constructor(props: ElementArgs = Element.defaultArgs) {
+class Component extends BaseComponent <LabelArgs, any> {
+    constructor(props: LabelArgs = Element.defaultArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/Label/component.tsx
+++ b/src/components/Label/component.tsx
@@ -5,8 +5,8 @@ import BaseComponent from '../Element/component';
 /**
  * The Label is a simple span element that displays some text.
  */
-class Component extends BaseComponent <Element.Args, any> {
-    constructor(props: Element.Args = Element.defaultArgs) {
+class Component extends BaseComponent <ElementArgs, any> {
+    constructor(props: ElementArgs = Element.defaultArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/Label/index.ts
+++ b/src/components/Label/index.ts
@@ -1,35 +1,33 @@
 import * as pcuiClass from '../../class';
-import Element from '../Element/index';
+import Element, { ElementArgs, IBindableArgs, IFlexArgs, IPlaceholder, IPlaceholderArgs } from '../Element/index';
 import Input from '../Input/index';
 
 const CLASS_LABEL = 'pcui-label';
 
-namespace Label {
-    export interface Args extends Element.Args, Element.IBindableArgs, Element.IPlaceholderArgs, Element.IFlexArgs {
-        /**
-         * Sets the text of the Label.
-         */
-        text?: string | number,
-        /**
-         * If true then the innerHTML property will be used to set the text. Otherwise textContent will be used instead.
-         */
-        unsafe?: boolean,
-        /**
-         * If true then use the text of the label as the native HTML tooltip.
-         */
-        nativeTooltip?: boolean,
-        /**
-         * If true then the label can be clicked to select text.
-         */
-        allowTextSelection?: boolean
-    }
+export interface LabelArgs extends ElementArgs, IBindableArgs, IPlaceholderArgs, IFlexArgs {
+    /**
+     * Sets the text of the Label.
+     */
+    text?: string | number,
+    /**
+     * If true then the innerHTML property will be used to set the text. Otherwise textContent will be used instead.
+     */
+    unsafe?: boolean,
+    /**
+     * If true then use the text of the label as the native HTML tooltip.
+     */
+    nativeTooltip?: boolean,
+    /**
+     * If true then the label can be clicked to select text.
+     */
+    allowTextSelection?: boolean
 }
 
 /**
  * The Label is a simple span element that displays some text.
  */
-class Label extends Input implements Element.IPlaceholder {
-    static readonly defaultArgs: Label.Args = {
+class Label extends Input implements IPlaceholder {
+    static readonly defaultArgs: LabelArgs = {
         ...Element.defaultArgs,
         value: '',
         text: '',
@@ -47,7 +45,7 @@ class Label extends Input implements Element.IPlaceholder {
 
     _optionValue: any;
 
-    constructor(args: Label.Args = Label.defaultArgs) {
+    constructor(args: LabelArgs = Label.defaultArgs) {
         args = { ...Label.defaultArgs, ...args };
         super(args.dom, args);
 

--- a/src/components/LabelGroup/component.tsx
+++ b/src/components/LabelGroup/component.tsx
@@ -4,8 +4,8 @@ import BaseComponent from '../Element/component';
 /**
  * Represents a group of a Label and a Element. Useful for rows of labeled fields.
  */
-class LabelGroup extends BaseComponent <Element.Args, any> {
-    constructor(props: Element.Args) {
+class LabelGroup extends BaseComponent <ElementArgs, any> {
+    constructor(props: ElementArgs) {
         super(props);
         // @ts-ignore
         this.elementClass = Element;

--- a/src/components/LabelGroup/component.tsx
+++ b/src/components/LabelGroup/component.tsx
@@ -1,11 +1,11 @@
-import Element from './index';
+import Element, { LabelGroupArgs } from './index';
 import BaseComponent from '../Element/component';
 
 /**
  * Represents a group of a Label and a Element. Useful for rows of labeled fields.
  */
-class LabelGroup extends BaseComponent <ElementArgs, any> {
-    constructor(props: ElementArgs) {
+class LabelGroup extends BaseComponent <LabelGroupArgs, any> {
+    constructor(props: LabelGroupArgs) {
         super(props);
         // @ts-ignore
         this.elementClass = Element;

--- a/src/components/LabelGroup/index.ts
+++ b/src/components/LabelGroup/index.ts
@@ -1,36 +1,34 @@
 import Element from '../Element/index';
-import Container from '../Container';
+import Container, { ContainerArgs } from '../Container';
 import Label from '../Label';
 
 const CLASS_LABEL_GROUP = 'pcui-label-group';
 const CLASS_LABEL_TOP = CLASS_LABEL_GROUP + '-align-top';
 
-namespace LabelGroup {
-    export interface Args extends Container.Args {
-        /**
-         * The label text.
-         */
-        text?: string;
-        /**
-         * The element to be wrapped by the label group.
-         */
-        field?: Element;
-        /**
-         * Whether to align the label at the top of the group. Defaults to false which aligns it at the center.
-         */
-        labelAlignTop?: boolean;
-        /**
-         * Add a native tooltip to the label.
-         */
-        nativeTooltip?: boolean;
-    }
+export interface LabelGroupArgs extends ContainerArgs {
+    /**
+     * The label text.
+     */
+    text?: string;
+    /**
+     * The element to be wrapped by the label group.
+     */
+    field?: Element;
+    /**
+     * Whether to align the label at the top of the group. Defaults to false which aligns it at the center.
+     */
+    labelAlignTop?: boolean;
+    /**
+     * Add a native tooltip to the label.
+     */
+    nativeTooltip?: boolean;
 }
 
 /**
  * Represents a group of a Label and a Element. Useful for rows of labeled fields.
  */
 class LabelGroup extends Container {
-    static readonly defaultArgs: LabelGroup.Args = {
+    static readonly defaultArgs: LabelGroupArgs = {
         ...Container.defaultArgs,
         text: 'Label',
         field: null,
@@ -41,7 +39,7 @@ class LabelGroup extends Container {
 
     protected _field: Element;
 
-    constructor(args: LabelGroup.Args = LabelGroup.defaultArgs) {
+    constructor(args: LabelGroupArgs = LabelGroup.defaultArgs) {
         args = { ...LabelGroup.defaultArgs, ...args };
         super(args);
 

--- a/src/components/Menu/component.tsx
+++ b/src/components/Menu/component.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Element from './index';
+import Element, { MenuArgs } from './index';
 import BaseComponent from '../Element/component';
 
 /**
@@ -7,8 +7,8 @@ import BaseComponent from '../Element/component';
  * to show context menus and nested menus. Note that a Menu must be appended to the root Element
  * and then positioned accordingly.
  */
-class Menu extends BaseComponent <ElementArgs, any> {
-    constructor(props: ElementArgs) {
+class Menu extends BaseComponent <MenuArgs, any> {
+    constructor(props: MenuArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/Menu/component.tsx
+++ b/src/components/Menu/component.tsx
@@ -7,8 +7,8 @@ import BaseComponent from '../Element/component';
  * to show context menus and nested menus. Note that a Menu must be appended to the root Element
  * and then positioned accordingly.
  */
-class Menu extends BaseComponent <Element.Args, any> {
-    constructor(props: Element.Args) {
+class Menu extends BaseComponent <ElementArgs, any> {
+    constructor(props: ElementArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/Menu/index.ts
+++ b/src/components/Menu/index.ts
@@ -1,17 +1,15 @@
-import Container from '../Container';
-import Element from '../Element';
+import Container, { ContainerArgs } from '../Container';
+import { IFocusable } from '../Element';
 import MenuItem from '../MenuItem';
 
 const CLASS_MENU = 'pcui-menu';
 const CLASS_MENU_ITEMS = CLASS_MENU + '-items';
 
-namespace Menu {
-    export interface Args extends Container.Args {
-        /**
-         * An optional array of MenuItem data. If these are passed then new MenuItems will be created and appended to the menu.
-         */
-        items: any;
-    }
+export interface MenuArgs extends ContainerArgs {
+    /**
+     * An optional array of MenuItem data. If these are passed then new MenuItems will be created and appended to the menu.
+     */
+    items: any;
 }
 
 /**
@@ -19,8 +17,8 @@ namespace Menu {
  * to show context menus and nested menus. Note that a Menu must be appended to the root Element
  * and then positioned accordingly.
  */
-class Menu extends Container implements Element.IFocusable {
-    static readonly defaultArgs: Menu.Args = {
+class Menu extends Container implements IFocusable {
+    static readonly defaultArgs: MenuArgs = {
         ...Container.defaultArgs,
         hidden: true,
         tabIndex: 1,
@@ -37,7 +35,7 @@ class Menu extends Container implements Element.IFocusable {
 
     protected _domEvtBlur: any;
 
-    constructor(args: Menu.Args = Menu.defaultArgs) {
+    constructor(args: MenuArgs = Menu.defaultArgs) {
         args = { ...Menu.defaultArgs, ...args };
         super(args);
 

--- a/src/components/MenuItem/index.ts
+++ b/src/components/MenuItem/index.ts
@@ -1,5 +1,5 @@
-import Container from '../Container';
-import Element from '../Element';
+import Container, { ContainerArgs } from '../Container';
+import { IBindable } from '../Element';
 import Label from '../Label';
 
 const CLASS_MENU_ITEM = 'pcui-menu-item';
@@ -7,42 +7,40 @@ const CLASS_MENU_ITEM_CONTENT = CLASS_MENU_ITEM + '-content';
 const CLASS_MENU_ITEM_CHILDREN = CLASS_MENU_ITEM + '-children';
 const CLASS_MENU_ITEM_HAS_CHILDREN = CLASS_MENU_ITEM + '-has-children';
 
-namespace MenuItem {
-    export interface Args extends Container.Args {
-        value?: any;
-        /**
-         * Whether the MenuItem has any child MenuItems.
-         */
-        hasChildren?: boolean;
-        /**
-         * Gets / sets the text shown on the MenuItem.
-         */
-        text?: string;
-        /**
-         * Gets / sets the CSS code for an icon for the MenuItem. e.g. 'E401' (notice we omit the '\\' character).
-         */
-        icon?: string;
-        /**
-         * Gets / sets the parent Menu Element.
-         */
-        menu?: any;
-        /**
-         * Gets / sets the function called when we select the MenuItem.
-         */
-        onSelect?: () => void;
-        /**
-         * Gets / sets the function that determines whether the MenuItem should be enabled when the Menu is shown.
-         */
-        onIsEnabled?: () => boolean;
-        /**
-         * Gets / sets the function that determines whether the MenuItem should be visible when the Menu is shown.
-         */
-        onIsVisible?: () => boolean;
-        /**
-         * An array of MenuItem constructor data. If defined then child MenuItems will be created and added to the MenuItem.
-         */
-        items?: any;
-    }
+export interface MenuItemArgs extends ContainerArgs {
+    value?: any;
+    /**
+     * Whether the MenuItem has any child MenuItems.
+     */
+    hasChildren?: boolean;
+    /**
+     * Gets / sets the text shown on the MenuItem.
+     */
+    text?: string;
+    /**
+     * Gets / sets the CSS code for an icon for the MenuItem. e.g. 'E401' (notice we omit the '\\' character).
+     */
+    icon?: string;
+    /**
+     * Gets / sets the parent Menu Element.
+     */
+    menu?: any;
+    /**
+     * Gets / sets the function called when we select the MenuItem.
+     */
+    onSelect?: () => void;
+    /**
+     * Gets / sets the function that determines whether the MenuItem should be enabled when the Menu is shown.
+     */
+    onIsEnabled?: () => boolean;
+    /**
+     * Gets / sets the function that determines whether the MenuItem should be visible when the Menu is shown.
+     */
+    onIsVisible?: () => boolean;
+    /**
+     * An array of MenuItem constructor data. If defined then child MenuItems will be created and added to the MenuItem.
+     */
+    items?: any;
 }
 
 /**
@@ -50,8 +48,8 @@ namespace MenuItem {
  * A MenuItem can also contain child MenuItems (by appending them to the MenuItem). This
  * can be useful to show nested Menus.
  */
-class MenuItem extends Container implements Element.IBindable {
-    static readonly defaultArgs: MenuItem.Args = {
+class MenuItem extends Container implements IBindable {
+    static readonly defaultArgs: MenuItemArgs = {
         ...Container.defaultArgs
     };
 
@@ -77,7 +75,7 @@ class MenuItem extends Container implements Element.IBindable {
 
     protected _renderChanges: boolean;
 
-    constructor(args: MenuItem.Args = MenuItem.defaultArgs) {
+    constructor(args: MenuItemArgs = MenuItem.defaultArgs) {
         args = { ...MenuItem.defaultArgs, ...args };
         super(args);
 

--- a/src/components/NumericInput/component.tsx
+++ b/src/components/NumericInput/component.tsx
@@ -1,13 +1,13 @@
-import Element from './index';
+import Element, { NumericInputArgs } from './index';
 import BaseComponent from '../Element/component';
 
 /**
  * The NumericInput represents an input element that holds numbers.
  */
-class Component extends BaseComponent <ElementArgs, any> {
+class Component extends BaseComponent <NumericInputArgs, any> {
     onValidate: (value: string) => boolean;
 
-    constructor(props: ElementArgs) {
+    constructor(props: NumericInputArgs) {
         super(props);
         this.elementClass = Element;
 

--- a/src/components/NumericInput/component.tsx
+++ b/src/components/NumericInput/component.tsx
@@ -4,10 +4,10 @@ import BaseComponent from '../Element/component';
 /**
  * The NumericInput represents an input element that holds numbers.
  */
-class Component extends BaseComponent <Element.Args, any> {
+class Component extends BaseComponent <ElementArgs, any> {
     onValidate: (value: string) => boolean;
 
-    constructor(props: Element.Args) {
+    constructor(props: ElementArgs) {
         super(props);
         this.elementClass = Element;
 

--- a/src/components/NumericInput/index.ts
+++ b/src/components/NumericInput/index.ts
@@ -1,5 +1,5 @@
 import Element from '../Element/index';
-import TextInput from '../TextInput';
+import TextInput, { TextInputArgs } from '../TextInput';
 import * as pcuiClass from '../../class';
 
 const CLASS_NUMERIC_INPUT = 'pcui-numeric-input';
@@ -9,44 +9,42 @@ const CLASS_NUMERIC_INPUT_SLIDER_CONTROL_HIDDEN = CLASS_NUMERIC_INPUT_SLIDER_CON
 
 const REGEX_COMMA = /,/g;
 
-namespace NumericInput {
-    export interface Args extends TextInput.Args {
-        /**
-         * Sets the minimum value this field can take.
-         */
-        min?: number,
-        /**
-         * Sets the maximum value this field can take.
-         */
-        max?: number,
-        /**
-         * Sets the maximum value this field can take.
-         */
-        precision?: number,
-        /**
-         * Sets the amount that the value will be increased or decreased when using the arrow keys and the slider input.
-         */
-        step?: number,
-        /**
-         * Sets the amount that the value will be increased or decreased when holding shift using the arrow keys and the slider input. Defaults to {@link NumericInput#step} * 0.1.
-         */
-        stepPrecision?: number,
-        /**
-         * Hide the input mouse drag slider.
-         */
-        hideSlider?: boolean,
-        /**
-         * Sets whether the value can be null. If not then it will be 0 instead of null.
-         */
-        allowNull?: boolean
-    }
+export interface NumericInputArgs extends TextInputArgs {
+    /**
+     * Sets the minimum value this field can take.
+     */
+    min?: number,
+    /**
+     * Sets the maximum value this field can take.
+     */
+    max?: number,
+    /**
+     * Sets the maximum value this field can take.
+     */
+    precision?: number,
+    /**
+     * Sets the amount that the value will be increased or decreased when using the arrow keys and the slider input.
+     */
+    step?: number,
+    /**
+     * Sets the amount that the value will be increased or decreased when holding shift using the arrow keys and the slider input. Defaults to {@link NumericInput#step} * 0.1.
+     */
+    stepPrecision?: number,
+    /**
+     * Hide the input mouse drag slider.
+     */
+    hideSlider?: boolean,
+    /**
+     * Sets whether the value can be null. If not then it will be 0 instead of null.
+     */
+    allowNull?: boolean
 }
 
 /**
  * The NumericInput represents an input element that holds numbers.
  */
 class NumericInput extends TextInput {
-    static readonly defaultArgs: NumericInput.Args = {
+    static readonly defaultArgs: NumericInputArgs = {
         ...TextInput.defaultArgs,
         precision: 7,
         min: null,
@@ -87,7 +85,7 @@ class NumericInput extends TextInput {
 
     protected _sliderMovement: number;
 
-    constructor(args: NumericInput.Args = NumericInput.defaultArgs) {
+    constructor(args: NumericInputArgs = NumericInput.defaultArgs) {
         args = { ...NumericInput.defaultArgs, ...args };
         // make copy of args
         args = Object.assign({}, args);

--- a/src/components/Overlay/component.tsx
+++ b/src/components/Overlay/component.tsx
@@ -1,11 +1,11 @@
-import Element from './index';
+import Element, { OverlayArgs } from './index';
 import BaseComponent from '../Element/component';
 
 /**
  * An overlay element.
  */
-class Component extends BaseComponent <ElementArgs, any> {
-    constructor(props: ElementArgs) {
+class Component extends BaseComponent <OverlayArgs, any> {
+    constructor(props: OverlayArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/Overlay/component.tsx
+++ b/src/components/Overlay/component.tsx
@@ -4,8 +4,8 @@ import BaseComponent from '../Element/component';
 /**
  * An overlay element.
  */
-class Component extends BaseComponent <Element.Args, any> {
-    constructor(props: Element.Args) {
+class Component extends BaseComponent <ElementArgs, any> {
+    constructor(props: ElementArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/Overlay/index.ts
+++ b/src/components/Overlay/index.ts
@@ -1,4 +1,4 @@
-import Element from '../Element/index';
+import Element, { ElementArgs } from '../Element/index';
 import Container from '../Container';
 
 const CLASS_OVERLAY = 'pcui-overlay';
@@ -7,24 +7,22 @@ const CLASS_OVERLAY_CLICKABLE = CLASS_OVERLAY + '-clickable';
 const CLASS_OVERLAY_TRANSPARENT = CLASS_OVERLAY + '-transparent';
 const CLASS_OVERLAY_CONTENT = CLASS_OVERLAY + '-content';
 
-namespace Overlay {
-    export interface Args extends Element.Args {
-        /**
-         * Whether the overlay can be hidden by clicking on it.
-         */
-        clickable?: boolean,
-        /**
-         * Whether the overlay is transparent or not.
-         */
-        transparent?: boolean,
-    }
+export interface OverlayArgs extends ElementArgs {
+    /**
+     * Whether the overlay can be hidden by clicking on it.
+     */
+    clickable?: boolean,
+    /**
+     * Whether the overlay is transparent or not.
+     */
+    transparent?: boolean,
 }
 
 /**
  * An overlay element.
  */
 class Overlay extends Container {
-    static readonly defaultArgs: Overlay.Args = {
+    static readonly defaultArgs: OverlayArgs = {
         ...Element.defaultArgs
     };
 
@@ -32,7 +30,7 @@ class Overlay extends Container {
 
     protected _domEventMouseDown: any;
 
-    constructor(args: Overlay.Args = Overlay.defaultArgs) {
+    constructor(args: OverlayArgs = Overlay.defaultArgs) {
         args = { ...Overlay.defaultArgs, ...args };
         super(args);
 

--- a/src/components/Panel/component.tsx
+++ b/src/components/Panel/component.tsx
@@ -6,12 +6,12 @@ import BaseComponent from '../Element/component';
  * The Panel is a pcui.Container that itself contains a header container and a content container. The
  * respective pcui.Container functions work using the content container. One can also append elements to the header of the Panel.
  */
-class Component extends BaseComponent <Element.Args, any> {
+class Component extends BaseComponent <ElementArgs, any> {
     nodeElement: any;
 
     containerElement: any;
 
-    constructor(props: Element.Args = Element.defaultArgs) {
+    constructor(props: ElementArgs = Element.defaultArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/Panel/component.tsx
+++ b/src/components/Panel/component.tsx
@@ -1,17 +1,17 @@
 import React from 'react';
-import Element from './index';
+import Element, { PanelArgs } from './index';
 import BaseComponent from '../Element/component';
 
 /**
  * The Panel is a pcui.Container that itself contains a header container and a content container. The
  * respective pcui.Container functions work using the content container. One can also append elements to the header of the Panel.
  */
-class Component extends BaseComponent <ElementArgs, any> {
+class Component extends BaseComponent <PanelArgs, any> {
     nodeElement: any;
 
     containerElement: any;
 
-    constructor(props: ElementArgs = Element.defaultArgs) {
+    constructor(props: PanelArgs = Element.defaultArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/Panel/index.ts
+++ b/src/components/Panel/index.ts
@@ -13,46 +13,46 @@ const CLASS_PANEL_SORTABLE_ICON = CLASS_PANEL + '-sortable-icon';
 const CLASS_PANEL_REMOVE = CLASS_PANEL + '-remove';
 
 export interface PanelArgs extends ContainerArgs {
-/**
- * Sets whether the Element is collapsible.
- */
-collapsible?: boolean,
-/**
- * Sets whether the Element should be collapsed.
- */
-collapsed?: number,
-/**
- * Sets whether the panel can be reordered.
- */
-sortable?: boolean,
-/**
- * Sets whether the panel collapses horizontally - this would be the case for side panels. Defaults to false.
- */
-collapseHorizontally?: boolean,
-/**
- * Sets whether the panel can be removed.
- */
-removable?: boolean,
-/**
- * The height of the header in pixels. Defaults to 32.
- */
-headerSize?: number,
-/**
- * The header text of the panel. Defaults to the empty string.
- */
-headerText?: string,
-/**
- * Sets the panel type.
- */
-panelType?: 'normal',
-/**
- * A dom element to use for the content container.
- */
-content?: HTMLElement
-/**
- * A dom element to use for the header container.
- */
-header?: HTMLElement
+    /**
+     * Sets whether the Element is collapsible.
+     */
+    collapsible?: boolean,
+    /**
+     * Sets whether the Element should be collapsed.
+     */
+    collapsed?: number,
+    /**
+     * Sets whether the panel can be reordered.
+     */
+    sortable?: boolean,
+    /**
+     * Sets whether the panel collapses horizontally - this would be the case for side panels. Defaults to false.
+     */
+    collapseHorizontally?: boolean,
+    /**
+     * Sets whether the panel can be removed.
+     */
+    removable?: boolean,
+    /**
+     * The height of the header in pixels. Defaults to 32.
+     */
+    headerSize?: number,
+    /**
+     * The header text of the panel. Defaults to the empty string.
+     */
+    headerText?: string,
+    /**
+     * Sets the panel type.
+     */
+    panelType?: 'normal',
+    /**
+     * A dom element to use for the content container.
+     */
+    content?: HTMLElement
+    /**
+     * A dom element to use for the header container.
+     */
+    header?: HTMLElement
 }
 
 /**

--- a/src/components/Panel/index.ts
+++ b/src/components/Panel/index.ts
@@ -1,6 +1,6 @@
 import * as pcuiClass from '../../class';
 import Element from '../Element/index';
-import Container from '../Container/index';
+import Container, { ContainerArgs } from '../Container/index';
 import Label from '../Label/index';
 import Button from '../Button/index';
 
@@ -12,49 +12,47 @@ const CLASS_PANEL_HORIZONTAL = CLASS_PANEL + '-horizontal';
 const CLASS_PANEL_SORTABLE_ICON = CLASS_PANEL + '-sortable-icon';
 const CLASS_PANEL_REMOVE = CLASS_PANEL + '-remove';
 
-namespace Panel {
-    export interface Args extends Container.Args {
-    /**
-     * Sets whether the Element is collapsible.
-     */
-    collapsible?: boolean,
-    /**
-     * Sets whether the Element should be collapsed.
-     */
-    collapsed?: number,
-    /**
-     * Sets whether the panel can be reordered.
-     */
-    sortable?: boolean,
-    /**
-     * Sets whether the panel collapses horizontally - this would be the case for side panels. Defaults to false.
-     */
-    collapseHorizontally?: boolean,
-    /**
-     * Sets whether the panel can be removed.
-     */
-    removable?: boolean,
-    /**
-     * The height of the header in pixels. Defaults to 32.
-     */
-    headerSize?: number,
-    /**
-     * The header text of the panel. Defaults to the empty string.
-     */
-    headerText?: string,
-    /**
-     * Sets the panel type.
-     */
-    panelType?: 'normal',
-    /**
-     * A dom element to use for the content container.
-     */
-    content?: HTMLElement
-    /**
-     * A dom element to use for the header container.
-     */
-    header?: HTMLElement
-    }
+export interface PanelArgs extends ContainerArgs {
+/**
+ * Sets whether the Element is collapsible.
+ */
+collapsible?: boolean,
+/**
+ * Sets whether the Element should be collapsed.
+ */
+collapsed?: number,
+/**
+ * Sets whether the panel can be reordered.
+ */
+sortable?: boolean,
+/**
+ * Sets whether the panel collapses horizontally - this would be the case for side panels. Defaults to false.
+ */
+collapseHorizontally?: boolean,
+/**
+ * Sets whether the panel can be removed.
+ */
+removable?: boolean,
+/**
+ * The height of the header in pixels. Defaults to 32.
+ */
+headerSize?: number,
+/**
+ * The header text of the panel. Defaults to the empty string.
+ */
+headerText?: string,
+/**
+ * Sets the panel type.
+ */
+panelType?: 'normal',
+/**
+ * A dom element to use for the content container.
+ */
+content?: HTMLElement
+/**
+ * A dom element to use for the header container.
+ */
+header?: HTMLElement
 }
 
 /**
@@ -76,7 +74,7 @@ class Panel extends Container {
      */
     public static readonly EVENT_EXPAND = 'expand';
 
-    static readonly defaultArgs: Panel.Args = {
+    static readonly defaultArgs: PanelArgs = {
         ...Container.defaultArgs,
         headerSize: 32
     };
@@ -124,7 +122,7 @@ class Panel extends Container {
      *
      * @param {object} args - The arguments. Extends the pcui.Container constructor arguments. All settable properties can also be set through the constructor.
      */
-    constructor(args: Panel.Args = Panel.defaultArgs) {
+    constructor(args: PanelArgs = Panel.defaultArgs) {
         args = { ...Panel.defaultArgs, ...args };
 
         const panelArgs = Object.assign({}, args);
@@ -183,7 +181,7 @@ class Panel extends Container {
         this._reflow();
     }
 
-    protected _initializeHeader(args: Panel.Args) {
+    protected _initializeHeader(args: PanelArgs) {
         // header container
         this._containerHeader = new Container({
             flex: true,
@@ -221,7 +219,7 @@ class Panel extends Container {
         this.emit('click:remove');
     }
 
-    protected _initializeContent(args: Panel.Args) {
+    protected _initializeContent(args: PanelArgs) {
         // containers container
         this._containerContent = new Container({
             class: CLASS_PANEL_CONTENT,

--- a/src/components/Progress/component.tsx
+++ b/src/components/Progress/component.tsx
@@ -1,11 +1,11 @@
-import Element from './index';
+import Element, { ProgressArgs } from './index';
 import BaseComponent from '../Element/component';
 
 /**
  * Represents a bar that can highlight progress of an activity.
  */
-class Component extends BaseComponent <ElementArgs, any> {
-    constructor(props: ElementArgs) {
+class Component extends BaseComponent <ProgressArgs, any> {
+    constructor(props: ProgressArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/Progress/component.tsx
+++ b/src/components/Progress/component.tsx
@@ -4,8 +4,8 @@ import BaseComponent from '../Element/component';
 /**
  * Represents a bar that can highlight progress of an activity.
  */
-class Component extends BaseComponent <Element.Args, any> {
-    constructor(props: Element.Args) {
+class Component extends BaseComponent <ElementArgs, any> {
+    constructor(props: ElementArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/Progress/index.ts
+++ b/src/components/Progress/index.ts
@@ -1,23 +1,21 @@
 import Element from '../Element/index';
-import Container from '../Container';
+import Container, { ContainerArgs } from '../Container';
 
 const CLASS_ROOT = 'pcui-progress';
 const CLASS_INNER = CLASS_ROOT + '-inner';
 
-namespace Progress {
-    export interface Args extends Container.Args {
-        /**
-         * Gets / sets the value of the progress bar (between 0 and 100).
-         */
-        value?: number
-    }
+export interface ProgressArgs extends ContainerArgs {
+    /**
+     * Gets / sets the value of the progress bar (between 0 and 100).
+     */
+    value?: number
 }
 
 /**
  * Represents a bar that can highlight progress of an activity.
  */
 class Progress extends Container {
-    static readonly defaultArgs: Progress.Args = {
+    static readonly defaultArgs: ProgressArgs = {
         ...Container.defaultArgs
     };
 
@@ -25,7 +23,7 @@ class Progress extends Container {
 
     protected _value: number;
 
-    constructor(args: Progress.Args = Progress.defaultArgs) {
+    constructor(args: ProgressArgs = Progress.defaultArgs) {
         args = { ...Progress.defaultArgs, ...args };
         super(args);
         this.class.add(CLASS_ROOT);

--- a/src/components/RadioButton/component.tsx
+++ b/src/components/RadioButton/component.tsx
@@ -1,11 +1,11 @@
-import Element from './index';
+import Element, { RadioButtonArgs } from './index';
 import BaseComponent from '../Element/component';
 
 /**
  * A radio button element.
  */
-class Component extends BaseComponent <ElementArgs, any> {
-    constructor(props: ElementArgs) {
+class Component extends BaseComponent <RadioButtonArgs, any> {
+    constructor(props: RadioButtonArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/RadioButton/component.tsx
+++ b/src/components/RadioButton/component.tsx
@@ -4,8 +4,8 @@ import BaseComponent from '../Element/component';
 /**
  * A radio button element.
  */
-class Component extends BaseComponent <Element.Args, any> {
-    constructor(props: Element.Args) {
+class Component extends BaseComponent <ElementArgs, any> {
+    constructor(props: ElementArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/RadioButton/index.ts
+++ b/src/components/RadioButton/index.ts
@@ -1,23 +1,21 @@
-import Element from '../Element/index';
+import Element, { ElementArgs, IBindable, IBindableArgs, IFocusable } from '../Element/index';
 import * as pcuiClass from '../../class';
 
 const CLASS_RADIO_BUTTON = 'pcui-radio-button';
 const CLASS_RADIO_BUTTON_SELECTED = CLASS_RADIO_BUTTON + '-selected';
 
-namespace RadioButton {
-    export interface Args extends Element.Args, Element.IBindableArgs {
-        /**
-         * The text to display next to the radio button.
-         */
-        text?: string;
-    }
+export interface RadioButtonArgs extends ElementArgs, IBindableArgs {
+    /**
+     * The text to display next to the radio button.
+     */
+    text?: string;
 }
 
 /**
  * A radio button element.
  */
-class RadioButton extends Element implements Element.IBindable, Element.IFocusable {
-    static readonly defaultArgs: RadioButton.Args = {
+class RadioButton extends Element implements IBindable, IFocusable {
+    static readonly defaultArgs: RadioButtonArgs = {
         ...Element.defaultArgs,
         text: '',
         value: null,
@@ -36,7 +34,7 @@ class RadioButton extends Element implements Element.IBindable, Element.IFocusab
 
     protected _renderChanges: boolean;
 
-    constructor(args: RadioButton.Args = RadioButton.defaultArgs) {
+    constructor(args: RadioButtonArgs = RadioButton.defaultArgs) {
         args = { ...RadioButton.defaultArgs, ...args };
         super(args.dom, args);
 

--- a/src/components/SelectInput/component.tsx
+++ b/src/components/SelectInput/component.tsx
@@ -1,11 +1,11 @@
-import Element from './index';
+import Element, { SelectInputArgs } from './index';
 import BaseComponent from '../Element/component';
 
 /**
  * An input that allows selecting from a dropdown or entering tags.
  */
-class Component extends BaseComponent <ElementArgs, any> {
-    constructor(props: ElementArgs) {
+class Component extends BaseComponent <SelectInputArgs, any> {
+    constructor(props: SelectInputArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/SelectInput/component.tsx
+++ b/src/components/SelectInput/component.tsx
@@ -4,8 +4,8 @@ import BaseComponent from '../Element/component';
 /**
  * An input that allows selecting from a dropdown or entering tags.
  */
-class Component extends BaseComponent <Element.Args, any> {
-    constructor(props: Element.Args) {
+class Component extends BaseComponent <ElementArgs, any> {
+    constructor(props: ElementArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/SelectInput/index.ts
+++ b/src/components/SelectInput/index.ts
@@ -1,4 +1,4 @@
-import Element from '../Element/index';
+import Element, { ElementArgs, IBindable, IBindableArgs, IFocusable, IPlaceholderArgs } from '../Element/index';
 import Container from '../Container';
 import TextInput from '../TextInput';
 import Button from '../Button';
@@ -27,61 +27,59 @@ const CLASS_OPEN = 'pcui-open';
 
 const DEFAULT_BOTTOM_OFFSET = 25;
 
-namespace SelectInput {
-    export interface Args extends Element.Args, Element.IBindableArgs, Element.IPlaceholderArgs {
-        /**
-         * Used to map the options
-         */
-        optionsFn?: any;
-        /**
-         * default value for the input
-         */
-        defaultValue?: any;
-        /**
-         * If true then the input value becomes an array allowing the selection of multiple options. Defaults to false.
-         */
-        multiSelect?: boolean;
-        /**
-         * The dropdown options of the input. Contains an array of objects with the following format \{v: Any, t: String\} where v is the value and t is the text of the option.
-         */
-        options?: Array<{ v: any, t: string }>;
-        /**
-         * An array of values against which new values are checked before they are created. If a value is in the array it will not be created.
-         */
-        invalidOptions?: Array<any>;
-        /**
-         * If true then null is a valid input value. Defaults to false.
-         */
-        allowNull?: boolean;
-        /**
-         * If true then a text field is shown for the user to search for values or enter new ones. Defaults to false.
-         */
-        allowInput?: boolean;
-        /**
-         * If true then the input allows creating new values from the text field. Only used when allowInput is true. Defaults to false.
-         */
-        allowCreate?: boolean;
-        /**
-         * A function to be executed when the user selects to create a new value. The function takes the new value as a parameter.
-         */
-        createFn?: (value: string) => void;
-        /**
-         * The placeholder text to show when creating a new value. Used when allowInput and allowCreate are both true.
-         */
-        createLabelText?: string;
-        /**
-         * The type of each value. Can be one of 'string', 'number' or 'boolean'.
-         */
-        type?: 'string' | 'number' | 'boolean';
-    }
+export interface SelectInputArgs extends ElementArgs, IBindableArgs, IPlaceholderArgs {
+    /**
+     * Used to map the options
+     */
+    optionsFn?: any;
+    /**
+     * default value for the input
+     */
+    defaultValue?: any;
+    /**
+     * If true then the input value becomes an array allowing the selection of multiple options. Defaults to false.
+     */
+    multiSelect?: boolean;
+    /**
+     * The dropdown options of the input. Contains an array of objects with the following format \{v: Any, t: String\} where v is the value and t is the text of the option.
+     */
+    options?: Array<{ v: any, t: string }>;
+    /**
+     * An array of values against which new values are checked before they are created. If a value is in the array it will not be created.
+     */
+    invalidOptions?: Array<any>;
+    /**
+     * If true then null is a valid input value. Defaults to false.
+     */
+    allowNull?: boolean;
+    /**
+     * If true then a text field is shown for the user to search for values or enter new ones. Defaults to false.
+     */
+    allowInput?: boolean;
+    /**
+     * If true then the input allows creating new values from the text field. Only used when allowInput is true. Defaults to false.
+     */
+    allowCreate?: boolean;
+    /**
+     * A function to be executed when the user selects to create a new value. The function takes the new value as a parameter.
+     */
+    createFn?: (value: string) => void;
+    /**
+     * The placeholder text to show when creating a new value. Used when allowInput and allowCreate are both true.
+     */
+    createLabelText?: string;
+    /**
+     * The type of each value. Can be one of 'string', 'number' or 'boolean'.
+     */
+    type?: 'string' | 'number' | 'boolean';
 }
 
 
 /**
  * An input that allows selecting from a dropdown or entering tags.
  */
-class SelectInput extends Element implements Element.IBindable, Element.IFocusable {
-    static readonly defaultArgs: SelectInput.Args = {
+class SelectInput extends Element implements IBindable, IFocusable {
+    static readonly defaultArgs: SelectInputArgs = {
         ...Element.defaultArgs,
         optionsFn: null,
         defaultValue: null,
@@ -162,7 +160,7 @@ class SelectInput extends Element implements Element.IBindable, Element.IFocusab
 
     protected _renderChanges: boolean;
 
-    constructor(args: SelectInput.Args = SelectInput.defaultArgs) {
+    constructor(args: SelectInputArgs = SelectInput.defaultArgs) {
         args = { ...SelectInput.defaultArgs, ...args };
         // main container
         const container = new Container({ dom: args.dom });

--- a/src/components/SliderInput/component.tsx
+++ b/src/components/SliderInput/component.tsx
@@ -1,12 +1,12 @@
-import Element from './index';
+import Element, { SliderInputArgs } from './index';
 import BaseComponent from '../Element/component';
 
 /**
  * The SliderInput shows a pcui.NumericInput and a slider widget next to it. It acts as a proxy
  * of the NumericInput.
  */
-class Component extends BaseComponent <ElementArgs, any> {
-    constructor(props: ElementArgs) {
+class Component extends BaseComponent <SliderInputArgs, any> {
+    constructor(props: SliderInputArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/SliderInput/component.tsx
+++ b/src/components/SliderInput/component.tsx
@@ -5,8 +5,8 @@ import BaseComponent from '../Element/component';
  * The SliderInput shows a pcui.NumericInput and a slider widget next to it. It acts as a proxy
  * of the NumericInput.
  */
-class Component extends BaseComponent <Element.Args, any> {
-    constructor(props: Element.Args) {
+class Component extends BaseComponent <ElementArgs, any> {
+    constructor(props: ElementArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/SliderInput/index.ts
+++ b/src/components/SliderInput/index.ts
@@ -1,5 +1,5 @@
-import Element from '../Element/index';
-import NumericInput from '../NumericInput';
+import Element, { ElementArgs, IBindable, IBindableArgs, IFlexArgs, IFocusable } from '../Element/index';
+import NumericInput, { NumericInputArgs } from '../NumericInput';
 import * as pcuiClass from '../../class';
 import * as utils from '../../helpers/utils';
 
@@ -24,49 +24,47 @@ const PROXY_FIELDS = [
 ];
 
 
-namespace SliderInput {
-    export interface Args extends Element.Args, Element.IBindableArgs, Element.IFlexArgs {
-        /**
-         * Gets / sets the minimum value that the numeric input field can take. Defaults to 0.
-         */
-        min?: number,
-        /**
-         * Gets / sets the maximum value that the numeric input field can take. Defaults to 1.
-         */
-        max?: number,
-        /**
-         * Gets / sets the minimum value that the slider field can take.
-         */
-        sliderMin?: number,
-        /**
-         * Gets / sets the maximum value that the slider field can take.
-         */
-        sliderMax?: number,
-        /**
-         * Gets / sets the maximum number of decimals a value can take. Here for backwards compatibility. Use the precision argument instead going forward.
-         */
-        pre?: number,
-        /**
-         * Gets / sets the maximum number of decimals a value can take.
-         */
-        precision?: number,
-        /**
-         * Gets / sets the amount that the value will be increased or decreased when using the arrow keys. Holding Shift will use 10x the step.
-         */
-        step?: number,
-        /**
-         * Gets / sets whether the value can be null. If not then it will be 0 instead of null.
-         */
-        allowNull?: boolean
-    }
+export interface SliderInputArgs extends ElementArgs, IBindableArgs, IFlexArgs {
+    /**
+     * Gets / sets the minimum value that the numeric input field can take. Defaults to 0.
+     */
+    min?: number,
+    /**
+     * Gets / sets the maximum value that the numeric input field can take. Defaults to 1.
+     */
+    max?: number,
+    /**
+     * Gets / sets the minimum value that the slider field can take.
+     */
+    sliderMin?: number,
+    /**
+     * Gets / sets the maximum value that the slider field can take.
+     */
+    sliderMax?: number,
+    /**
+     * Gets / sets the maximum number of decimals a value can take. Here for backwards compatibility. Use the precision argument instead going forward.
+     */
+    pre?: number,
+    /**
+     * Gets / sets the maximum number of decimals a value can take.
+     */
+    precision?: number,
+    /**
+     * Gets / sets the amount that the value will be increased or decreased when using the arrow keys. Holding Shift will use 10x the step.
+     */
+    step?: number,
+    /**
+     * Gets / sets whether the value can be null. If not then it will be 0 instead of null.
+     */
+    allowNull?: boolean
 }
 
 /**
  * The SliderInput shows a pcui.NumericInput and a slider widget next to it. It acts as a proxy
  * of the NumericInput.
  */
-class SliderInput extends Element implements Element.IBindable, Element.IFocusable {
-    static readonly defaultArgs: SliderInput.Args = {
+class SliderInput extends Element implements IBindable, IFocusable {
+    static readonly defaultArgs: SliderInputArgs = {
         ...Element.defaultArgs,
         min: 0,
         max: 1
@@ -111,9 +109,9 @@ class SliderInput extends Element implements Element.IBindable, Element.IFocusab
      *
      * @param args
      */
-    constructor(args: SliderInput.Args = SliderInput.defaultArgs) {
+    constructor(args: SliderInputArgs = SliderInput.defaultArgs) {
         args = { ...SliderInput.defaultArgs, ...args };
-        const inputArgs: NumericInput.Args = {};
+        const inputArgs: NumericInputArgs = {};
         PROXY_FIELDS.forEach((field) => {
             // @ts-ignore
             inputArgs[field] = args[field];

--- a/src/components/Spinner/component.tsx
+++ b/src/components/Spinner/component.tsx
@@ -5,10 +5,10 @@ import BaseComponent from '../Element/component';
 /**
  * Represents a spinning icon
  */
-class Component extends BaseComponent <Element.Args, any> {
-    static defaultProps: Element.Args;
+class Component extends BaseComponent <ElementArgs, any> {
+    static defaultProps: ElementArgs;
 
-    constructor(props: Element.Args) {
+    constructor(props: ElementArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/Spinner/component.tsx
+++ b/src/components/Spinner/component.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
-import Element from './index';
+import Element, { SpinnerArgs } from './index';
 import BaseComponent from '../Element/component';
 
 /**
  * Represents a spinning icon
  */
-class Component extends BaseComponent <ElementArgs, any> {
-    static defaultProps: ElementArgs;
+class Component extends BaseComponent <SpinnerArgs, any> {
+    static defaultProps: SpinnerArgs;
 
-    constructor(props: ElementArgs) {
+    constructor(props: SpinnerArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/Spinner/index.ts
+++ b/src/components/Spinner/index.ts
@@ -1,4 +1,4 @@
-import Element from '../Element/index';
+import Element, { ElementArgs } from '../Element/index';
 
 const CLASS_ROOT = 'pcui-spinner';
 
@@ -13,18 +13,16 @@ function createSmallThick(size: any, dom: any) {
     return spinner;
 }
 
-namespace Spinner {
-    export interface Args extends Element.Args {
+export interface SpinnerArgs extends ElementArgs {
 
-        /**
-         * Sets the pixel size of the spinner. Defaults to 12.
-         */
-        size?: string | number,
-        /**
-         * Can be 'small-thick'. Defaults to 'small-thick'.
-         */
-        type?: 'small-thick'
-    }
+    /**
+     * Sets the pixel size of the spinner. Defaults to 12.
+     */
+    size?: string | number,
+    /**
+     * Can be 'small-thick'. Defaults to 'small-thick'.
+     */
+    type?: 'small-thick'
 }
 
 /**
@@ -33,7 +31,7 @@ namespace Spinner {
 class Spinner extends Element {
     static TYPE_SMALL_THICK = 'small-thick';
 
-    static readonly defaultArgs: Spinner.Args = {
+    static readonly defaultArgs: SpinnerArgs = {
         ...Element.defaultArgs,
         type: 'small-thick'
     };
@@ -43,7 +41,7 @@ class Spinner extends Element {
      *
      * @param args
      */
-    constructor(args: Spinner.Args = Spinner.defaultArgs) {
+    constructor(args: SpinnerArgs = Spinner.defaultArgs) {
         args = { ...Spinner.defaultArgs, ...args };
         let dom = null;
 

--- a/src/components/TextAreaInput/component.tsx
+++ b/src/components/TextAreaInput/component.tsx
@@ -4,8 +4,8 @@ import BaseComponent from '../Element/component';
 /**
  * The TextAreaInput wraps a textarea element. It has the same interface as pcui.TextInput.
  */
-class Component extends BaseComponent <Element.Args, any> {
-    constructor(props: Element.Args) {
+class Component extends BaseComponent <ElementArgs, any> {
+    constructor(props: ElementArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/TextAreaInput/component.tsx
+++ b/src/components/TextAreaInput/component.tsx
@@ -1,11 +1,11 @@
-import Element from './index';
+import Element, { TextAreaInputArgs } from './index';
 import BaseComponent from '../Element/component';
 
 /**
  * The TextAreaInput wraps a textarea element. It has the same interface as pcui.TextInput.
  */
-class Component extends BaseComponent <ElementArgs, any> {
-    constructor(props: ElementArgs) {
+class Component extends BaseComponent <TextAreaInputArgs, any> {
+    constructor(props: TextAreaInputArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/TextAreaInput/index.ts
+++ b/src/components/TextAreaInput/index.ts
@@ -1,5 +1,5 @@
 import Element from '../Element/index';
-import TextInput from '../TextInput/index';
+import TextInput, { TextInputArgs } from '../TextInput/index';
 
 const CLASS_TEXT_AREA_INPUT = 'pcui-text-area-input';
 const CLASS_TEXT_AREA_INPUT_RESIZABLE = CLASS_TEXT_AREA_INPUT + '-resizable';
@@ -8,24 +8,22 @@ const CLASS_TEXT_AREA_INPUT_RESIZABLE_BOTH = CLASS_TEXT_AREA_INPUT_RESIZABLE + '
 const CLASS_TEXT_AREA_INPUT_RESIZABLE_HORIZONTAL = CLASS_TEXT_AREA_INPUT_RESIZABLE + '-horizontal';
 const CLASS_TEXT_AREA_INPUT_RESIZABLE_VERTICAL = CLASS_TEXT_AREA_INPUT_RESIZABLE + '-vertical';
 
-namespace TextAreaInput {
-    export interface Args extends TextInput.Args {
-        /**
-         * Sets which directions the text area can be resized in. One of 'both', 'horizontal', 'vertical' or 'none'. Defaults to none.
-         */
-        resizable?: 'horizontal' | 'vertical' | 'both' | 'none'
-    }
+export interface TextAreaInputArgs extends TextInputArgs {
+    /**
+     * Sets which directions the text area can be resized in. One of 'both', 'horizontal', 'vertical' or 'none'. Defaults to none.
+     */
+    resizable?: 'horizontal' | 'vertical' | 'both' | 'none'
 }
 
 /**
  * The TextAreaInput wraps a textarea element. It has the same interface as pcui.TextInput.
  */
 class TextAreaInput extends TextInput {
-    static readonly defaultArgs: TextAreaInput.Args = {
+    static readonly defaultArgs: TextAreaInputArgs = {
         ...TextInput.defaultArgs
     };
 
-    constructor(args: TextAreaInput.Args = TextAreaInput.defaultArgs) {
+    constructor(args: TextAreaInputArgs = TextAreaInput.defaultArgs) {
         args = { ...TextAreaInput.defaultArgs, ...args };
         args = Object.assign({
             input: document.createElement('textarea')

--- a/src/components/TextInput/component.tsx
+++ b/src/components/TextInput/component.tsx
@@ -4,10 +4,10 @@ import BaseComponent from '../Element/component';
 /**
  * The TextInput is an input element of type text.
  */
-class TextInput extends BaseComponent <Element.Args, any> {
+class TextInput extends BaseComponent <ElementArgs, any> {
     onValidate: (value: string) => boolean;
 
-    constructor(props: Element.Args = Element.defaultArgs) {
+    constructor(props: ElementArgs = Element.defaultArgs) {
         super(props);
         this.elementClass = Element;
 

--- a/src/components/TextInput/component.tsx
+++ b/src/components/TextInput/component.tsx
@@ -1,13 +1,13 @@
-import Element from './index';
+import Element, { TextInputArgs } from './index';
 import BaseComponent from '../Element/component';
 
 /**
  * The TextInput is an input element of type text.
  */
-class TextInput extends BaseComponent <ElementArgs, any> {
+class TextInput extends BaseComponent <TextInputArgs, any> {
     onValidate: (value: string) => boolean;
 
-    constructor(props: ElementArgs = Element.defaultArgs) {
+    constructor(props: TextInputArgs = Element.defaultArgs) {
         super(props);
         this.elementClass = Element;
 

--- a/src/components/TextInput/index.ts
+++ b/src/components/TextInput/index.ts
@@ -1,40 +1,38 @@
-import Element from '../Element/index';
-import Input from '../Input/index';
+import Element, { IBindableArgs, IFocusable, IPlaceholder, IPlaceholderArgs } from '../Element/index';
+import Input, { InputArgs } from '../Input/index';
 import * as pcuiClass from '../../class';
 
 const CLASS_TEXT_INPUT = 'pcui-text-input';
 
-namespace TextInput {
-    export interface Args extends Input.Args, Element.IBindableArgs, Element.IPlaceholderArgs {
-        /**
-         * Sets whether pressing Enter will blur (unfocus) the field. Defaults to true.
-         */
-        blurOnEnter?: boolean,
-        /**
-         * Sets whether pressing Escape will blur (unfocus) the field. Defaults to true.
-         */
-        blurOnEscape?: boolean,
-        /**
-         * Sets whether any key up event will cause a change event to be fired.
-         */
-        keyChange?: boolean,
-        /**
-         * A function that validates the value that is entered into the input and returns true if it is valid or false otherwise.
-         * If false then the input will be set in an error state and the value will not propagate to the binding.
-         */
-        onValidate?: (value: string) => boolean,
-        /**
-         * The input element to associate this TextInput with. If not supplied one will be created instead.
-         */
-        input?: HTMLInputElement
-    }
+export interface TextInputArgs extends InputArgs, IBindableArgs, IPlaceholderArgs {
+    /**
+     * Sets whether pressing Enter will blur (unfocus) the field. Defaults to true.
+     */
+    blurOnEnter?: boolean,
+    /**
+     * Sets whether pressing Escape will blur (unfocus) the field. Defaults to true.
+     */
+    blurOnEscape?: boolean,
+    /**
+     * Sets whether any key up event will cause a change event to be fired.
+     */
+    keyChange?: boolean,
+    /**
+     * A function that validates the value that is entered into the input and returns true if it is valid or false otherwise.
+     * If false then the input will be set in an error state and the value will not propagate to the binding.
+     */
+    onValidate?: (value: string) => boolean,
+    /**
+     * The input element to associate this TextInput with. If not supplied one will be created instead.
+     */
+    input?: HTMLInputElement
 }
 
 /**
  * The TextInput is an input element of type text.
  */
-class TextInput extends Input implements Element.IFocusable, Element.IPlaceholder {
-    static readonly defaultArgs: TextInput.Args = {
+class TextInput extends Input implements IFocusable, IPlaceholder {
+    static readonly defaultArgs: TextInputArgs = {
         ...Input.defaultArgs,
         blurOnEnter: true,
         blurOnEscape: true,
@@ -69,7 +67,7 @@ class TextInput extends Input implements Element.IFocusable, Element.IPlaceholde
 
     protected _blurOnEscape: boolean;
 
-    constructor(args: TextInput.Args = TextInput.defaultArgs) {
+    constructor(args: TextInputArgs = TextInput.defaultArgs) {
         args = { ...TextInput.defaultArgs, ...args };
         super(args.dom, args);
 

--- a/src/components/TreeView/component.tsx
+++ b/src/components/TreeView/component.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import TreeViewElement from './index';
+import TreeViewElement, { TreeViewArgs } from './index';
 import TreeViewItemElement from '../TreeViewItem/index';
 import BaseComponent from '../Element/component';
 
@@ -7,10 +7,10 @@ import BaseComponent from '../Element/component';
  * A container that can show a TreeView like a hierarchy. The TreeView contains
  * TreeViewItems.
  */
-class Component extends BaseComponent <TreeViewElementArgs, any> {
+class Component extends BaseComponent <TreeViewArgs, any> {
     parentElement: any;
 
-    constructor(props: TreeViewElementArgs) {
+    constructor(props: TreeViewArgs) {
         super(props);
 
         this.element = new TreeViewElement({ ...props });

--- a/src/components/TreeView/component.tsx
+++ b/src/components/TreeView/component.tsx
@@ -7,10 +7,10 @@ import BaseComponent from '../Element/component';
  * A container that can show a TreeView like a hierarchy. The TreeView contains
  * TreeViewItems.
  */
-class Component extends BaseComponent <TreeViewElement.Args, any> {
+class Component extends BaseComponent <TreeViewElementArgs, any> {
     parentElement: any;
 
-    constructor(props: TreeViewElement.Args) {
+    constructor(props: TreeViewElementArgs) {
         super(props);
 
         this.element = new TreeViewElement({ ...props });

--- a/src/components/TreeView/index.ts
+++ b/src/components/TreeView/index.ts
@@ -1,4 +1,4 @@
-import Container from '../Container';
+import Container, { ContainerArgs } from '../Container';
 import Element from '../Element/index';
 import TreeViewItem from '../TreeViewItem';
 import { searchItems } from '../../helpers/search';
@@ -13,38 +13,36 @@ const DRAG_AREA_INSIDE = 'inside';
 const DRAG_AREA_BEFORE = 'before';
 const DRAG_AREA_AFTER = 'after';
 
-namespace TreeView {
-    export interface Args extends Container.Args {
-        /**
-         * Whether dragging a TreeViewItem is allowed.
-         */
-        allowDrag?: boolean,
-        /**
-         * Whether reordering TreeViewItems is allowed.
-         */
-        allowReordering?: boolean,
-        /**
-         * Whether renaming TreeViewItems is allowed by double clicking on them.
-         */
-        allowRenaming?: boolean,
-        /**
-         * A filter that searches TreeViewItems and only shows the ones that are relevant to the filter.
-         */
-        filter?: string,
-        /**
-         * A function to be called when we right click on a TreeViewItem.
-         */
-        onContextMenu?: any,
-        /**
-         * A function to be called when we try to reparent tree items. If a function is provided then the
-         * tree items will not be reparented by the TreeView but instead will rely on the function to reparent them as it sees fit.
-         */
-        onReparent?: any,
-        /**
-         * The element to scroll on drag. Defaults to this TreeView's dom.
-         */
-        dragScrollElement?: HTMLElement
-    }
+export interface TreeViewArgs extends ContainerArgs {
+    /**
+     * Whether dragging a TreeViewItem is allowed.
+     */
+    allowDrag?: boolean,
+    /**
+     * Whether reordering TreeViewItems is allowed.
+     */
+    allowReordering?: boolean,
+    /**
+     * Whether renaming TreeViewItems is allowed by double clicking on them.
+     */
+    allowRenaming?: boolean,
+    /**
+     * A filter that searches TreeViewItems and only shows the ones that are relevant to the filter.
+     */
+    filter?: string,
+    /**
+     * A function to be called when we right click on a TreeViewItem.
+     */
+    onContextMenu?: any,
+    /**
+     * A function to be called when we try to reparent tree items. If a function is provided then the
+     * tree items will not be reparented by the TreeView but instead will rely on the function to reparent them as it sees fit.
+     */
+    onReparent?: any,
+    /**
+     * The element to scroll on drag. Defaults to this TreeView's dom.
+     */
+    dragScrollElement?: HTMLElement
 }
 
 /**
@@ -100,7 +98,7 @@ class TreeView extends Container {
      */
     public static readonly EVENT_RENAME = 'rename';
 
-    static defaultArgs : TreeView.Args = {
+    static defaultArgs : TreeViewArgs = {
         ...Container.defaultArgs,
         allowDrag: true,
         allowReordering: true
@@ -157,7 +155,7 @@ class TreeView extends Container {
      *
      * @param args
      */
-    constructor(args: TreeView.Args = TreeView.defaultArgs) {
+    constructor(args: TreeViewArgs = TreeView.defaultArgs) {
         args = { ...TreeView.defaultArgs, ...args };
         super(args);
 

--- a/src/components/TreeViewItem/component.tsx
+++ b/src/components/TreeViewItem/component.tsx
@@ -1,15 +1,15 @@
-import Element from './index';
+import Element, { TreeViewItemArgs } from './index';
 import BaseComponent from '../Element/component';
 
 /**
  * Represents a Tree View Item to be added to a pcui.TreeView.
  */
-class Component extends BaseComponent <ElementArgs, any> {
+class Component extends BaseComponent <TreeViewItemArgs, any> {
     onSelect: () => void;
 
     onDeselect: () => void;
 
-    constructor(props: ElementArgs) {
+    constructor(props: TreeViewItemArgs) {
         super(props);
         this.elementClass = Element;
 

--- a/src/components/TreeViewItem/component.tsx
+++ b/src/components/TreeViewItem/component.tsx
@@ -4,12 +4,12 @@ import BaseComponent from '../Element/component';
 /**
  * Represents a Tree View Item to be added to a pcui.TreeView.
  */
-class Component extends BaseComponent <Element.Args, any> {
+class Component extends BaseComponent <ElementArgs, any> {
     onSelect: () => void;
 
     onDeselect: () => void;
 
-    constructor(props: Element.Args) {
+    constructor(props: ElementArgs) {
         super(props);
         this.elementClass = Element;
 

--- a/src/components/TreeViewItem/index.ts
+++ b/src/components/TreeViewItem/index.ts
@@ -1,5 +1,5 @@
 import Label from '../Label/index';
-import Container from '../Container/index';
+import Container, { ContainerArgs } from '../Container/index';
 import TextInput from '../TextInput/index';
 import * as pcuiClass from '../../class';
 
@@ -12,52 +12,50 @@ const CLASS_CONTENTS = CLASS_ROOT + '-contents';
 const CLASS_EMPTY = CLASS_ROOT + '-empty';
 const CLASS_RENAME = CLASS_ROOT + '-rename';
 
-namespace TreeViewItem {
-    export interface Args extends Container.Args {
-        /**
-         * Whether the item is selected.
-         */
-        selected?: boolean;
-        /**
-         * Whether the item can be selected. Defaults to true.
-         */
-        allowSelect?: boolean,
-        /**
-         * Whether the item is open meaning showing its children.
-         */
-        open?: boolean,
-        /**
-         * Whether this tree item can be dragged. Only considered if the parent treeview has allowDrag true. Defaults to true.
-         */
-        allowDrag?: boolean,
-        /**
-         * Whether dropping is allowed on the tree item. Defaults to true.
-         */
-        allowDrop?: boolean,
-        /**
-         * The text shown by the TreeViewItem.
-         */
-        text?: string,
-        /**
-         * The icon shown before the text in the TreeViewItem. Defaults to E360.
-         */
-        icon?: string,
-        /**
-         * Method to be called when the TreeViewItem is selected.
-         */
-        onSelect?: (deselect: () => void) => void,
-        /**
-         * Method to be called when the TreeViewItem is deselected.
-         */
-        onDeselect?: () => void
-    }
+export interface TreeViewItemArgs extends ContainerArgs {
+    /**
+     * Whether the item is selected.
+     */
+    selected?: boolean;
+    /**
+     * Whether the item can be selected. Defaults to true.
+     */
+    allowSelect?: boolean,
+    /**
+     * Whether the item is open meaning showing its children.
+     */
+    open?: boolean,
+    /**
+     * Whether this tree item can be dragged. Only considered if the parent treeview has allowDrag true. Defaults to true.
+     */
+    allowDrag?: boolean,
+    /**
+     * Whether dropping is allowed on the tree item. Defaults to true.
+     */
+    allowDrop?: boolean,
+    /**
+     * The text shown by the TreeViewItem.
+     */
+    text?: string,
+    /**
+     * The icon shown before the text in the TreeViewItem. Defaults to E360.
+     */
+    icon?: string,
+    /**
+     * Method to be called when the TreeViewItem is selected.
+     */
+    onSelect?: (deselect: () => void) => void,
+    /**
+     * Method to be called when the TreeViewItem is deselected.
+     */
+    onDeselect?: () => void
 }
 
 /**
  * Represents a Tree View Item to be added to a pcui.TreeView.
  */
 class TreeViewItem extends Container {
-    static readonly defaultArgs: TreeViewItem.Args = {
+    static readonly defaultArgs: TreeViewItemArgs = {
         ...Container.defaultArgs,
         flex: true,
         icon: 'E360',
@@ -143,7 +141,7 @@ class TreeViewItem extends Container {
      *
      * @param args
      */
-    constructor(args: TreeViewItem.Args = TreeViewItem.defaultArgs) {
+    constructor(args: TreeViewItemArgs = TreeViewItem.defaultArgs) {
         args = { ...TreeViewItem.defaultArgs, ...args };
         super(args);
 

--- a/src/components/VectorInput/component.tsx
+++ b/src/components/VectorInput/component.tsx
@@ -1,11 +1,11 @@
-import Element from './index';
+import Element, { VectorInputArgs } from './index';
 import BaseComponent from '../Element/component';
 
 /**
  * A vector input
  */
-class Component extends BaseComponent <ElementArgs, any> {
-    constructor(props: ElementArgs) {
+class Component extends BaseComponent <VectorInputArgs, any> {
+    constructor(props: VectorInputArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/VectorInput/component.tsx
+++ b/src/components/VectorInput/component.tsx
@@ -4,8 +4,8 @@ import BaseComponent from '../Element/component';
 /**
  * A vector input
  */
-class Component extends BaseComponent <Element.Args, any> {
-    constructor(props: Element.Args) {
+class Component extends BaseComponent <ElementArgs, any> {
+    constructor(props: ElementArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/VectorInput/index.ts
+++ b/src/components/VectorInput/index.ts
@@ -1,43 +1,41 @@
-import Element from '../Element/index';
+import Element, { ElementArgs, IBindable, IBindableArgs, IFocusable, IPlaceholder, IPlaceholderArgs } from '../Element/index';
 import NumericInput from '../NumericInput';
 import * as pcuiClass from '../../class';
 
 const CLASS_VECTOR_INPUT = 'pcui-vector-input';
 
-namespace VectorInput {
-    export interface Args extends Element.Args, Element.IPlaceholderArgs, Element.IBindableArgs {
-        /**
-         * The number of dimensions in the vector. Can be between 2 to 4. Defaults to 3.
-         */
-        dimensions?: number;
-        /**
-         * The minimum value of each vector element.
-         */
-        min?: number;
-        /**
-         * The maximum value of each vector element.
-         */
-        max?: number;
-        /**
-         * The incremental step when using arrow keys or dragger for each vector element.
-         */
-        step?: number;
-        /**
-         * The decimal precision of each vector element.
-         */
-        precision?: number;
-        /**
-         *  The incremental step when holding Shift and using arrow keys or dragger for each vector element.
-         */
-        stepPrecision?: number;
-    }
+export interface VectorInputArgs extends ElementArgs, IPlaceholderArgs, IBindableArgs {
+    /**
+     * The number of dimensions in the vector. Can be between 2 to 4. Defaults to 3.
+     */
+    dimensions?: number;
+    /**
+     * The minimum value of each vector element.
+     */
+    min?: number;
+    /**
+     * The maximum value of each vector element.
+     */
+    max?: number;
+    /**
+     * The incremental step when using arrow keys or dragger for each vector element.
+     */
+    step?: number;
+    /**
+     * The decimal precision of each vector element.
+     */
+    precision?: number;
+    /**
+     *  The incremental step when holding Shift and using arrow keys or dragger for each vector element.
+     */
+    stepPrecision?: number;
 }
 
 /**
  * A vector input
  */
-class VectorInput extends Element implements Element.IBindable, Element.IFocusable, Element.IPlaceholder {
-    static readonly defaultArgs: VectorInput.Args = {
+class VectorInput extends Element implements IBindable, IFocusable, IPlaceholder {
+    static readonly defaultArgs: VectorInputArgs = {
         ...Element.defaultArgs,
         dimensions: 3
     };
@@ -46,7 +44,7 @@ class VectorInput extends Element implements Element.IBindable, Element.IFocusab
 
     protected _applyingChange: boolean;
 
-    constructor(args: VectorInput.Args = VectorInput.defaultArgs) {
+    constructor(args: VectorInputArgs = VectorInput.defaultArgs) {
         args = { ...VectorInput.defaultArgs, ...args };
 
         // set binding after inputs have been created

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,67 +1,106 @@
-import ArrayInput from './ArrayInput/index';
-import BooleanInput from './BooleanInput/index';
-import Button from './Button/index';
-import Canvas from './Canvas/index';
-import Code from './Code/index';
-import ColorPicker from './ColorPicker/index';
-import Container from './Container/index';
-import ContextMenu from './ContextMenu/index';
-import Divider from './Divider/index';
-import Element from './Element/index';
-import GradientPicker from './GradientPicker/index';
-import GridView from './GridView/index';
-import GridViewItem from './GridViewItem/index';
-import InfoBox from './InfoBox/index';
-import Label from './Label/index';
-import LabelGroup from './LabelGroup/index';
-import Menu from './Menu/index';
-import MenuItem from './MenuItem/index';
-import NumericInput from './NumericInput/index';
-import Overlay from './Overlay/index';
-import Panel from './Panel/index';
-import Progress from './Progress/index';
-import RadioButton from './RadioButton/index';
-import SelectInput from './SelectInput/index';
-import SliderInput from './SliderInput/index';
-import Spinner from './Spinner/index';
-import TextAreaInput from './TextAreaInput/index';
-import TextInput from './TextInput/index';
-import TreeView from './TreeView/index';
-import TreeViewItem from './TreeViewItem/index';
-import Input from './Input/index';
-import VectorInput from './VectorInput/index';
+import ArrayInput, { ArrayInputArgs } from './ArrayInput/index';
+import BooleanInput, { BooleanInputArgs } from './BooleanInput/index';
+import Button, { ButtonArgs } from './Button/index';
+import Canvas, { CanvasArgs } from './Canvas/index';
+import Code, { CodeArgs } from './Code/index';
+import ColorPicker, { ColorPickerArgs } from './ColorPicker/index';
+import Container, { ContainerArgs } from './Container/index';
+import ContextMenu, { ContextMenuArgs } from './ContextMenu/index';
+import Divider, { DividerArgs } from './Divider/index';
+import Element, { ElementArgs, IBindable, IBindableArgs, IFlexArgs, IFocusable, IParentArgs, IPlaceholder, IPlaceholderArgs } from './Element/index';
+import GradientPicker, { GradientPickerArgs } from './GradientPicker/index';
+import GridView, { GridViewArgs } from './GridView/index';
+import GridViewItem, { GridViewItemArgs } from './GridViewItem/index';
+import InfoBox, { InfoBoxArgs } from './InfoBox/index';
+import Label, { LabelArgs } from './Label/index';
+import LabelGroup, { LabelGroupArgs } from './LabelGroup/index';
+import Menu, { MenuArgs } from './Menu/index';
+import MenuItem, { MenuItemArgs } from './MenuItem/index';
+import NumericInput, { NumericInputArgs } from './NumericInput/index';
+import Overlay, { OverlayArgs } from './Overlay/index';
+import Panel, { PanelArgs } from './Panel/index';
+import Progress, { ProgressArgs } from './Progress/index';
+import RadioButton, { RadioButtonArgs } from './RadioButton/index';
+import SelectInput, { SelectInputArgs } from './SelectInput/index';
+import SliderInput, { SliderInputArgs } from './SliderInput/index';
+import Spinner, { SpinnerArgs } from './Spinner/index';
+import TextAreaInput, { TextAreaInputArgs } from './TextAreaInput/index';
+import TextInput, { TextInputArgs } from './TextInput/index';
+import TreeView, { TreeViewArgs } from './TreeView/index';
+import TreeViewItem, { TreeViewItemArgs } from './TreeViewItem/index';
+import Input, { InputArgs } from './Input/index';
+import VectorInput, { VectorInputArgs } from './VectorInput/index';
 
 export {
     ArrayInput,
+    ArrayInputArgs,
     BooleanInput,
+    BooleanInputArgs,
     Button,
+    ButtonArgs,
     Canvas,
+    CanvasArgs,
     Code,
+    CodeArgs,
     ColorPicker,
+    ColorPickerArgs,
     Container,
+    ContainerArgs,
     ContextMenu,
+    ContextMenuArgs,
     Divider,
+    DividerArgs,
     Element,
+    ElementArgs,
     GradientPicker,
+    GradientPickerArgs,
     GridView,
+    GridViewArgs,
     GridViewItem,
+    GridViewItemArgs,
     InfoBox,
+    InfoBoxArgs,
     Label,
+    LabelArgs,
     LabelGroup,
+    LabelGroupArgs,
     Menu,
+    MenuArgs,
     MenuItem,
+    MenuItemArgs,
     NumericInput,
+    NumericInputArgs,
     Overlay,
+    OverlayArgs,
     Panel,
+    PanelArgs,
     Progress,
+    ProgressArgs,
     RadioButton,
+    RadioButtonArgs,
     SelectInput,
+    SelectInputArgs,
     SliderInput,
+    SliderInputArgs,
     Spinner,
+    SpinnerArgs,
     TextAreaInput,
+    TextAreaInputArgs,
     TextInput,
+    TextInputArgs,
     TreeView,
+    TreeViewArgs,
     TreeViewItem,
+    TreeViewItemArgs,
     VectorInput,
-    Input
+    VectorInputArgs,
+    Input,
+    InputArgs,
+    IBindable,
+    IBindableArgs,
+    IPlaceholder,
+    IPlaceholderArgs,
+    IFocusable,
+    IParentArgs,
+    IFlexArgs
 };


### PR DESCRIPTION
Currently all interfaces are combined with a class using a namespace. This pattern could be seen as unintuitive to new users of PCUI. This PR exports / imports interfaces explicitly instead.