### PR TITLE
Migrate key event handlers to use `key` instead of `keyCode`

### DIFF
--- a/src/components/BooleanInput/index.ts
+++ b/src/components/BooleanInput/index.ts
@@ -73,14 +73,14 @@ class BooleanInput extends Input implements IBindable, IFocusable {
     }
 
     protected _onKeyDown(evt: KeyboardEvent) {
-        if (evt.keyCode === 27) {
+        if (evt.key === 'Escape') {
             this.blur();
             return;
         }
 
         if (!this.enabled || this.readOnly) return;
 
-        if (evt.keyCode === 32) {
+        if (evt.key === ' ') {
             evt.stopPropagation();
             evt.preventDefault();
             this.value = !this.value;

--- a/src/components/Button/index.ts
+++ b/src/components/Button/index.ts
@@ -63,9 +63,9 @@ class Button extends Element {
     // click on enter
     // blur on escape
     protected _onKeyDown(evt: KeyboardEvent) {
-        if (evt.keyCode === 27) {
+        if (evt.key === 'Escape') {
             this.blur();
-        } else if (evt.keyCode === 13) {
+        } else if (evt.key === 'Enter') {
             this._onClick(evt);
         }
     }

--- a/src/components/ColorPicker/index.ts
+++ b/src/components/ColorPicker/index.ts
@@ -397,7 +397,7 @@ class ColorPicker extends Element {
         this._overlay.position(x, y);
     }
 
-    protected _setPickerColor(color: number[]) {
+    protected _setPickerColor(color: any) {
         if (this._changing || this._dragging)
             return;
 

--- a/src/components/ColorPicker/index.ts
+++ b/src/components/ColorPicker/index.ts
@@ -361,12 +361,12 @@ class ColorPicker extends Element {
 
     protected _onKeyDown(evt: KeyboardEvent) {
         // escape blurs the field
-        if (evt.keyCode === 27) {
+        if (evt.key === 'Escape') {
             this.blur();
         }
 
         // enter opens the color picker
-        if (evt.keyCode !== 13 || !this.enabled || this.readOnly) {
+        if (evt.key !== 'Enter' || !this.enabled || this.readOnly) {
             return;
         }
 
@@ -397,7 +397,7 @@ class ColorPicker extends Element {
         this._overlay.position(x, y);
     }
 
-    protected _setPickerColor(color: any) {
+    protected _setPickerColor(color: number[]) {
         if (this._changing || this._dragging)
             return;
 

--- a/src/components/GradientPicker/index.ts
+++ b/src/components/GradientPicker/index.ts
@@ -499,12 +499,12 @@ class GradientPicker extends Element {
 
     protected _onKeyDown(evt: KeyboardEvent) {
         // escape blurs the field
-        if (evt.keyCode === 27) {
+        if (evt.key === 'Escape') {
             this.blur();
         }
 
         // enter opens the gradient picker
-        if (evt.keyCode !== 13 || !this.enabled || this.readOnly || this.class.contains(CLASS_MULTIPLE_VALUES)) {
+        if (evt.key !== 'Enter' || !this.enabled || this.readOnly || this.class.contains(CLASS_MULTIPLE_VALUES)) {
             return;
         }
 

--- a/src/components/Menu/index.ts
+++ b/src/components/Menu/index.ts
@@ -124,8 +124,7 @@ class Menu extends Container implements IFocusable {
     protected _onKeyDown(evt: KeyboardEvent) {
         if (this.hidden) return;
 
-        // hide on esc
-        if (evt.keyCode === 27) {
+        if (evt.key === 'Escape') {
             this.hidden = true;
         }
     }

--- a/src/components/NumericInput/index.ts
+++ b/src/components/NumericInput/index.ts
@@ -201,8 +201,8 @@ class NumericInput extends TextInput {
         if (!this.enabled || this.readOnly) return super._onInputKeyDown(evt);
 
         // increase / decrease value with arrow keys
-        if (evt.keyCode === 38 || evt.keyCode === 40) {
-            const inc = evt.keyCode === 40 ? -1 : 1;
+        if (evt.key === 'ArrowUp' || evt.key === 'ArrowDown') {
+            const inc = evt.key === 'ArrowDown' ? -1 : 1;
             this.value += (evt.shiftKey ? this._stepPrecision : this._step) * inc;
             return;
         }

--- a/src/components/RadioButton/index.ts
+++ b/src/components/RadioButton/index.ts
@@ -68,14 +68,14 @@ class RadioButton extends Element implements IBindable, IFocusable {
     }
 
     protected _onKeyDown(evt: KeyboardEvent) {
-        if (evt.keyCode === 27) {
+        if (evt.key === 'Escape') {
             this.blur();
             return;
         }
 
         if (!this.enabled || this.readOnly) return;
 
-        if (evt.keyCode === 32) {
+        if (evt.key === ' ') {
             evt.stopPropagation();
             evt.preventDefault();
             this.value = !this.value;

--- a/src/components/SelectInput/index.ts
+++ b/src/components/SelectInput/index.ts
@@ -656,7 +656,7 @@ class SelectInput extends Element implements IBindable, IFocusable {
     }
 
     protected _onInputKeyDown(evt: KeyboardEvent) {
-        if (evt.keyCode === 13 && this.enabled && !this.readOnly) {
+        if (evt.key === 'Enter' && this.enabled && !this.readOnly) {
             evt.stopPropagation();
             evt.preventDefault();
 
@@ -697,20 +697,19 @@ class SelectInput extends Element implements IBindable, IFocusable {
 
     protected _onKeyDown(evt: KeyboardEvent) {
         // close options on ESC and blur
-        if (evt.keyCode === 27) {
+        if (evt.key === 'Escape') {
             this.close();
             return;
         }
 
-        // handle tab
-        if (evt.keyCode === 9) {
+        if (evt.key === 'Tab') {
             this.close();
             return;
         }
 
         if (!this.enabled || this.readOnly) return;
 
-        if (evt.keyCode === 13 && !this._allowInput) {
+        if (evt.key === 'Enter' && !this._allowInput) {
             if (this._labelHighlighted && this._labelHighlighted._optionValue !== undefined) {
                 this._onSelectValue(this._labelHighlighted._optionValue);
                 this.close();
@@ -719,9 +718,7 @@ class SelectInput extends Element implements IBindable, IFocusable {
             return;
         }
 
-        if ([38, 40].indexOf(evt.keyCode) === -1) {
-            return;
-        }
+        if (evt.key !== 'ArrowUp' && evt.key !== 'ArrowDown') return;
 
         evt.stopPropagation();
         evt.preventDefault();
@@ -742,9 +739,9 @@ class SelectInput extends Element implements IBindable, IFocusable {
                 }
             }
 
-            if (evt.keyCode === 38) {
+            if (evt.key === 'ArrowUp') {
                 index--;
-            } else if (evt.keyCode === 40) {
+            } else if (evt.key === 'ArrowDown') {
                 index++;
             }
 
@@ -760,9 +757,9 @@ class SelectInput extends Element implements IBindable, IFocusable {
             } else {
                 let highlightedLabelDom = this._labelHighlighted.dom;
                 do {
-                    if (evt.keyCode === 38) {
+                    if (evt.key === 'ArrowUp') {
                         highlightedLabelDom = highlightedLabelDom.previousSibling;
-                    } else if (evt.keyCode === 40) {
+                    } else if (evt.key === 'ArrowDown') {
                         highlightedLabelDom = highlightedLabelDom.nextSibling;
                     }
                 } while (highlightedLabelDom && highlightedLabelDom.ui.hidden);

--- a/src/components/SelectInput/index.ts
+++ b/src/components/SelectInput/index.ts
@@ -718,7 +718,9 @@ class SelectInput extends Element implements IBindable, IFocusable {
             return;
         }
 
-        if (evt.key !== 'ArrowUp' && evt.key !== 'ArrowDown') return;
+        if (evt.key !== 'ArrowUp' && evt.key !== 'ArrowDown') {
+            return;
+        }
 
         evt.stopPropagation();
         evt.preventDefault();

--- a/src/components/SliderInput/index.ts
+++ b/src/components/SliderInput/index.ts
@@ -267,7 +267,7 @@ class SliderInput extends Element implements IBindable, IFocusable {
     }
 
     protected _onKeyDown(evt: KeyboardEvent) {
-        if (evt.keyCode === 27) {
+        if (evt.key === 'Escape') {
             this.blur();
             return;
         }
@@ -275,11 +275,11 @@ class SliderInput extends Element implements IBindable, IFocusable {
         if (!this.enabled || this.readOnly) return;
 
         // move slider with left / right arrow keys
-        if (evt.keyCode !== 37 && evt.keyCode !== 39) return;
+        if (evt.key !== 'ArrowLeft' && evt.key !== 'ArrowRight') return;
 
         evt.stopPropagation();
         evt.preventDefault();
-        let x = evt.keyCode === 37 ? -1 : 1;
+        let x = evt.key === 'ArrowLeft' ? -1 : 1;
         if (evt.shiftKey) {
             x *= 10;
         }

--- a/src/components/TextAreaInput/index.ts
+++ b/src/components/TextAreaInput/index.ts
@@ -50,7 +50,7 @@ class TextAreaInput extends TextInput {
     }
 
     protected _onInputKeyDown(evt: KeyboardEvent) {
-        if ((evt.keyCode === 27 && this.blurOnEscape) || (evt.keyCode === 13 && this.blurOnEnter && !evt.shiftKey)) {
+        if ((evt.key === 'Escape' && this.blurOnEscape) || (evt.key === 'Enter' && this.blurOnEnter && !evt.shiftKey)) {
             this._domInput.blur();
         }
 

--- a/src/components/TextInput/index.ts
+++ b/src/components/TextInput/index.ts
@@ -158,7 +158,7 @@ class TextInput extends Input implements IFocusable, IPlaceholder {
     }
 
     protected _onInputKeyDown(evt: KeyboardEvent) {
-        if (evt.keyCode === 13 && this.blurOnEnter) {
+        if (evt.key === 'Enter' && this.blurOnEnter) {
             // do not fire input change event on blur
             // if keyChange is true (because a change event)
             // will have already been fired before for the current
@@ -166,7 +166,7 @@ class TextInput extends Input implements IFocusable, IPlaceholder {
             this._suspendInputChangeEvt = this.keyChange;
             this._domInput.blur();
             this._suspendInputChangeEvt = false;
-        } else if (evt.keyCode === 27) {
+        } else if (evt.key === 'Escape') {
             this._suspendInputChangeEvt = true;
             const prev = this._domInput.value;
             this._domInput.value = this._prevValue;
@@ -186,7 +186,7 @@ class TextInput extends Input implements IFocusable, IPlaceholder {
     }
 
     protected _onInputKeyUp(evt: KeyboardEvent) {
-        if (evt.keyCode !== 27) {
+        if (evt.key !== 'Escape') {
             this._onInputChange(evt);
         }
 

--- a/src/components/TreeView/index.ts
+++ b/src/components/TreeView/index.ts
@@ -401,7 +401,7 @@ class TreeView extends Container {
 
     // Called when a key is down on a child TreeViewItem.
     protected _onChildKeyDown(evt: KeyboardEvent, element: any) {
-        if (!['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Tab'].includes(evt.key)) return;
+        if (['Tab', 'ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].indexOf(evt.key) !== -1) return;
 
         evt.preventDefault();
         evt.stopPropagation();

--- a/src/components/TreeView/index.ts
+++ b/src/components/TreeView/index.ts
@@ -401,10 +401,8 @@ class TreeView extends Container {
 
     // Called when a key is down on a child TreeViewItem.
     protected _onChildKeyDown(evt: KeyboardEvent, element: any) {
-        if (evt.key !== 'ArrowDown' && evt.key !== 'ArrowUp' && evt.key !== 'ArrowLeft' && evt.key !== 'ArrowRight' && evt.key !== 'Tab') {
-            return;
-        }
-        
+        if (!['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Tab'].includes(evt.key)) return;
+
         evt.preventDefault();
         evt.stopPropagation();
 

--- a/src/components/TreeView/index.ts
+++ b/src/components/TreeView/index.ts
@@ -401,12 +401,14 @@ class TreeView extends Container {
 
     // Called when a key is down on a child TreeViewItem.
     protected _onChildKeyDown(evt: KeyboardEvent, element: any) {
-        if ([9, 37, 38, 39, 40].indexOf(evt.keyCode) === -1) return;
-
+        if (evt.key !== 'ArrowDown' && evt.key !== 'ArrowUp' && evt.key !== 'ArrowLeft' && evt.key !== 'ArrowRight' && evt.key !== 'Tab') {
+            return;
+        }
+        
         evt.preventDefault();
         evt.stopPropagation();
 
-        if (evt.keyCode === 40) {
+        if (evt.key === 'ArrowDown') {
             // down - select next tree item
             if (this._selectedItems.length) {
                 const next = this._findNextVisibleTreeItem(element);
@@ -418,7 +420,7 @@ class TreeView extends Container {
                     }
                 }
             }
-        } else if (evt.keyCode === 38) {
+        } else if (evt.key === 'ArrowUp') {
             // up - select previous tree item
             if (this._selectedItems.length) {
                 const prev = this._findPreviousVisibleTreeItem(element);
@@ -431,15 +433,15 @@ class TreeView extends Container {
                 }
             }
 
-        } else if (evt.keyCode === 37) {
+        } else if (evt.key === 'ArrowLeft') {
             // left (close)
             if (element.parent !== this) {
                 element.open = false;
             }
-        } else if (evt.keyCode === 39) {
+        } else if (evt.key === 'ArrowRight') {
             // right (open)
             element.open = true;
-        } else if (evt.keyCode === 9) {
+        } else if (evt.key === 'Tab') {
             // tab
             // skip
         }

--- a/src/components/TreeView/index.ts
+++ b/src/components/TreeView/index.ts
@@ -401,7 +401,7 @@ class TreeView extends Container {
 
     // Called when a key is down on a child TreeViewItem.
     protected _onChildKeyDown(evt: KeyboardEvent, element: any) {
-        if (['Tab', 'ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].indexOf(evt.key) !== -1) return;
+        if (['Tab', 'ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].indexOf(evt.key) === -1) return;
 
         evt.preventDefault();
         evt.stopPropagation();


### PR DESCRIPTION
[`KeyboardEvent.keyCode`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode) is deprecated.

![image](https://user-images.githubusercontent.com/697563/208982508-4b04dbc7-fc87-4f91-a608-0604f4d69329.png)

Instead, it is recommended to use [`KeyboardEvent.key`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key) instead. This PR migrates all occurrences of `keyCode` with `key`. It is better  since `key` values are human readable.

Note that `KeyboardEvent.key` now has 98.32% browser support: https://caniuse.com/keyboardevent-key