### PR TITLE
Remove `Canvas#dom`

### DIFF
--- a/src/components/Canvas/index.ts
+++ b/src/components/Canvas/index.ts
@@ -48,7 +48,9 @@ class Canvas extends Element {
         this._ratio = (args.useDevicePixelRatio !== undefined && args.useDevicePixelRatio) ? window.devicePixelRatio : 1;
 
         // Disable I-bar cursor on click+drag
-        canvas.onselectstart = (event: Event) => { return false };
+        canvas.onselectstart = (event: Event) => {
+            return false;
+        };
     }
 
     /**

--- a/src/components/Canvas/index.ts
+++ b/src/components/Canvas/index.ts
@@ -128,10 +128,6 @@ class Canvas extends Element {
     get pixelRatio(): number {
         return this._ratio;
     }
-
-    get dom(): HTMLCanvasElement {
-        return this._dom;
-    }
 }
 
 Element.register('canvas', Canvas);

--- a/src/components/Canvas/index.ts
+++ b/src/components/Canvas/index.ts
@@ -34,31 +34,28 @@ class Canvas extends Element {
         args = { ...Canvas.defaultArgs, ...args };
         super(args.dom, args);
 
-        this.dom.classList.add('pcui-canvas');
+        const canvas = this._dom as HTMLCanvasElement;
+        canvas.classList.add('pcui-canvas');
 
         if (args.id !== undefined)
-            this.dom.id = args.id;
+            canvas.id = args.id;
 
         if (args.tabindex !== undefined)
-            this.dom.setAttribute('tabindex', args.tabindex);
+            canvas.setAttribute('tabindex', args.tabindex);
 
         this._width = 300;
         this._height = 150;
         this._ratio = (args.useDevicePixelRatio !== undefined && args.useDevicePixelRatio) ? window.devicePixelRatio : 1;
 
         // Disable I-bar cursor on click+drag
-        this.dom.onselectstart = this.onselectstart;
-    }
-
-    private onselectstart() {
-        return false;
+        canvas.onselectstart = (event: Event) => { return false };
     }
 
     /**
      * Resize the canvas using the given width and height parameters.
      *
-     * @param width
-     * @param height
+     * @param width - The new width of the canvas.
+     * @param height - The new height of the canvas.
      */
     resize(width: number, height: number) {
         if (this._width === width && this._height === height)
@@ -66,10 +63,13 @@ class Canvas extends Element {
 
         this._width = width;
         this._height = height;
-        this.dom.width = this.pixelWidth;
-        this.dom.height = this.pixelHeight;
-        this.dom.style.width = width + 'px';
-        this.dom.style.height = height + 'px';
+
+        const canvas = this._dom as HTMLCanvasElement;
+        canvas.width = this.pixelWidth;
+        canvas.height = this.pixelHeight;
+        canvas.style.width = width + 'px';
+        canvas.style.height = height + 'px';
+
         this.emit('resize', width, height);
     }
 
@@ -81,8 +81,11 @@ class Canvas extends Element {
             return;
 
         this._width = value;
-        this.dom.width = this.pixelWidth;
-        this.dom.style.width = value + 'px';
+
+        const canvas = this._dom as HTMLCanvasElement;
+        canvas.width = this.pixelWidth;
+        canvas.style.width = value + 'px';
+
         this.emit('resize', this._width, this._height);
     }
 
@@ -99,8 +102,11 @@ class Canvas extends Element {
             return;
 
         this._height = value;
-        this.dom.height = this.pixelHeight;
-        this.dom.style.height = value + 'px';
+
+        const canvas = this._dom as HTMLCanvasElement;
+        canvas.height = this.pixelHeight;
+        canvas.style.height = value + 'px';
+
         this.emit('resize', this._width, this._height);
     }
 

--- a/src/components/GradientPicker/index.ts
+++ b/src/components/GradientPicker/index.ts
@@ -133,7 +133,8 @@ class GradientPicker extends Element {
         this.dom.appendChild(this._canvas.dom);
         this._canvas.parent = this;
         this._canvas.on('resize', this._renderGradient.bind(this));
-        this._checkerboardPattern = this.createCheckerboardPattern(this._canvas.dom.getContext('2d'));
+        const canvasElement = this._canvas.dom as HTMLCanvasElement;
+        this._checkerboardPattern = this.createCheckerboardPattern(canvasElement.getContext('2d'));
 
         // make sure canvas is the same size as the container element
         // 20 times a second
@@ -569,7 +570,7 @@ class GradientPicker extends Element {
     }
 
     protected _renderGradient() {
-        const canvas = this._canvas.dom;
+        const canvas = this._canvas.dom as HTMLCanvasElement;
         const context = canvas.getContext('2d');
 
         const width = this._canvas.width;


### PR DESCRIPTION
The `Canvas` class needlessly redefines the `dom` accessor. It's already defined in the base `Element` class. This PR removes it.