### PR TITLE
Improve Element typing

### DIFF
--- a/src/components/Element/index.ts
+++ b/src/components/Element/index.ts
@@ -191,7 +191,7 @@ export interface ElementArgs {
 
 // Declare an additional property on the HTMLElement interface that references the owner Element
 declare global {
-    interface HTMLElement {
+    interface Node {
         ui: Element;
     }
 }

--- a/src/components/Element/index.ts
+++ b/src/components/Element/index.ts
@@ -189,6 +189,13 @@ export interface ElementArgs {
     readOnly?: boolean
 }
 
+// Declare an additional property on the HTMLElement interface that references the owner Element
+declare global {
+    interface HTMLElement {
+        ui: Element;
+    }
+}
+
 /**
  * The base class for all UI elements.
  */
@@ -302,13 +309,13 @@ class Element extends Events {
 
     protected _eventsParent: any[];
 
-    protected _dom: any;
+    protected _dom: HTMLElement;
 
     protected _class: any[];
 
     protected _hiddenParents: boolean;
 
-    protected _flashTimeout: any;
+    protected _flashTimeout: number;
 
     protected _suppressChange: boolean;
 
@@ -339,12 +346,16 @@ class Element extends Events {
         this._eventsParent = [];
 
         if (typeof dom === 'string') {
-            dom = document.createElement(dom);
+            this._dom = document.createElement(dom);
+        } else if (dom instanceof HTMLElement) {
+            this._dom = dom;
         } else if (typeof args.dom === 'string') {
-            args.dom = document.createElement(args.dom);
+            this._dom = document.createElement(args.dom);
+        } else if (args.dom instanceof HTMLElement) {
+            this._dom = args.dom;
+        } else {
+            this._dom = document.createElement('div');
         }
-
-        this._dom = dom || args.dom || document.createElement('div');
 
         if (args.id !== undefined) {
             this._dom.id = args.id;
@@ -442,7 +453,7 @@ class Element extends Events {
         if (this._flashTimeout) return;
 
         this.classAdd(pcuiClass.FLASH);
-        this._flashTimeout = setTimeout(() => {
+        this._flashTimeout = window.setTimeout(() => {
             this._flashTimeout = null;
             this.classRemove(pcuiClass.FLASH);
         }, 200);
@@ -627,7 +638,7 @@ class Element extends Events {
         this._domEventMouseOut = null;
 
         if (this._flashTimeout) {
-            clearTimeout(this._flashTimeout);
+            window.clearTimeout(this._flashTimeout);
         }
 
         this.emit('destroy', dom, this);

--- a/src/components/Element/index.ts
+++ b/src/components/Element/index.ts
@@ -191,7 +191,7 @@ export interface ElementArgs {
 
 // Declare an additional property on the HTMLElement interface that references the owner Element
 declare global {
-    interface Node {
+    interface Node { // eslint-disable-line no-unused-vars
         ui: Element;
     }
 }

--- a/src/components/Element/index.ts
+++ b/src/components/Element/index.ts
@@ -189,7 +189,7 @@ export interface ElementArgs {
     readOnly?: boolean
 }
 
-// Declare an additional property on the HTMLElement interface that references the owner Element
+// Declare an additional property on the base Node interface that references the owner Element
 declare global {
     interface Node { // eslint-disable-line no-unused-vars
         ui: Element;

--- a/src/components/GridView/index.ts
+++ b/src/components/GridView/index.ts
@@ -227,7 +227,6 @@ class GridView extends Container {
                     return;
                 }
 
-                // @ts-ignore
                 const child = children[i].ui;
                 if (child instanceof GridViewItem) {
                     if (this._filterFn && !this._filterFn(child)) {

--- a/src/components/GridViewItem/index.ts
+++ b/src/components/GridViewItem/index.ts
@@ -199,9 +199,7 @@ class GridViewItem extends Container implements IFocusable {
     get nextSibling() {
         let sibling = this.dom.nextSibling;
         while (sibling) {
-            // @ts-ignore
             if (sibling.ui instanceof GridViewItem && !sibling.ui.hidden) {
-                // @ts-ignore
                 return sibling.ui;
             }
 
@@ -217,9 +215,7 @@ class GridViewItem extends Container implements IFocusable {
     get previousSibling() {
         let sibling = this.dom.previousSibling;
         while (sibling) {
-            // @ts-ignore
             if (sibling.ui instanceof GridViewItem && !sibling.ui.hidden) {
-                // @ts-ignore
                 return sibling.ui;
             }
 

--- a/src/components/Menu/index.stories.tsx
+++ b/src/components/Menu/index.stories.tsx
@@ -17,7 +17,6 @@ window.addEventListener('contextmenu', (evt: MouseEvent) => {
     if (evt.target.ui instanceof LabelElement) {
         const element = document.querySelector('.pcui-menu');
         if (element) {
-            // @ts-ignore
             const menu = element.ui as Menu;
             evt.stopPropagation();
             evt.preventDefault();

--- a/src/components/Menu/index.ts
+++ b/src/components/Menu/index.ts
@@ -99,7 +99,6 @@ class Menu extends Container implements IFocusable {
 
         // filter child menu items
         this._containerMenuItems.dom.childNodes.forEach((child) => {
-            // @ts-ignore
             this._filterMenuItems(child.ui);
         });
     }
@@ -116,8 +115,7 @@ class Menu extends Container implements IFocusable {
 
         // @ts-ignore
         item._containerItems.dom.childNodes.forEach((child) => {
-            // @ts-ignore
-            this._filterMenuItems(child.ui);
+            this._filterMenuItems(child.ui as MenuItem);
         });
     }
 
@@ -150,8 +148,7 @@ class Menu extends Container implements IFocusable {
         }
 
         containerItems.dom.childNodes.forEach((child) => {
-            // @ts-ignore
-            this._limitSubmenuAtScreenEdges(child.ui);
+            this._limitSubmenuAtScreenEdges(child.ui as MenuItem);
         });
     }
 
@@ -191,8 +188,7 @@ class Menu extends Container implements IFocusable {
         this._containerMenuItems.style.top = top + 'px';
 
         this._containerMenuItems.dom.childNodes.forEach((child) => {
-            // @ts-ignore
-            this._limitSubmenuAtScreenEdges(child.ui);
+            this._limitSubmenuAtScreenEdges(child.ui as MenuItem);
         });
     }
 

--- a/src/components/Menu/index.ts
+++ b/src/components/Menu/index.ts
@@ -99,7 +99,7 @@ class Menu extends Container implements IFocusable {
 
         // filter child menu items
         this._containerMenuItems.dom.childNodes.forEach((child) => {
-            this._filterMenuItems(child.ui);
+            this._filterMenuItems(child.ui as MenuItem);
         });
     }
 

--- a/src/components/MenuItem/index.ts
+++ b/src/components/MenuItem/index.ts
@@ -260,9 +260,7 @@ class MenuItem extends Container implements IBindable {
         // set menu on child menu items
         if (!this._containerItems.destroyed) {
             this._containerItems.dom.childNodes.forEach((child) => {
-                // @ts-ignore
                 if (child.ui instanceof MenuItem) {
-                    // @ts-ignore
                     child.ui.menu = value;
                 }
             });

--- a/src/components/Overlay/index.ts
+++ b/src/components/Overlay/index.ts
@@ -37,7 +37,6 @@ class Overlay extends Container {
         this.class.add(CLASS_OVERLAY);
 
         this._domClickableOverlay = document.createElement('div');
-        // @ts-ignore
         this._domClickableOverlay.ui = this;
         // @ts-ignore
         this._domClickableOverlay.classList = CLASS_OVERLAY_INNER;
@@ -47,7 +46,6 @@ class Overlay extends Container {
         this._domClickableOverlay.addEventListener('mousedown', this._domEventMouseDown);
 
         this.domContent = document.createElement('div');
-        // @ts-ignore
         this.domContent.ui = this;
         this.domContent.classList.add(CLASS_OVERLAY_CONTENT);
         this.dom.appendChild(this.domContent);

--- a/src/components/SelectInput/index.ts
+++ b/src/components/SelectInput/index.ts
@@ -648,7 +648,6 @@ class SelectInput extends Element implements IBindable, IFocusable {
         }
 
         if (containerDom.firstChild) {
-            // @ts-ignore
             this._highlightLabel(containerDom.firstChild.ui);
         }
 
@@ -754,7 +753,6 @@ class SelectInput extends Element implements IBindable, IFocusable {
             if (!this._containerOptions.dom.childNodes.length) return;
 
             if (!this._labelHighlighted) {
-                // @ts-ignore
                 this._highlightLabel(this._containerOptions.dom.childNodes[0].ui);
             } else {
                 let highlightedLabelDom = this._labelHighlighted.dom;
@@ -878,7 +876,6 @@ class SelectInput extends Element implements IBindable, IFocusable {
             }
         });
         if (!this._labelHighlighted) {
-            // @ts-ignore
             this._highlightLabel(this._containerOptions.dom.childNodes[0].ui);
         }
 

--- a/src/components/SliderInput/index.ts
+++ b/src/components/SliderInput/index.ts
@@ -163,12 +163,10 @@ class SliderInput extends Element implements IBindable, IFocusable {
 
         this._domBar = document.createElement('div');
         this._domBar.classList.add(CLASS_SLIDER_BAR);
-        // @ts-ignore
         this._domBar.ui = this;
         this._domSlider.appendChild(this._domBar);
 
         this._domHandle = document.createElement('div');
-        // @ts-ignore
         this._domHandle.ui = this;
         this._domHandle.tabIndex = 0;
         this._domHandle.classList.add(CLASS_SLIDER_HANDLE);

--- a/src/components/TreeView/index.ts
+++ b/src/components/TreeView/index.ts
@@ -305,7 +305,6 @@ class TreeView extends Container {
             let endIndex = -1;
 
             for (let i = 0; i < filterResults.length; i++) {
-                // @ts-ignore ui
                 const item = filterResults[i].ui;
 
                 if (item === startChild) {
@@ -318,8 +317,7 @@ class TreeView extends Container {
                     const start = (startIndex < endIndex ? startIndex : endIndex);
                     const end = (startIndex < endIndex ? endIndex : startIndex);
                     for (let j = start; j <= end; j++) {
-                        // @ts-ignore ui
-                        result.push(filterResults[j].ui);
+                        result.push(filterResults[j].ui as TreeViewItem);
                     }
 
                     break;

--- a/src/components/TreeViewItem/index.ts
+++ b/src/components/TreeViewItem/index.ts
@@ -301,7 +301,7 @@ class TreeViewItem extends Container {
             this.open = !this.open;
             if (evt.altKey) {
                 // apply to all children as well
-                this._dfs((node: any) => {
+                this._dfs((node: TreeViewItem) => {
                     node.open = this.open;
                 });
             }
@@ -313,10 +313,10 @@ class TreeViewItem extends Container {
 
     protected _dfs(fn: any) {
         fn(this);
-        let child = this.firstChild;
+        let child = this.firstChild as TreeViewItem;
         while (child) {
             child._dfs(fn);
-            child = child.nextSibling;
+            child = child.nextSibling as TreeViewItem;
         }
     }
 
@@ -580,10 +580,8 @@ class TreeViewItem extends Container {
     get firstChild() {
         if (this._numChildren) {
             for (let i = 0; i < this.dom.childNodes.length; i++) {
-                // @ts-ignore
                 if (this.dom.childNodes[i].ui instanceof TreeViewItem) {
-                    // @ts-ignore
-                    return this.dom.childNodes[i].ui;
+                    return this.dom.childNodes[i].ui as TreeViewItem;
                 }
             }
         }
@@ -597,10 +595,8 @@ class TreeViewItem extends Container {
     get lastChild() {
         if (this._numChildren) {
             for (let i = this.dom.childNodes.length - 1; i >= 0; i--) {
-                // @ts-ignore
                 if (this.dom.childNodes[i].ui instanceof TreeViewItem) {
-                    // @ts-ignore
-                    return this.dom.childNodes[i].ui;
+                    return this.dom.childNodes[i].ui as TreeViewItem;
                 }
             }
         }
@@ -613,12 +609,10 @@ class TreeViewItem extends Container {
      */
     get nextSibling() {
         let sibling = this.dom.nextSibling;
-        // @ts-ignore
         while (sibling && !(sibling.ui instanceof TreeViewItem)) {
             sibling = sibling.nextSibling;
         }
 
-        // @ts-ignore
         return sibling && sibling.ui;
     }
 
@@ -627,12 +621,10 @@ class TreeViewItem extends Container {
      */
     get previousSibling() {
         let sibling = this.dom.previousSibling;
-        // @ts-ignore
         while (sibling && !(sibling.ui instanceof TreeViewItem)) {
             sibling = sibling.previousSibling;
         }
 
-        // @ts-ignore
         return sibling && sibling.ui;
     }
 

--- a/src/components/TreeViewItem/index.ts
+++ b/src/components/TreeViewItem/index.ts
@@ -313,7 +313,7 @@ class TreeViewItem extends Container {
 
     protected _dfs(fn: any) {
         fn(this);
-        let child = this.firstChild as TreeViewItem;
+        let child = this.firstChild;
         while (child) {
             child._dfs(fn);
             child = child.nextSibling as TreeViewItem;


### PR DESCRIPTION
* Define types for `_dom` and `_flashTimeout`.
* Type the `ui` property on the DOM `Node` interface.
* Remove 30 occurrences of `@ts-ignore`