### PR TITLE
Refactor DOM event handlers

### DIFF
--- a/src/binding/BindingObserversToElement/index.ts
+++ b/src/binding/BindingObserversToElement/index.ts
@@ -17,9 +17,7 @@ class BindingObserversToElement extends BindingBase {
 
     _events: any[];
 
-    _updateElementHandler: any;
-
-    _updateTimeout: any;
+    _updateTimeout: number;
 
     /**
      * Creates a new BindingObserversToElement instance.
@@ -31,27 +29,26 @@ class BindingObserversToElement extends BindingBase {
 
         this._customUpdate = args.customUpdate;
         this._events = [];
-        this._updateElementHandler = this._updateElement.bind(this);
         this._updateTimeout = null;
     }
 
     private _linkObserver(observer: Observer, path: string) {
-        this._events.push(observer.on(path + ':set', this._deferUpdateElement.bind(this)));
-        this._events.push(observer.on(path + ':unset', this._deferUpdateElement.bind(this)));
-        this._events.push(observer.on(path + ':insert', this._deferUpdateElement.bind(this)));
-        this._events.push(observer.on(path + ':remove', this._deferUpdateElement.bind(this)));
+        this._events.push(observer.on(path + ':set', this._deferUpdateElement));
+        this._events.push(observer.on(path + ':unset', this._deferUpdateElement));
+        this._events.push(observer.on(path + ':insert', this._deferUpdateElement));
+        this._events.push(observer.on(path + ':remove', this._deferUpdateElement));
     }
 
-    private _deferUpdateElement() {
+    private _deferUpdateElement = () => {
         if (this.applyingChange) return;
         this.applyingChange = true;
 
-        this._updateTimeout = setTimeout(this._updateElementHandler);
-    }
+        this._updateTimeout = window.setTimeout(this._updateElement);
+    };
 
-    private _updateElement() {
+    private _updateElement = () => {
         if (this._updateTimeout) {
-            clearTimeout(this._updateTimeout);
+            window.clearTimeout(this._updateTimeout);
             this._updateTimeout = null;
         }
 
@@ -79,7 +76,7 @@ class BindingObserversToElement extends BindingBase {
         }
 
         this.applyingChange = false;
-    }
+    };
 
     link(observers: Observer|Observer[], paths: string|string[]) {
         super.link(observers, paths);
@@ -116,7 +113,7 @@ class BindingObserversToElement extends BindingBase {
         this._events.length = 0;
 
         if (this._updateTimeout) {
-            clearTimeout(this._updateTimeout);
+            window.clearTimeout(this._updateTimeout);
             this._updateTimeout = null;
         }
 

--- a/src/binding/BindingObserversToElement/index.ts
+++ b/src/binding/BindingObserversToElement/index.ts
@@ -43,10 +43,12 @@ class BindingObserversToElement extends BindingBase {
         if (this.applyingChange) return;
         this.applyingChange = true;
 
-        this._updateTimeout = window.setTimeout(this._updateElement);
+        this._updateTimeout = window.setTimeout(() => {
+            this._updateElement();
+        });
     };
 
-    private _updateElement = () => {
+    private _updateElement() {
         if (this._updateTimeout) {
             window.clearTimeout(this._updateTimeout);
             this._updateTimeout = null;
@@ -76,7 +78,7 @@ class BindingObserversToElement extends BindingBase {
         }
 
         this.applyingChange = false;
-    };
+    }
 
     link(observers: Observer|Observer[], paths: string|string[]) {
         super.link(observers, paths);

--- a/src/components/ArrayInput/index.ts
+++ b/src/components/ArrayInput/index.ts
@@ -140,9 +140,9 @@ class ArrayInput extends Element implements IFocusable, IBindable {
             min: 0,
             readOnly: this._fixedSize
         });
-        this._inputSize.on('change', this._onSizeChange.bind(this));
-        this._inputSize.on('focus', this._onFocus.bind(this));
-        this._inputSize.on('blur', this._onBlur.bind(this));
+        this._inputSize.on('change', this._onSizeChange);
+        this._inputSize.on('focus', this._onFocus);
+        this._inputSize.on('blur', this._onBlur);
         this._suspendSizeChangeEvt = false;
         this._container.append(this._inputSize);
 
@@ -188,7 +188,15 @@ class ArrayInput extends Element implements IFocusable, IBindable {
         this.renderChanges = args.renderChanges || false;
     }
 
-    protected _onSizeChange(size: number) {
+    destroy() {
+        if (this._destroyed) return;
+
+        this._arrayElements.length = 0;
+
+        super.destroy();
+    }
+
+    protected _onSizeChange = (size: number) => {
         // if size is explicitly 0 then add empty class
         // size can also be null with multi-select so do not
         // check just !size
@@ -269,15 +277,15 @@ class ArrayInput extends Element implements IFocusable, IBindable {
         }
 
         this._updateValues(values, true);
-    }
+    };
 
-    protected _onFocus() {
+    protected _onFocus = () => {
         this.emit('focus');
-    }
+    };
 
-    protected _onBlur() {
+    protected _onBlur = () => {
         this.emit('blur');
-    }
+    };
 
     protected _createArrayElement() {
         const args = Object.assign({}, this._elementArgs);
@@ -514,12 +522,6 @@ class ArrayInput extends Element implements IFocusable, IBindable {
         this._containerArray.forEachChild((element, i) => {
             return fn(element.dom.firstChild.ui, i);
         });
-    }
-
-    destroy() {
-        if (this._destroyed) return;
-        this._arrayElements.length = 0;
-        super.destroy();
     }
 
     // override binding setter to create

--- a/src/components/ArrayInput/index.ts
+++ b/src/components/ArrayInput/index.ts
@@ -147,9 +147,15 @@ class ArrayInput extends Element implements IFocusable, IBindable {
             min: 0,
             readOnly: this._fixedSize
         });
-        this._inputSize.on('change', this._onSizeChange);
-        this._inputSize.on('focus', this._onFocus);
-        this._inputSize.on('blur', this._onBlur);
+        this._inputSize.on('change', (value: number) => {
+            this._onSizeChange(value);
+        });
+        this._inputSize.on('focus', () => {
+            this.emit('focus');
+        });
+        this._inputSize.on('blur', () => {
+            this.emit('blur');
+        });
         this._suspendSizeChangeEvt = false;
         this._container.append(this._inputSize);
 
@@ -203,7 +209,7 @@ class ArrayInput extends Element implements IFocusable, IBindable {
         super.destroy();
     }
 
-    protected _onSizeChange = (size: number) => {
+    protected _onSizeChange(size: number) {
         // if size is explicitly 0 then add empty class
         // size can also be null with multi-select so do not
         // check just !size
@@ -284,15 +290,7 @@ class ArrayInput extends Element implements IFocusable, IBindable {
         }
 
         this._updateValues(values, true);
-    };
-
-    protected _onFocus = () => {
-        this.emit('focus');
-    };
-
-    protected _onBlur = () => {
-        this.emit('blur');
-    };
+    }
 
     protected _createArrayElement() {
         const args = Object.assign({}, this._elementArgs);

--- a/src/components/ArrayInput/index.ts
+++ b/src/components/ArrayInput/index.ts
@@ -100,7 +100,7 @@ class ArrayInput extends Element implements IFocusable, IBindable {
 
     protected _suspendArrayElementEvts: boolean;
 
-    protected _arrayElementChangeTimeout: any;
+    protected _arrayElementChangeTimeout: number;
 
     protected _getDefaultFn: any;
 
@@ -412,7 +412,7 @@ class ArrayInput extends Element implements IFocusable, IBindable {
         // here when only the array element changed value and not the whole array so
         // wait a bit and fire the change event later otherwise the _updateValues function
         // will cancel this timeout and fire a change event for the whole array instead
-        this._arrayElementChangeTimeout = setTimeout(() => {
+        this._arrayElementChangeTimeout = window.setTimeout(() => {
             this._arrayElementChangeTimeout = null;
             this.emit('change', this.value);
         });
@@ -504,7 +504,7 @@ class ArrayInput extends Element implements IFocusable, IBindable {
         this._suspendArrayElementEvts = false;
 
         if (this._arrayElementChangeTimeout) {
-            clearTimeout(this._arrayElementChangeTimeout);
+            window.clearTimeout(this._arrayElementChangeTimeout);
             this._arrayElementChangeTimeout = null;
         }
 

--- a/src/components/ArrayInput/index.ts
+++ b/src/components/ArrayInput/index.ts
@@ -534,7 +534,7 @@ class ArrayInput extends Element implements IFocusable, IBindable {
     set binding(value) {
         super.binding = value;
 
-        this._arrayElements.forEach((entry: { element: { binding: any; }; }) => {
+        this._arrayElements.forEach((entry: { element: Element; }) => {
             entry.element.binding = value ? value.clone() : null;
         });
     }

--- a/src/components/ArrayInput/index.ts
+++ b/src/components/ArrayInput/index.ts
@@ -27,7 +27,7 @@ export interface ArrayInputArgs extends ElementArgs, IBindableArgs {
      * - `vec3`
      * - `vec4`
      */
-    type?: string;
+    type?: 'boolean' | 'number' | 'string' | 'vec2' | 'vec3' | 'vec4';
     /**
      * Arguments for each array Element.
      */

--- a/src/components/ArrayInput/index.ts
+++ b/src/components/ArrayInput/index.ts
@@ -18,7 +18,14 @@ const CLASS_ARRAY_DELETE = CLASS_ARRAY_ELEMENT + '-delete';
  */
 export interface ArrayInputArgs extends ElementArgs, IBindableArgs {
     /**
-     * The type of values that the array can hold.
+     * The type of values that the array can hold. Can be one of the following:
+     *
+     * - `boolean`
+     * - `number`
+     * - `string`
+     * - `vec2`
+     * - `vec3`
+     * - `vec4`
      */
     type?: string;
     /**

--- a/src/components/BooleanInput/index.ts
+++ b/src/components/BooleanInput/index.ts
@@ -63,7 +63,7 @@ class BooleanInput extends Input implements IBindable, IFocusable {
         super.destroy();
     }
 
-    protected _onClick = (evt: MouseEvent) => {
+    protected _onClick(evt: MouseEvent) {
         if (this.enabled) {
             this.focus();
         }
@@ -73,7 +73,7 @@ class BooleanInput extends Input implements IBindable, IFocusable {
         }
 
         return super._onClick(evt);
-    };
+    }
 
     protected _onKeyDown = (evt: KeyboardEvent) => {
         if (evt.key === 'Escape') {

--- a/src/components/BooleanInput/index.ts
+++ b/src/components/BooleanInput/index.ts
@@ -28,12 +28,6 @@ class BooleanInput extends Input implements IBindable, IFocusable {
         dom: 'div'
     };
 
-    protected _domEventKeyDown: any;
-
-    protected _domEventFocus: any;
-
-    protected _domEventBlur: any;
-
     protected _value: boolean;
 
     constructor(args: BooleanInputArgs = BooleanInput.defaultArgs) {
@@ -47,13 +41,9 @@ class BooleanInput extends Input implements IBindable, IFocusable {
         }
         this.class.add(pcuiClass.NOT_FLEXIBLE);
 
-        this._domEventKeyDown = this._onKeyDown.bind(this);
-        this._domEventFocus = this._onFocus.bind(this);
-        this._domEventBlur = this._onBlur.bind(this);
-
-        this.dom.addEventListener('keydown', this._domEventKeyDown);
-        this.dom.addEventListener('focus', this._domEventFocus);
-        this.dom.addEventListener('blur', this._domEventBlur);
+        this.dom.addEventListener('keydown', this._onKeyDown);
+        this.dom.addEventListener('focus', this._onFocus);
+        this.dom.addEventListener('blur', this._onBlur);
 
         this._value = null;
         if (args.value !== undefined) {
@@ -61,6 +51,16 @@ class BooleanInput extends Input implements IBindable, IFocusable {
         }
 
         this.renderChanges = args.renderChanges;
+    }
+
+    destroy() {
+        if (this._destroyed) return;
+
+        this.dom.removeEventListener('keydown', this._onKeyDown);
+        this.dom.removeEventListener('focus', this._onFocus);
+        this.dom.removeEventListener('blur', this._onBlur);
+
+        super.destroy();
     }
 
     protected _onClick(evt: MouseEvent) {
@@ -75,7 +75,7 @@ class BooleanInput extends Input implements IBindable, IFocusable {
         return super._onClick(evt);
     }
 
-    protected _onKeyDown(evt: KeyboardEvent) {
+    protected _onKeyDown = (evt: KeyboardEvent) => {
         if (evt.key === 'Escape') {
             this.blur();
             return;
@@ -88,15 +88,15 @@ class BooleanInput extends Input implements IBindable, IFocusable {
             evt.preventDefault();
             this.value = !this.value;
         }
-    }
+    };
 
-    protected _onFocus() {
+    protected _onFocus = () => {
         this.emit('focus');
-    }
+    };
 
-    protected _onBlur() {
+    protected _onBlur = () => {
         this.emit('blur');
-    }
+    };
 
     protected _updateValue(value: boolean) {
         this.class.remove(pcuiClass.MULTIPLE_VALUES);
@@ -126,16 +126,6 @@ class BooleanInput extends Input implements IBindable, IFocusable {
 
     blur() {
         this.dom.blur();
-    }
-
-    destroy() {
-        if (this._destroyed) return;
-
-        this.dom.removeEventListener('keydown', this._domEventKeyDown);
-        this.dom.removeEventListener('focus', this._domEventFocus);
-        this.dom.removeEventListener('blur', this._domEventBlur);
-
-        super.destroy();
     }
 
     set value(value: boolean) {

--- a/src/components/BooleanInput/index.ts
+++ b/src/components/BooleanInput/index.ts
@@ -63,7 +63,7 @@ class BooleanInput extends Input implements IBindable, IFocusable {
         super.destroy();
     }
 
-    protected _onClick(evt: MouseEvent) {
+    protected _onClick = (evt: MouseEvent) => {
         if (this.enabled) {
             this.focus();
         }
@@ -73,7 +73,7 @@ class BooleanInput extends Input implements IBindable, IFocusable {
         }
 
         return super._onClick(evt);
-    }
+    };
 
     protected _onKeyDown = (evt: KeyboardEvent) => {
         if (evt.key === 'Escape') {

--- a/src/components/Button/index.ts
+++ b/src/components/Button/index.ts
@@ -78,12 +78,12 @@ class Button extends Element {
         }
     };
 
-    protected _onClick(evt: Event) {
+    protected _onClick = (evt: Event) => {
         this.blur();
         if (this.readOnly) return;
 
         super._onClick(evt);
-    }
+    };
 
     focus() {
         this.dom.focus();

--- a/src/components/Button/index.ts
+++ b/src/components/Button/index.ts
@@ -78,12 +78,12 @@ class Button extends Element {
         }
     };
 
-    protected _onClick = (evt: Event) => {
+    protected _onClick(evt: Event) {
         this.blur();
         if (this.readOnly) return;
 
         super._onClick(evt);
-    };
+    }
 
     focus() {
         this.dom.focus();

--- a/src/components/Button/index.ts
+++ b/src/components/Button/index.ts
@@ -41,8 +41,6 @@ class Button extends Element {
 
     protected _unsafe: boolean;
 
-    protected _domEventKeyDown: any;
-
     protected _text: string;
 
     protected _icon: string;
@@ -61,19 +59,24 @@ class Button extends Element {
         this.size = args.size;
         this.icon = args.icon;
 
-        this._domEventKeyDown = this._onKeyDown.bind(this);
-        this.dom.addEventListener('keydown', this._onKeyDown.bind(this));
+        this.dom.addEventListener('keydown', this._onKeyDown);
     }
 
-    // click on enter
-    // blur on escape
-    protected _onKeyDown(evt: KeyboardEvent) {
+    destroy() {
+        if (this._destroyed) return;
+
+        this.dom.removeEventListener('keydown', this._onKeyDown);
+
+        super.destroy();
+    }
+
+    protected _onKeyDown = (evt: KeyboardEvent) => {
         if (evt.key === 'Escape') {
             this.blur();
         } else if (evt.key === 'Enter') {
             this._onClick(evt);
         }
-    }
+    };
 
     protected _onClick(evt: Event) {
         this.blur();
@@ -88,13 +91,6 @@ class Button extends Element {
 
     blur() {
         this.dom.blur();
-    }
-
-    destroy() {
-        if (this._destroyed) return;
-
-        this.dom.removeEventListener('keydown', this._domEventKeyDown);
-        super.destroy();
     }
 
     /**

--- a/src/components/ColorPicker/index.ts
+++ b/src/components/ColorPicker/index.ts
@@ -37,12 +37,6 @@ class ColorPicker extends Element {
 
     protected _domColor: HTMLDivElement;
 
-    protected _domEventKeyDown: any;
-
-    protected _domEventFocus: any;
-
-    protected _domEventBlur: any;
-
     protected _historyCombine: boolean;
 
     protected _historyPostfix: any;
@@ -131,10 +125,6 @@ class ColorPicker extends Element {
         this._domColor = document.createElement('div');
         this.dom.appendChild(this._domColor);
 
-        this._domEventKeyDown = this._onKeyDown.bind(this);
-        this._domEventFocus = this._onFocus.bind(this);
-        this._domEventBlur = this._onBlur.bind(this);
-
         this._pickRectMouseMove = this._pickRectMouseMove.bind(this);
         this._pickRectMouseUp = this._pickRectMouseUp.bind(this);
 
@@ -144,15 +134,14 @@ class ColorPicker extends Element {
         this._pickOpacityMouseMove = this._pickOpacityMouseMove.bind(this);
         this._pickOpacityMouseUp = this._pickOpacityMouseUp.bind(this);
 
-        this._closePicker = this._closePicker.bind(this);
-
-        this.dom.addEventListener('keydown', this._domEventKeyDown);
-        this.dom.addEventListener('focus', this._domEventFocus);
-        this.dom.addEventListener('blur', this._domEventBlur);
+        this.dom.addEventListener('keydown', this._onKeyDown);
+        this.dom.addEventListener('focus', this._onFocus);
+        this.dom.addEventListener('blur', this._onBlur);
 
         this.on('click', () => {
-            if (!this.enabled || this.readOnly) return;
-            this._openColorPicker();
+            if (this.enabled && !this.readOnly) {
+                this._openColorPicker();
+            }
         });
 
         this._historyCombine = false;
@@ -300,7 +289,9 @@ class ColorPicker extends Element {
         // @ts-ignore
         this._fieldR.flexGrow = 1;
         this._fieldR.class.add('field', 'field-r');
-        this._fieldR.on('change', this._updateRects.bind(this));
+        this._fieldR.on('change', () => {
+            this._updateRects();
+        });
         this._panelFields.appendChild(this._fieldR.dom);
 
         // G
@@ -314,7 +305,9 @@ class ColorPicker extends Element {
         this._fieldG.renderChanges = false;
         this._fieldG.placeholder = 'g';
         this._fieldG.class.add('field', 'field-g');
-        this._fieldG.on('change', this._updateRects.bind(this));
+        this._fieldG.on('change', () => {
+            this._updateRects();
+        });
         this._panelFields.appendChild(this._fieldG.dom);
 
         // B
@@ -328,7 +321,9 @@ class ColorPicker extends Element {
         this._fieldB.renderChanges = false;
         this._fieldB.placeholder = 'b';
         this._fieldB.class.add('field', 'field-b');
-        this._fieldB.on('change', this._updateRects.bind(this));
+        this._fieldB.on('change', () => {
+            this._updateRects();
+        });
         this._panelFields.appendChild(this._fieldB.dom);
 
         this._fieldA = new NumericInput({
@@ -341,7 +336,9 @@ class ColorPicker extends Element {
         this._fieldA.renderChanges = false;
         this._fieldA.placeholder = 'a';
         this._fieldA.class.add('field', 'field-a');
-        this._fieldA.on('change', this._updateRectAlpha.bind(this));
+        this._fieldA.on('change', (value: number) => {
+            this._updateRectAlpha(value);
+        });
         this._panelFields.appendChild(this._fieldA.dom);
 
 
@@ -350,8 +347,20 @@ class ColorPicker extends Element {
         this._fieldHex.renderChanges = false;
         this._fieldHex.placeholder = '#';
         this._fieldHex.class.add('field', 'field-hex');
-        this._fieldHex.on('change', this._updateHex.bind(this));
+        this._fieldHex.on('change', () => {
+            this._updateHex();
+        });
         this._panelFields.appendChild(this._fieldHex.dom);
+    }
+
+    destroy() {
+        if (this._destroyed) return;
+
+        this.dom.removeEventListener('keydown', this._onKeyDown);
+        this.dom.removeEventListener('focus', this._onFocus);
+        this.dom.removeEventListener('blur', this._onBlur);
+
+        super.destroy();
     }
 
     focus() {
@@ -362,7 +371,7 @@ class ColorPicker extends Element {
         this.dom.blur();
     }
 
-    protected _onKeyDown(evt: KeyboardEvent) {
+    protected _onKeyDown = (evt: KeyboardEvent) => {
         // escape blurs the field
         if (evt.key === 'Escape') {
             this.blur();
@@ -375,15 +384,15 @@ class ColorPicker extends Element {
 
         evt.stopPropagation();
         evt.preventDefault();
-    }
+    };
 
-    protected _onFocus(evt: FocusEvent) {
+    protected _onFocus = (evt: FocusEvent) => {
         this.emit('focus');
-    }
+    };
 
-    protected _onBlur(evt: FocusEvent) {
+    protected _onBlur = (evt: FocusEvent) => {
         this.emit('blur');
-    }
+    };
 
     protected _closePicker() {
         this._overlay.hidden = true;
@@ -497,7 +506,7 @@ class ColorPicker extends Element {
         // focus on hex field
         this._fieldHex.dom.focus();
 
-        setTimeout(() => {
+        window.setTimeout(() => {
             this._fieldHex.dom.focus();
         }, 100);
     }
@@ -717,15 +726,9 @@ class ColorPicker extends Element {
             return;
 
         this._callingCallback = true;
-        setTimeout(this.callbackHandle.bind(this), 1000 / 60);
-    }
-
-    destroy() {
-        if (this._destroyed) return;
-        this.dom.removeEventListener('keydown', this._domEventKeyDown);
-        this.dom.removeEventListener('focus', this._domEventFocus);
-        this.dom.removeEventListener('blur', this._domEventBlur);
-        super.destroy();
+        window.setTimeout(() => {
+            this.callbackHandle();
+        }, 1000 / 60);
     }
 
     set value(value) {

--- a/src/components/ColorPicker/index.ts
+++ b/src/components/ColorPicker/index.ts
@@ -272,7 +272,7 @@ class ColorPicker extends Element {
         this._evtColorPickStart = null;
         this._evtColorPickEnd = null;
 
-        this._overlay.on('hide', function () {
+        this._overlay.on('hide', () => {
             this._evtColorPick.unbind();
             this._evtColorPick = null;
 
@@ -284,7 +284,7 @@ class ColorPicker extends Element {
 
             this._evtColorPickEnd.unbind();
             this._evtColorPickEnd = null;
-        }.bind(this));
+        });
 
         // R
         this._fieldR = new NumericInput({

--- a/src/components/ColorPicker/index.ts
+++ b/src/components/ColorPicker/index.ts
@@ -400,11 +400,6 @@ class ColorPicker extends Element {
         this.focus();
     }
 
-    protected _getColorRect() {
-        // @ts-ignore rect not a property of Overlay
-        return this._overlay.rect;
-    }
-
     protected _setColorPickerPosition(x: number, y: number) {
         this._overlay.position(x, y);
     }
@@ -750,7 +745,7 @@ class ColorPicker extends Element {
         for (let i = 1; i < values.length; i++) {
             if (Array.isArray(value)) {
                 // @ts-ignore
-                if (!value.equals(values[i])) {
+                if (!value.equals(values[i])) { // TODO: check if this works
                     different = true;
                     break;
                 }

--- a/src/components/Container/index.ts
+++ b/src/components/Container/index.ts
@@ -313,8 +313,7 @@ class Container extends Element {
 
         if (this._domResizeHandle) {
             this._domResizeHandle.removeEventListener('mousedown', this._onResizeStart);
-            // @ts-ignore removeEventListener shouldn't be passed the passive option
-            this._domResizeHandle.removeEventListener('touchstart', this._onResizeTouchStart, { passive: false });
+            this._domResizeHandle.removeEventListener('touchstart', this._onResizeTouchStart);
             this._domResizeHandle = null;
         }
 

--- a/src/components/Container/index.ts
+++ b/src/components/Container/index.ts
@@ -103,7 +103,7 @@ class Container extends Element {
 
     protected _domResizeHandle: HTMLDivElement;
 
-    protected _resizeTouchId: any;
+    protected _resizeTouchId: number;
 
     protected _resizeData: any;
 
@@ -115,11 +115,11 @@ class Container extends Element {
 
     protected _draggedStartIndex: number;
 
-    protected _domContent: any;
+    protected _domContent: HTMLElement;
 
     protected _resizable: string;
 
-    protected _draggedHeight: any;
+    protected _draggedHeight: number;
 
     constructor(args: ContainerArgs = Container.defaultArgs) {
         args = { ...Container.defaultArgs, ...args };

--- a/src/components/Container/index.ts
+++ b/src/components/Container/index.ts
@@ -95,27 +95,13 @@ class Container extends Element {
      */
     public static readonly EVENT_RESIZE = 'resize';
 
-    protected _domEventScroll: any;
-
     protected _scrollable: boolean;
 
     protected _flex: boolean;
 
     protected _grid: boolean;
 
-    protected _domResizeHandle: any;
-
-    protected _domEventResizeStart: any;
-
-    protected _domEventResizeMove: any;
-
-    protected _domEventResizeEnd: any;
-
-    protected _domEventResizeTouchStart: any;
-
-    protected _domEventResizeTouchMove: any;
-
-    protected _domEventResizeTouchEnd: any;
+    protected _domResizeHandle: HTMLDivElement;
 
     protected _resizeTouchId: any;
 
@@ -141,7 +127,6 @@ class Container extends Element {
 
         this.class.add(CLASS_CONTAINER);
 
-        this._domEventScroll = this._onScroll.bind(this);
         this.domContent = this._dom;
 
         // scroll
@@ -167,12 +152,6 @@ class Container extends Element {
 
         // resize related
         this._domResizeHandle = null;
-        this._domEventResizeStart = this._onResizeStart.bind(this);
-        this._domEventResizeMove = this._onResizeMove.bind(this);
-        this._domEventResizeEnd = this._onResizeEnd.bind(this);
-        this._domEventResizeTouchStart = this._onResizeTouchStart.bind(this);
-        this._domEventResizeTouchMove = this._onResizeTouchMove.bind(this);
-        this._domEventResizeTouchEnd = this._onResizeTouchEnd.bind(this);
         this._resizeTouchId = null;
         this._resizeData = null;
         this._resizeHorizontally = true;
@@ -189,6 +168,23 @@ class Container extends Element {
         }
 
         this._draggedStartIndex = -1;
+    }
+
+    destroy() {
+        if (this._destroyed) return;
+        this.domContent = null;
+
+        if (this._domResizeHandle) {
+            this._domResizeHandle.removeEventListener('mousedown', this._onResizeStart);
+            window.removeEventListener('mousemove', this._onResizeMove);
+            window.removeEventListener('mouseup', this._onResizeEnd);
+
+            this._domResizeHandle.removeEventListener('touchstart', this._onResizeTouchStart);
+            window.removeEventListener('touchmove', this._onResizeTouchMove);
+            window.removeEventListener('touchend', this._onResizeTouchEnd);
+        }
+
+        super.destroy();
     }
 
     /**
@@ -316,8 +312,9 @@ class Container extends Element {
         }
 
         if (this._domResizeHandle) {
-            this._domResizeHandle.removeEventListener('mousedown', this._domEventResizeStart);
-            this._domResizeHandle.removeEventListener('touchstart', this._domEventResizeTouchStart, { passive: false });
+            this._domResizeHandle.removeEventListener('mousedown', this._onResizeStart);
+            // @ts-ignore removeEventListener shouldn't be passed the passive option
+            this._domResizeHandle.removeEventListener('touchstart', this._onResizeTouchStart, { passive: false });
             this._domResizeHandle = null;
         }
 
@@ -353,49 +350,49 @@ class Container extends Element {
         this.emit('remove', element);
     }
 
-    protected _onScroll(evt: Event) {
+    protected _onScroll = (evt: Event) => {
         this.emit('scroll', evt);
-    }
+    };
 
     protected _createResizeHandle() {
         const handle = document.createElement('div');
         handle.classList.add(CLASS_RESIZABLE_HANDLE);
         handle.ui = this;
 
-        handle.addEventListener('mousedown', this._domEventResizeStart);
-        handle.addEventListener('touchstart', this._domEventResizeTouchStart, { passive: false });
+        handle.addEventListener('mousedown', this._onResizeStart);
+        handle.addEventListener('touchstart', this._onResizeTouchStart, { passive: false });
 
         this._domResizeHandle = handle;
     }
 
-    protected _onResizeStart(evt: MouseEvent) {
+    protected _onResizeStart = (evt: MouseEvent) => {
         evt.preventDefault();
         evt.stopPropagation();
 
-        window.addEventListener('mousemove', this._domEventResizeMove);
-        window.addEventListener('mouseup', this._domEventResizeEnd);
+        window.addEventListener('mousemove', this._onResizeMove);
+        window.addEventListener('mouseup', this._onResizeEnd);
 
         this._resizeStart();
-    }
+    };
 
-    protected _onResizeMove(evt: MouseEvent) {
+    protected _onResizeMove = (evt: MouseEvent) => {
         evt.preventDefault();
         evt.stopPropagation();
 
         this._resizeMove(evt.clientX, evt.clientY);
-    }
+    };
 
-    protected _onResizeEnd(evt: MouseEvent) {
+    protected _onResizeEnd = (evt: MouseEvent) => {
         evt.preventDefault();
         evt.stopPropagation();
 
-        window.removeEventListener('mousemove', this._domEventResizeMove);
-        window.removeEventListener('mouseup', this._domEventResizeEnd);
+        window.removeEventListener('mousemove', this._onResizeMove);
+        window.removeEventListener('mouseup', this._onResizeEnd);
 
         this._resizeEnd();
-    }
+    };
 
-    protected _onResizeTouchStart(evt: TouchEvent) {
+    protected _onResizeTouchStart = (evt: TouchEvent) => {
         evt.preventDefault();
         evt.stopPropagation();
 
@@ -406,13 +403,13 @@ class Container extends Element {
             }
         }
 
-        window.addEventListener('touchmove', this._domEventResizeTouchMove);
-        window.addEventListener('touchend', this._domEventResizeTouchEnd);
+        window.addEventListener('touchmove', this._onResizeTouchMove);
+        window.addEventListener('touchend', this._onResizeTouchEnd);
 
         this._resizeStart();
-    }
+    };
 
-    protected _onResizeTouchMove(evt: TouchEvent) {
+    protected _onResizeTouchMove = (evt: TouchEvent) => {
         for (let i = 0; i < evt.changedTouches.length; i++) {
             const touch = evt.changedTouches[i];
             if (touch.identifier !== this._resizeTouchId) {
@@ -426,9 +423,9 @@ class Container extends Element {
 
             break;
         }
-    }
+    };
 
-    protected _onResizeTouchEnd(evt: TouchEvent) {
+    protected _onResizeTouchEnd = (evt: TouchEvent) => {
         for (let i = 0; i < evt.changedTouches.length; i++) {
             const touch = evt.changedTouches[i];
             if (touch.identifier === this._resizeTouchId) {
@@ -440,14 +437,14 @@ class Container extends Element {
             evt.preventDefault();
             evt.stopPropagation();
 
-            window.removeEventListener('touchmove', this._domEventResizeTouchMove);
-            window.removeEventListener('touchend', this._domEventResizeTouchEnd);
+            window.removeEventListener('touchmove', this._onResizeTouchMove);
+            window.removeEventListener('touchend', this._onResizeTouchEnd);
 
             this._resizeEnd();
 
             break;
         }
-    }
+    };
 
     protected _resizeStart() {
         this.class.add(CLASS_RESIZING);
@@ -681,32 +678,6 @@ class Container extends Element {
         });
     }
 
-    destroy() {
-        if (this._destroyed) return;
-        this.domContent = null;
-
-        if (this._domResizeHandle) {
-            this._domResizeHandle.removeEventListener('mousedown', this._domEventResizeStart);
-            window.removeEventListener('mousemove', this._domEventResizeMove);
-            window.removeEventListener('mouseup', this._domEventResizeEnd);
-
-            this._domResizeHandle.removeEventListener('touchstart', this._domEventResizeTouchStart);
-            window.removeEventListener('touchmove', this._domEventResizeTouchMove);
-            window.removeEventListener('touchend', this._domEventResizeTouchEnd);
-        }
-
-        this._domResizeHandle = null;
-        this._domEventResizeStart = null;
-        this._domEventResizeMove = null;
-        this._domEventResizeEnd = null;
-        this._domEventResizeTouchStart = null;
-        this._domEventResizeTouchMove = null;
-        this._domEventResizeTouchEnd = null;
-        this._domEventScroll = null;
-
-        super.destroy();
-    }
-
     /**
      * Gets / sets whether the Element supports flex layout.
      */
@@ -837,13 +808,13 @@ class Container extends Element {
         if (this._domContent === value) return;
 
         if (this._domContent) {
-            this._domContent.removeEventListener('scroll', this._domEventScroll);
+            this._domContent.removeEventListener('scroll', this._onScroll);
         }
 
         this._domContent = value;
 
         if (this._domContent) {
-            this._domContent.addEventListener('scroll', this._domEventScroll);
+            this._domContent.addEventListener('scroll', this._onScroll);
         }
     }
 

--- a/src/components/Element/index.ts
+++ b/src/components/Element/index.ts
@@ -297,12 +297,6 @@ class Element extends Events {
 
     protected _parent: Element; // eslint-disable-line no-use-before-define
 
-    protected _domEventClick: any;
-
-    protected _domEventMouseOver: any;
-
-    protected _domEventMouseOut: any;
-
     protected _eventsParent: any[];
 
     protected _dom: HTMLElement;
@@ -336,9 +330,6 @@ class Element extends Events {
         this._destroyed = false;
         this._parent = null;
 
-        this._domEventClick = this._onClick.bind(this);
-        this._domEventMouseOver = this._onMouseOver.bind(this);
-        this._domEventMouseOut = this._onMouseOut.bind(this);
         this._eventsParent = [];
 
         if (typeof dom === 'string') {
@@ -361,9 +352,9 @@ class Element extends Events {
         this._dom.ui = this;
 
         // add event listeners
-        this._dom.addEventListener('click', this._domEventClick);
-        this._dom.addEventListener('mouseover', this._domEventMouseOver);
-        this._dom.addEventListener('mouseout', this._domEventMouseOut);
+        this._dom.addEventListener('click', this._onClick);
+        this._dom.addEventListener('mouseover', this._onMouseOver);
+        this._dom.addEventListener('mouseout', this._onMouseOut);
 
         // add element class
         this._dom.classList.add(CLASS_ELEMENT);
@@ -422,6 +413,75 @@ class Element extends Events {
     }
 
     /**
+     * Destroys the Element and its events.
+     */
+    destroy() {
+        if (this._destroyed) return;
+
+        this._destroyed = true;
+
+        if (this.binding) {
+            this.binding = null;
+        } else {
+            this.unlink();
+        }
+
+        if (this.parent) {
+            const parent = this.parent;
+
+            for (let i = 0; i < this._eventsParent.length; i++) {
+                this._eventsParent[i].unbind();
+            }
+            this._eventsParent.length = 0;
+
+            // remove element from parent
+            // check if parent has been destroyed already
+            // because we do not want to be emitting events
+            // on a destroyed parent after it's been destroyed
+            // as it is easy to lead to null exceptions
+            // @ts-ignore
+            if (parent.remove && !parent._destroyed) {
+                // @ts-ignore
+                parent.remove(this);
+            }
+
+            // set parent to null and remove from
+            // parent dom just in case parent.remove above
+            // didn't work because of an override or other condition
+            this._parent = null;
+
+            // Do not manually call removeChild for elements whose parent has already been destroyed.
+            // For example when we destroy a TreeViewItem that has many child nodes, that will trigger every child Element to call dom.parentElement.removeChild(dom).
+            // But we don't need to remove all these DOM elements from their parents since the root DOM element is destroyed anyway.
+            // This has a big impact on destroy speed in certain cases.
+            if (!parent._destroyed && this._dom && this._dom.parentElement) {
+                this._dom.parentElement.removeChild(this._dom);
+            }
+        }
+
+        const dom = this._dom;
+        if (dom) {
+            // remove event listeners
+            dom.removeEventListener('click', this._onClick);
+            dom.removeEventListener('mouseover', this._onMouseOver);
+            dom.removeEventListener('mouseout', this._onMouseOut);
+
+            // remove ui reference
+            delete dom.ui;
+
+            this._dom = null;
+        }
+
+        if (this._flashTimeout) {
+            window.clearTimeout(this._flashTimeout);
+        }
+
+        this.emit('destroy', dom, this);
+
+        this.unbind();
+    }
+
+    /**
      * Links the specified observers and paths to the Element's data binding.
      *
      * @param observers - An array of observers or a single observer.
@@ -455,19 +515,19 @@ class Element extends Events {
         }, 200);
     }
 
-    protected _onClick(evt: Event) {
+    protected _onClick = (evt: Event) => {
         if (this.enabled) {
             this.emit('click', evt);
         }
-    }
+    };
 
-    protected _onMouseOver(evt: MouseEvent) {
+    protected _onMouseOver = (evt: MouseEvent) => {
         this.emit('hover', evt);
-    }
+    };
 
-    protected _onMouseOut(evt: MouseEvent) {
+    protected _onMouseOut = (evt: MouseEvent) => {
         this.emit('hoverend', evt);
-    }
+    };
 
     protected _onHiddenToRootChange(hiddenToRoot: boolean) {
         if (hiddenToRoot) {
@@ -567,79 +627,6 @@ class Element extends Events {
         if (classList.contains(cls)) {
             classList.remove(cls);
         }
-    }
-
-    /**
-     * Destroys the Element and its events.
-     */
-    destroy() {
-        if (this._destroyed) return;
-
-        this._destroyed = true;
-
-        if (this.binding) {
-            this.binding = null;
-        } else {
-            this.unlink();
-        }
-
-        if (this.parent) {
-            const parent = this.parent;
-
-            for (let i = 0; i < this._eventsParent.length; i++) {
-                this._eventsParent[i].unbind();
-            }
-            this._eventsParent.length = 0;
-
-            // remove element from parent
-            // check if parent has been destroyed already
-            // because we do not want to be emitting events
-            // on a destroyed parent after it's been destroyed
-            // as it is easy to lead to null exceptions
-            // @ts-ignore
-            if (parent.remove && !parent._destroyed) {
-                // @ts-ignore
-                parent.remove(this);
-            }
-
-            // set parent to null and remove from
-            // parent dom just in case parent.remove above
-            // didn't work because of an override or other condition
-            this._parent = null;
-
-            // Do not manually call removeChild for elements whose parent has already been destroyed.
-            // For example when we destroy a TreeViewItem that has many child nodes, that will trigger every child Element to call dom.parentElement.removeChild(dom).
-            // But we don't need to remove all these DOM elements from their parents since the root DOM element is destroyed anyway.
-            // This has a big impact on destroy speed in certain cases.
-            if (!parent._destroyed && this._dom && this._dom.parentElement) {
-                this._dom.parentElement.removeChild(this._dom);
-            }
-        }
-
-        const dom = this._dom;
-        if (dom) {
-            // remove event listeners
-            dom.removeEventListener('click', this._domEventClick);
-            dom.removeEventListener('mouseover', this._domEventMouseOver);
-            dom.removeEventListener('mouseout', this._domEventMouseOut);
-
-            // remove ui reference
-            delete dom.ui;
-
-            this._dom = null;
-        }
-
-        this._domEventClick = null;
-        this._domEventMouseOver = null;
-        this._domEventMouseOut = null;
-
-        if (this._flashTimeout) {
-            window.clearTimeout(this._flashTimeout);
-        }
-
-        this.emit('destroy', dom, this);
-
-        this.unbind();
     }
 
     unbind(name?: string, fn?: any): Events {

--- a/src/components/Element/index.ts
+++ b/src/components/Element/index.ts
@@ -321,7 +321,7 @@ class Element extends Events {
 
     protected _hasError: boolean;
 
-    protected _domContent: any;
+    protected _domContent: HTMLElement;
 
     protected _onClickEvt: () => void;
 

--- a/src/components/Element/index.ts
+++ b/src/components/Element/index.ts
@@ -323,6 +323,8 @@ class Element extends Events {
 
     protected _domContent: any;
 
+    protected _onClickEvt: () => void;
+
     constructor(dom: HTMLElement | string, args: ElementArgs = Element.defaultArgs) {
         args = { ...Element.defaultArgs, ...args };
         super();
@@ -351,8 +353,10 @@ class Element extends Events {
         // add ui reference
         this._dom.ui = this;
 
+        this._onClickEvt = this._onClick.bind(this);
+
         // add event listeners
-        this._dom.addEventListener('click', this._onClick);
+        this._dom.addEventListener('click', this._onClickEvt);
         this._dom.addEventListener('mouseover', this._onMouseOver);
         this._dom.addEventListener('mouseout', this._onMouseOut);
 
@@ -462,7 +466,7 @@ class Element extends Events {
         const dom = this._dom;
         if (dom) {
             // remove event listeners
-            dom.removeEventListener('click', this._onClick);
+            dom.removeEventListener('click', this._onClickEvt);
             dom.removeEventListener('mouseover', this._onMouseOver);
             dom.removeEventListener('mouseout', this._onMouseOut);
 
@@ -515,11 +519,11 @@ class Element extends Events {
         }, 200);
     }
 
-    protected _onClick = (evt: Event) => {
+    protected _onClick(evt: Event) {
         if (this.enabled) {
             this.emit('click', evt);
         }
-    };
+    }
 
     protected _onMouseOver = (evt: MouseEvent) => {
         this.emit('hover', evt);

--- a/src/components/GradientPicker/index.ts
+++ b/src/components/GradientPicker/index.ts
@@ -134,7 +134,7 @@ class GradientPicker extends Element {
             this._renderGradient();
         });
         const canvasElement = this._canvas.dom as HTMLCanvasElement;
-        this._checkerboardPattern = this.createCheckerboardPattern(canvasElement.getContext('2d'));
+        this._checkerboardPattern = this._createCheckerboardPattern(canvasElement.getContext('2d'));
 
         // make sure canvas is the same size as the container element
         // 20 times a second
@@ -473,7 +473,7 @@ class GradientPicker extends Element {
         super.destroy();
     }
 
-    createCheckerboardPattern(context: CanvasRenderingContext2D) {
+    protected _createCheckerboardPattern(context: CanvasRenderingContext2D) {
         // create checkerboard pattern
         const canvas = document.createElement('canvas');
         const size = 24;
@@ -853,7 +853,7 @@ class GradientPicker extends Element {
         return this.editAlpha;
     }
 
-        // open the picker
+    // open the picker
     open() {
         this.UI.overlay.hidden = false;
     }

--- a/src/components/GradientPicker/index.ts
+++ b/src/components/GradientPicker/index.ts
@@ -375,7 +375,7 @@ class GradientPicker extends Element {
         this.UI.footer.append(this.UI.typeCombo);
         this.UI.typeCombo.value = -1;
         this.UI.typeCombo.on('change', (value: number) => {
-            this.onTypeChanged(value);
+            this._onTypeChanged(value);
         });
 
         // this.UI.footer.append(this.UI.positionLabel);
@@ -895,7 +895,7 @@ class GradientPicker extends Element {
         }
     }
 
-    onTypeChanged(value: number) {
+    protected _onTypeChanged(value: number) {
         value = this.STATE.typeMap[value];
         const paths: any = [];
         const values: any[] = [];

--- a/src/components/GradientPicker/index.ts
+++ b/src/components/GradientPicker/index.ts
@@ -49,13 +49,7 @@ class GradientPicker extends Element {
 
     protected _checkerboardPattern: CanvasPattern;
 
-    protected _resizeInterval?: any;
-
-    protected _domEventKeyDown: any;
-
-    protected _domEventFocus: any;
-
-    protected _domEventBlur: any;
+    protected _resizeInterval: number;
 
     protected _panel: Panel;
 
@@ -136,23 +130,21 @@ class GradientPicker extends Element {
         this._canvas = new Canvas({ useDevicePixelRatio: true });
         this.dom.appendChild(this._canvas.dom);
         this._canvas.parent = this;
-        this._canvas.on('resize', this._renderGradient.bind(this));
+        this._canvas.on('resize', () => {
+            this._renderGradient();
+        });
         const canvasElement = this._canvas.dom as HTMLCanvasElement;
         this._checkerboardPattern = this.createCheckerboardPattern(canvasElement.getContext('2d'));
 
         // make sure canvas is the same size as the container element
         // 20 times a second
-        this._resizeInterval = setInterval(() => {
-            this._canvas.resize((this.width as number), (this.height as number));
+        this._resizeInterval = window.setInterval(() => {
+            this._canvas.resize(this.width, this.height);
         }, 1000 / 20);
 
-        this._domEventKeyDown = this._onKeyDown.bind(this);
-        this._domEventFocus = this._onFocus.bind(this);
-        this._domEventBlur = this._onBlur.bind(this);
-
-        this.dom.addEventListener('keydown', this._domEventKeyDown);
-        this.dom.addEventListener('focus', this._domEventFocus);
-        this.dom.addEventListener('blur', this._domEventBlur);
+        this.dom.addEventListener('keydown', this._onKeyDown);
+        this.dom.addEventListener('focus', this._onFocus);
+        this.dom.addEventListener('blur', this._onBlur);
 
         this.on('click', () => {
             if (!this.enabled || this.readOnly || this.class.contains(CLASS_MULTIPLE_VALUES)) return;
@@ -331,10 +323,6 @@ class GradientPicker extends Element {
             colorPicker: null
         };
 
-        this.doCopy = this.doCopy.bind(this);
-        this.doPaste = this.doPaste.bind(this);
-        this.doDelete = this.doDelete.bind(this);
-
         // current state
         this.STATE = {
             curves: [],            // holds all the gradient curves (either 3 or 4 of them)
@@ -386,7 +374,9 @@ class GradientPicker extends Element {
 
         this.UI.footer.append(this.UI.typeCombo);
         this.UI.typeCombo.value = -1;
-        this.UI.typeCombo.on('change', this.onTypeChanged.bind(this));
+        this.UI.typeCombo.on('change', (value: number) => {
+            this.onTypeChanged(value);
+        });
 
         // this.UI.footer.append(this.UI.positionLabel);
 
@@ -399,7 +389,9 @@ class GradientPicker extends Element {
             }
         });
 
-        this.UI.copyButton.on('click', this.doCopy);
+        this.UI.copyButton.on('click', () => {
+            this.doCopy();
+        });
         this.UI.copyButton.class.add('copy-curve-button');
         this.UI.footer.append(this.UI.copyButton);
         // Tooltip.attach({
@@ -409,11 +401,15 @@ class GradientPicker extends Element {
         //     root: this.UI.root
         // });
 
-        this.UI.pasteButton.on('click', this.doPaste);
+        this.UI.pasteButton.on('click', () => {
+            this.doPaste();
+        });
         this.UI.pasteButton.class.add('paste-curve-button');
         this.UI.footer.append(this.UI.pasteButton);
 
-        this.UI.deleteButton.on('click', this.doDelete);
+        this.UI.deleteButton.on('click', () => {
+            this.doDelete();
+        });
         this.UI.deleteButton.class.add('delete-curve-button');
         this.UI.footer.append(this.UI.deleteButton);
 
@@ -455,12 +451,6 @@ class GradientPicker extends Element {
             this.colorSelectedAnchor(color, true);
         });
 
-        this.anchorsOnMouseDown = this.anchorsOnMouseDown.bind(this);
-        this.anchorsOnMouseMove = this.anchorsOnMouseMove.bind(this);
-        this.anchorsOnMouseUp = this.anchorsOnMouseUp.bind(this);
-
-        this.emitCurveChange = this.emitCurveChange.bind(this);
-
         this._copiedData = null;
 
         this._channels = args.channels || 3;
@@ -469,6 +459,18 @@ class GradientPicker extends Element {
             // @ts-ignore
             this.value = args.value;
         }
+    }
+
+    destroy() {
+        if (this._destroyed) return;
+
+        this.dom.removeEventListener('keydown', this._onKeyDown);
+        this.dom.removeEventListener('focus', this._onFocus);
+        this.dom.removeEventListener('blur', this._onBlur);
+
+        window.clearInterval(this._resizeInterval);
+
+        super.destroy();
     }
 
     createCheckerboardPattern(context: CanvasRenderingContext2D) {
@@ -491,7 +493,7 @@ class GradientPicker extends Element {
         return context.createPattern(canvas, 'repeat');
     }
 
-    protected _onKeyDown(evt: KeyboardEvent) {
+    protected _onKeyDown = (evt: KeyboardEvent) => {
         // escape blurs the field
         if (evt.key === 'Escape') {
             this.blur();
@@ -506,15 +508,15 @@ class GradientPicker extends Element {
         evt.preventDefault();
 
         this._openGradientPicker();
-    }
+    };
 
-    protected _onFocus(evt: FocusEvent) {
+    protected _onFocus = (evt: FocusEvent) => {
         this.emit('focus');
-    }
+    };
 
-    protected _onBlur(evt: FocusEvent) {
+    protected _onBlur = (evt: FocusEvent) => {
         this.emit('blur');
-    }
+    };
 
     protected _getDefaultValue() {
         return {
@@ -609,18 +611,6 @@ class GradientPicker extends Element {
 
     blur() {
         this.dom.blur();
-    }
-
-    destroy() {
-        if (this._destroyed) return;
-        this.dom.removeEventListener('keydown', this._domEventKeyDown);
-        this.dom.removeEventListener('focus', this._domEventFocus);
-        this.dom.removeEventListener('blur', this._domEventBlur);
-
-        clearInterval(this._resizeInterval);
-        delete this._resizeInterval;
-
-        super.destroy();
     }
 
     set channels(value) {
@@ -875,9 +865,9 @@ class GradientPicker extends Element {
 
     // handle the picker being opened
     onOpen() {
-        window.addEventListener('mousemove', this.anchorsOnMouseMove);
-        window.addEventListener('mouseup', this.anchorsOnMouseUp);
-        this.UI.anchors.dom.addEventListener('mousedown', this.anchorsOnMouseDown);
+        window.addEventListener('mousemove', this._onAnchorsMouseMove);
+        window.addEventListener('mouseup', this._onAnchorsMouseUp);
+        this.UI.anchors.dom.addEventListener('mousedown', this._onAnchorsMouseDown);
         // editor.emit('picker:gradient:open');
         // editor.emit('picker:open', 'gradient');
     }
@@ -885,9 +875,9 @@ class GradientPicker extends Element {
     // handle the picker being closed
     onClose() {
         this.STATE.hoveredAnchor = -1;
-        window.removeEventListener('mousemove', this.anchorsOnMouseMove);
-        window.removeEventListener('mouseup', this.anchorsOnMouseUp);
-        this.UI.anchors.dom.removeEventListener('mousedown', this.anchorsOnMouseDown);
+        window.removeEventListener('mousemove', this._onAnchorsMouseMove);
+        window.removeEventListener('mouseup', this._onAnchorsMouseUp);
+        this.UI.anchors.dom.removeEventListener('mousedown', this._onAnchorsMouseDown);
 
         this._evtRefreshPicker.unbind();
         this._evtRefreshPicker = null;
@@ -905,7 +895,7 @@ class GradientPicker extends Element {
         }
     }
 
-    onTypeChanged(value: string | number) {
+    onTypeChanged(value: number) {
         value = this.STATE.typeMap[value];
         const paths: any = [];
         const values: any[] = [];
@@ -1080,7 +1070,7 @@ class GradientPicker extends Element {
                            rect.height - paddingTop - paddingBottom);
     }
 
-    anchorsOnMouseDown(e: MouseEvent) {
+    protected _onAnchorsMouseDown = (e: MouseEvent) => {
         if (this.STATE.hoveredAnchor === -1) {
             // user clicked in empty space, create new anchor and select it
             const coord = this.calcNormalizedCoord(e.clientX,
@@ -1100,9 +1090,9 @@ class GradientPicker extends Element {
         // drag the selected anchor
         this.dragStart();
         this.UI.draggingAnchor = true;
-    }
+    };
 
-    anchorsOnMouseMove(e: MouseEvent) {
+    protected _onAnchorsMouseMove = (e: MouseEvent) => {
         const coord = this.calcNormalizedCoord(e.clientX,
                                                e.clientY,
                                                this.getClientRect(this.UI.anchors.dom));
@@ -1149,16 +1139,16 @@ class GradientPicker extends Element {
         } else {
             this.UI.anchorAddCrossHair.style.visibility = 'hidden';
         }
-    }
+    };
 
-    anchorsOnMouseUp(evt: MouseEvent) {
+    _onAnchorsMouseUp = (evt: MouseEvent) => {
         if (this.UI.draggingAnchor) {
             this.dragEnd();
             this.UI.draggingAnchor = false;
         }
 
         this.UI.anchors.dom.style.cursor = 'pointer';
-    }
+    };
 
     selectHovered(index: number) {
         this.STATE.hoveredAnchor = index;

--- a/src/components/GradientPicker/index.ts
+++ b/src/components/GradientPicker/index.ts
@@ -1141,7 +1141,7 @@ class GradientPicker extends Element {
         }
     };
 
-    _onAnchorsMouseUp = (evt: MouseEvent) => {
+    protected _onAnchorsMouseUp = (evt: MouseEvent) => {
         if (this.UI.draggingAnchor) {
             this.dragEnd();
             this.UI.draggingAnchor = false;

--- a/src/components/GridView/index.ts
+++ b/src/components/GridView/index.ts
@@ -1,3 +1,5 @@
+import { EventHandle } from '@playcanvas/observer';
+
 import Element from '../Element/index';
 import Container, { ContainerArgs } from '../Container';
 import GridViewItem from '../GridViewItem';
@@ -86,14 +88,14 @@ class GridView extends Container {
     protected _onAppendGridViewItem(item: GridViewItem) {
         if (!(item instanceof GridViewItem)) return;
 
-        let evtClick: any;
+        let evtClick: EventHandle;
         if (this._clickFn)
             evtClick = item.on('click', evt => this._clickFn(evt, item));
         else
             evtClick = item.on('click', evt => this._onClickItem(evt, item));
         let evtSelect = item.on('select', () => this._onSelectItem(item));
 
-        let evtDeselect: any;
+        let evtDeselect: EventHandle;
         if (this._allowDeselect)
             evtDeselect = item.on('deselect', () => this._onDeselectItem(item));
 

--- a/src/components/GridView/index.ts
+++ b/src/components/GridView/index.ts
@@ -64,8 +64,8 @@ class GridView extends Container {
             this.class.add(CLASS_ROOT);
         }
 
-        this.on('append', this._onAppendGridViewItem.bind(this));
-        this.on('remove', this._onRemoveGridViewItem.bind(this));
+        this.on('append', this._onAppendGridViewItem);
+        this.on('remove', this._onRemoveGridViewItem);
 
         this._filterFn = args.filterFn;
         this._filterAnimationFrame = null;
@@ -78,7 +78,7 @@ class GridView extends Container {
         this._selected = [];
     }
 
-    protected _onAppendGridViewItem(item: GridViewItem) {
+    protected _onAppendGridViewItem = (item: GridViewItem) => {
         if (!(item instanceof GridViewItem)) return;
 
         let evtClick: any;
@@ -108,16 +108,16 @@ class GridView extends Container {
                 evtDeselect = null;
             }
         });
-    }
+    };
 
-    protected _onRemoveGridViewItem(item: GridViewItem) {
+    protected _onRemoveGridViewItem = (item: GridViewItem) => {
         if (!(item instanceof GridViewItem)) return;
 
         item.selected = false;
 
         item.emit('griditem:remove');
         item.unbind('griditem:remove');
-    }
+    };
 
     protected _onClickItem(evt: MouseEvent, item: GridViewItem) {
         if ((evt.ctrlKey || evt.metaKey) && this._multiSelect) {

--- a/src/components/GridView/index.ts
+++ b/src/components/GridView/index.ts
@@ -1,3 +1,4 @@
+import Element from '../Element/index';
 import Container, { ContainerArgs } from '../Container';
 import GridViewItem from '../GridViewItem';
 
@@ -64,8 +65,12 @@ class GridView extends Container {
             this.class.add(CLASS_ROOT);
         }
 
-        this.on('append', this._onAppendGridViewItem);
-        this.on('remove', this._onRemoveGridViewItem);
+        this.on('append', (element: Element) => {
+            this._onAppendGridViewItem(element as GridViewItem);
+        });
+        this.on('remove', (element: Element) => {
+            this._onRemoveGridViewItem(element as GridViewItem);
+        });
 
         this._filterFn = args.filterFn;
         this._filterAnimationFrame = null;
@@ -78,7 +83,7 @@ class GridView extends Container {
         this._selected = [];
     }
 
-    protected _onAppendGridViewItem = (item: GridViewItem) => {
+    protected _onAppendGridViewItem(item: GridViewItem) {
         if (!(item instanceof GridViewItem)) return;
 
         let evtClick: any;
@@ -108,16 +113,16 @@ class GridView extends Container {
                 evtDeselect = null;
             }
         });
-    };
+    }
 
-    protected _onRemoveGridViewItem = (item: GridViewItem) => {
+    protected _onRemoveGridViewItem(item: GridViewItem) {
         if (!(item instanceof GridViewItem)) return;
 
         item.selected = false;
 
         item.emit('griditem:remove');
         item.unbind('griditem:remove');
-    };
+    }
 
     protected _onClickItem(evt: MouseEvent, item: GridViewItem) {
         if ((evt.ctrlKey || evt.metaKey) && this._multiSelect) {

--- a/src/components/GridViewItem/index.ts
+++ b/src/components/GridViewItem/index.ts
@@ -48,15 +48,9 @@ class GridViewItem extends Container implements IFocusable {
 
     protected _radioButton: RadioButton;
 
-    protected _radioButtonClickEvt: any;
-
     protected _labelText: Label;
 
     protected _type: string;
-
-    protected _domEvtFocus: any;
-
-    protected _domEvtBlur: any;
 
     protected _allowSelect: boolean;
 
@@ -75,11 +69,9 @@ class GridViewItem extends Container implements IFocusable {
                 binding: new BindingObserversToElement({})
             });
 
-            this._radioButtonClickEvt = this._radioButtonClick.bind(this);
-
             // @ts-ignore Remove radio button click event listener
             this._radioButton.dom.removeEventListener('click', this._radioButton._onClick);
-            this._radioButton.dom.addEventListener('click', this._radioButtonClickEvt);
+            this._radioButton.dom.addEventListener('click', this._onRadioButtonClick);
 
             this.append(this._radioButton);
         } else {
@@ -96,24 +88,30 @@ class GridViewItem extends Container implements IFocusable {
         this.text = args.text;
         this._type = args.type;
 
-        this._domEvtFocus = this._onFocus.bind(this);
-        this._domEvtBlur = this._onBlur.bind(this);
-
-        this.dom.addEventListener('focus', this._domEvtFocus);
-        this.dom.addEventListener('blur', this._domEvtBlur);
+        this.dom.addEventListener('focus', this._onFocus);
+        this.dom.addEventListener('blur', this._onBlur);
     }
 
-    protected _radioButtonClick() {
+    destroy() {
+        if (this._destroyed) return;
+
+        this.dom.removeEventListener('focus', this._onFocus);
+        this.dom.removeEventListener('blur', this._onBlur);
+
+        super.destroy();
+    }
+
+    protected _onRadioButtonClick = () => {
         this._radioButton.value = this.selected;
-    }
+    };
 
-    protected _onFocus() {
+    protected _onFocus = () => {
         this.emit('focus');
-    }
+    };
 
-    protected _onBlur() {
+    protected _onBlur = () => {
         this.emit('blur');
-    }
+    };
 
     focus() {
         this.dom.focus();
@@ -129,15 +127,6 @@ class GridViewItem extends Container implements IFocusable {
 
     unlink() {
         this._labelText.unlink();
-    }
-
-    destroy() {
-        if (this._destroyed) return;
-
-        this.dom.removeEventListener('focus', this._domEvtFocus);
-        this.dom.removeEventListener('blur', this._domEvtBlur);
-
-        super.destroy();
     }
 
     /**

--- a/src/components/Menu/index.ts
+++ b/src/components/Menu/index.ts
@@ -32,14 +32,6 @@ class Menu extends Container implements IFocusable {
 
     protected _containerMenuItems: Container;
 
-    protected _domEvtContextMenu: any;
-
-    protected _domEvtKeyDown: any;
-
-    protected _domEvtFocus: any;
-
-    protected _domEvtBlur: any;
-
     constructor(args: MenuArgs = Menu.defaultArgs) {
         args = { ...Menu.defaultArgs, ...args };
         super(args);
@@ -55,15 +47,10 @@ class Menu extends Container implements IFocusable {
 
         this.domContent = this._containerMenuItems.dom;
 
-        this._domEvtContextMenu = this._onClickMenu.bind(this);
-        this._domEvtKeyDown = this._onKeyDown.bind(this);
-        this._domEvtFocus = this._onFocus.bind(this);
-        this._domEvtBlur = this._onBlur.bind(this);
-
-        this.on('click', this._onClickMenu.bind(this));
-        this.on('show', this._onShowMenu.bind(this));
-        this.dom.addEventListener('contextmenu', this._domEvtContextMenu);
-        this.dom.addEventListener('keydown', this._domEvtKeyDown);
+        this.on('click', this._onClickMenu);
+        this.on('show', this._onShowMenu);
+        this.dom.addEventListener('contextmenu', this._onClickMenu);
+        this.dom.addEventListener('keydown', this._onKeyDown);
 
         if (args.items) {
             args.items.forEach((item: MenuItemArgs) => {
@@ -71,6 +58,17 @@ class Menu extends Container implements IFocusable {
                 this.append(menuItem);
             });
         }
+    }
+
+    destroy() {
+        if (this.destroyed) return;
+
+        this.dom.removeEventListener('keydown', this._onKeyDown);
+        this.dom.removeEventListener('contextmenu', this._onClickMenu);
+        this.dom.removeEventListener('focus', this._onFocus);
+        this.dom.removeEventListener('blur', this._onBlur);
+
+        super.destroy();
     }
 
     protected _onAppendChild(element: Element) {
@@ -85,28 +83,19 @@ class Menu extends Container implements IFocusable {
         }
     }
 
-    protected _onClickMenu(evt: MouseEvent) {
+    protected _onClickMenu = (evt: MouseEvent) => {
         if (!this._containerMenuItems.dom.contains(evt.target as Node)) {
             this.hidden = true;
         }
-    }
+    };
 
-    protected _onFocus(evt: FocusEvent) {
+    protected _onFocus = (evt: FocusEvent) => {
         this.emit('focus');
-    }
+    };
 
-    protected _onBlur(evt: FocusEvent) {
+    protected _onBlur = (evt: FocusEvent) => {
         this.emit('blur');
-    }
-
-    protected _onShowMenu() {
-        this.focus();
-
-        // filter child menu items
-        this._containerMenuItems.dom.childNodes.forEach((child) => {
-            this._filterMenuItems(child.ui as MenuItem);
-        });
-    }
+    };
 
     protected _filterMenuItems(item: MenuItem) {
         if (!(item instanceof MenuItem)) return;
@@ -124,13 +113,22 @@ class Menu extends Container implements IFocusable {
         });
     }
 
-    protected _onKeyDown(evt: KeyboardEvent) {
+    protected _onShowMenu = () => {
+        this.focus();
+
+        // filter child menu items
+        this._containerMenuItems.dom.childNodes.forEach((child) => {
+            this._filterMenuItems(child.ui as MenuItem);
+        });
+    };
+
+    protected _onKeyDown = (evt: KeyboardEvent) => {
         if (this.hidden) return;
 
         if (evt.key === 'Escape') {
             this.hidden = true;
         }
-    }
+    };
 
     protected _limitSubmenuAtScreenEdges(item: MenuItem) {
         if (!(item instanceof MenuItem) || !item.hasChildren) return;
@@ -202,17 +200,6 @@ class Menu extends Container implements IFocusable {
      */
     clear() {
         this._containerMenuItems.clear();
-    }
-
-    destroy() {
-        if (this.destroyed) return;
-
-        this.dom.removeEventListener('keydown', this._domEvtKeyDown);
-        this.dom.removeEventListener('contextmenu', this._domEvtContextMenu);
-        this.dom.removeEventListener('focus', this._domEvtFocus);
-        this.dom.removeEventListener('blur', this._domEvtBlur);
-
-        super.destroy();
     }
 }
 

--- a/src/components/Menu/index.ts
+++ b/src/components/Menu/index.ts
@@ -48,7 +48,9 @@ class Menu extends Container implements IFocusable {
         this.domContent = this._containerMenuItems.dom;
 
         this.on('click', this._onClickMenu);
-        this.on('show', this._onShowMenu);
+        this.on('show', () => {
+            this._onShowMenu();
+        });
         this.dom.addEventListener('contextmenu', this._onClickMenu);
         this.dom.addEventListener('keydown', this._onKeyDown);
 
@@ -113,7 +115,7 @@ class Menu extends Container implements IFocusable {
         });
     }
 
-    protected _onShowMenu = () => {
+    protected _onShowMenu() {
         this.focus();
 
         // filter child menu items

--- a/src/components/Menu/index.ts
+++ b/src/components/Menu/index.ts
@@ -122,7 +122,7 @@ class Menu extends Container implements IFocusable {
         this._containerMenuItems.dom.childNodes.forEach((child) => {
             this._filterMenuItems(child.ui as MenuItem);
         });
-    };
+    }
 
     protected _onKeyDown = (evt: KeyboardEvent) => {
         if (this.hidden) return;

--- a/src/components/MenuItem/index.ts
+++ b/src/components/MenuItem/index.ts
@@ -67,8 +67,6 @@ class MenuItem extends Container implements IBindable {
 
     protected _containerItems: Container;
 
-    protected _domEvtMenuItemClick: any;
-
     protected _menu: any;
 
     protected _onSelect: any;
@@ -107,8 +105,7 @@ class MenuItem extends Container implements IBindable {
 
         this.text = args.text || 'Untitled';
 
-        this._domEvtMenuItemClick = this._onClickMenuItem.bind(this);
-        this.dom.addEventListener('click', this._domEvtMenuItemClick);
+        this.dom.addEventListener('click', this._onClickMenuItem);
 
         if (args.value) {
             this.value = args.value;
@@ -134,6 +131,14 @@ class MenuItem extends Container implements IBindable {
         }
     }
 
+    destroy() {
+        if (this.destroyed) return;
+
+        this.dom.removeEventListener('click', this._onClickMenuItem);
+
+        super.destroy();
+    }
+
     protected _onAppendChild(element: Element) {
         super._onAppendChild(element);
 
@@ -155,7 +160,7 @@ class MenuItem extends Container implements IBindable {
         super._onRemoveChild(element);
     }
 
-    protected _onClickMenuItem(evt: MouseEvent) {
+    protected _onClickMenuItem = (evt: MouseEvent) => {
         evt.preventDefault();
         evt.stopPropagation();
         if (this.enabled) {
@@ -166,7 +171,7 @@ class MenuItem extends Container implements IBindable {
                 this.menu.hidden = true;
             }
         }
-    }
+    };
 
     link(observers: Observer|Observer[], paths: string|string[]) {
         super.link(observers, paths);
@@ -192,14 +197,6 @@ class MenuItem extends Container implements IBindable {
         if (this.menu) {
             this.menu.hidden = true;
         }
-    }
-
-    destroy() {
-        if (this.destroyed) return;
-
-        this.dom.removeEventListener('click', this._domEvtMenuItemClick);
-
-        super.destroy();
     }
 
     /**

--- a/src/components/NumericInput/index.ts
+++ b/src/components/NumericInput/index.ts
@@ -151,11 +151,11 @@ class NumericInput extends TextInput {
         super.destroy();
     }
 
-    protected _updatePosition = (movement: number, shiftKey: boolean) => {
+    protected _updatePosition(movement: number, shiftKey: boolean) {
         // move one step or stepPrecision every 100 pixels
         this._sliderMovement += movement / 100 * (shiftKey ? this._stepPrecision : this._step);
         this.value = this._sliderPrevValue + this._sliderMovement;
-    };
+    }
 
     protected _onSliderMouseWheel = (evt: WheelEvent) => {
         this._updatePosition(evt.deltaY, evt.shiftKey);

--- a/src/components/NumericInput/index.ts
+++ b/src/components/NumericInput/index.ts
@@ -215,9 +215,7 @@ class NumericInput extends TextInput {
 
     protected _isScrolling() {
         if (!this._sliderControl) return false;
-        return (document.pointerLockElement === this._sliderControl.dom ||
-        // @ts-ignore
-            document.mozPointerLockElement === this._sliderControl.dom);
+        return document.pointerLockElement === this._sliderControl.dom;
     }
 
     protected _onPointerLockChange = () => {

--- a/src/components/Overlay/index.ts
+++ b/src/components/Overlay/index.ts
@@ -31,8 +31,6 @@ class Overlay extends Container {
 
     protected _domClickableOverlay: HTMLDivElement;
 
-    protected _domEventMouseDown: any;
-
     constructor(args: OverlayArgs = Overlay.defaultArgs) {
         args = { ...Overlay.defaultArgs, ...args };
         super(args);
@@ -44,8 +42,7 @@ class Overlay extends Container {
         this._domClickableOverlay.classList.add(CLASS_OVERLAY_INNER);
         this.dom.appendChild(this._domClickableOverlay);
 
-        this._domEventMouseDown = this._onMouseDown.bind(this);
-        this._domClickableOverlay.addEventListener('mousedown', this._domEventMouseDown);
+        this._domClickableOverlay.addEventListener('mousedown', this._onMouseDown);
 
         this.domContent = document.createElement('div');
         this.domContent.ui = this;
@@ -56,7 +53,15 @@ class Overlay extends Container {
         this.transparent = args.transparent || false;
     }
 
-    protected _onMouseDown(evt: MouseEvent) {
+    destroy() {
+        if (this._destroyed) return;
+
+        this._domClickableOverlay.removeEventListener('mousedown', this._onMouseDown);
+
+        super.destroy();
+    }
+
+    protected _onMouseDown = (evt: MouseEvent) => {
         if (!this.clickable) return;
 
         // some field might be in focus
@@ -68,7 +73,7 @@ class Overlay extends Container {
         });
 
         evt.preventDefault();
-    }
+    };
 
     /**
      * Position the overlay at specific x, y coordinates.
@@ -86,12 +91,6 @@ class Overlay extends Container {
         this.domContent.style.position = 'absolute';
         this.domContent.style.left = `${x}px`;
         this.domContent.style.top = `${y}px`;
-    }
-
-    destroy() {
-        if (this._destroyed) return;
-        this._domClickableOverlay.removeEventListener('mousedown', this._domEventMouseDown);
-        super.destroy();
     }
 
     /**

--- a/src/components/RadioButton/index.ts
+++ b/src/components/RadioButton/index.ts
@@ -19,12 +19,6 @@ class RadioButton extends Element implements IBindable, IFocusable {
         tabIndex: 0
     };
 
-    protected _domEventKeyDown: any;
-
-    protected _domEventFocus: any;
-
-    protected _domEventBlur: any;
-
     protected _value: boolean;
 
     protected _renderChanges: boolean;
@@ -36,16 +30,22 @@ class RadioButton extends Element implements IBindable, IFocusable {
         this.class.add(CLASS_RADIO_BUTTON);
         this.class.add(pcuiClass.NOT_FLEXIBLE);
 
-        this._domEventKeyDown = this._onKeyDown.bind(this);
-        this._domEventFocus = this._onFocus.bind(this);
-        this._domEventBlur = this._onBlur.bind(this);
-
-        this.dom.addEventListener('keydown', this._domEventKeyDown);
-        this.dom.addEventListener('focus', this._domEventFocus);
-        this.dom.addEventListener('blur', this._domEventBlur);
+        this.dom.addEventListener('keydown', this._onKeyDown);
+        this.dom.addEventListener('focus', this._onFocus);
+        this.dom.addEventListener('blur', this._onBlur);
 
         this.value = args.value;
         this._renderChanges = args.renderChanges;
+    }
+
+    destroy() {
+        if (this._destroyed) return;
+
+        this.dom.removeEventListener('keydown', this._onKeyDown);
+        this.dom.removeEventListener('focus', this._onFocus);
+        this.dom.removeEventListener('blur', this._onBlur);
+
+        super.destroy();
     }
 
     protected _onClick(evt: MouseEvent) {
@@ -60,7 +60,7 @@ class RadioButton extends Element implements IBindable, IFocusable {
         return super._onClick(evt);
     }
 
-    protected _onKeyDown(evt: KeyboardEvent) {
+    protected _onKeyDown = (evt: KeyboardEvent) => {
         if (evt.key === 'Escape') {
             this.blur();
             return;
@@ -73,15 +73,15 @@ class RadioButton extends Element implements IBindable, IFocusable {
             evt.preventDefault();
             this.value = !this.value;
         }
-    }
+    };
 
-    protected _onFocus(evt: FocusEvent) {
+    protected _onFocus = (evt: FocusEvent) => {
         this.emit('focus');
-    }
+    };
 
-    protected _onBlur(evt: FocusEvent) {
+    protected _onBlur = (evt: FocusEvent) => {
         this.emit('blur');
-    }
+    };
 
     protected _updateValue(value: boolean) {
         this.class.remove(pcuiClass.MULTIPLE_VALUES);
@@ -111,16 +111,6 @@ class RadioButton extends Element implements IBindable, IFocusable {
 
     blur() {
         this.dom.blur();
-    }
-
-    destroy() {
-        if (this._destroyed) return;
-
-        this.dom.removeEventListener('keydown', this._domEventKeyDown);
-        this.dom.removeEventListener('focus', this._domEventFocus);
-        this.dom.removeEventListener('blur', this._domEventBlur);
-
-        super.destroy();
     }
 
     set value(value) {

--- a/src/components/RadioButton/index.ts
+++ b/src/components/RadioButton/index.ts
@@ -48,7 +48,7 @@ class RadioButton extends Element implements IBindable, IFocusable {
         super.destroy();
     }
 
-    protected _onClick(evt: MouseEvent) {
+    protected _onClick = (evt: MouseEvent) => {
         if (this.enabled) {
             this.focus();
         }
@@ -58,7 +58,7 @@ class RadioButton extends Element implements IBindable, IFocusable {
         }
 
         return super._onClick(evt);
-    }
+    };
 
     protected _onKeyDown = (evt: KeyboardEvent) => {
         if (evt.key === 'Escape') {

--- a/src/components/RadioButton/index.ts
+++ b/src/components/RadioButton/index.ts
@@ -48,7 +48,7 @@ class RadioButton extends Element implements IBindable, IFocusable {
         super.destroy();
     }
 
-    protected _onClick = (evt: MouseEvent) => {
+    protected _onClick(evt: MouseEvent) {
         if (this.enabled) {
             this.focus();
         }
@@ -58,7 +58,7 @@ class RadioButton extends Element implements IBindable, IFocusable {
         }
 
         return super._onClick(evt);
-    };
+    }
 
     protected _onKeyDown = (evt: KeyboardEvent) => {
         if (evt.key === 'Escape') {

--- a/src/components/SelectInput/index.ts
+++ b/src/components/SelectInput/index.ts
@@ -288,6 +288,27 @@ class SelectInput extends Element implements IBindable, IFocusable {
         this._updateInputFieldsVisibility(false);
     }
 
+    destroy() {
+        if (this._destroyed) return;
+
+        this._labelValue.dom.removeEventListener('keydown', this._onKeyDown);
+        this._labelValue.dom.removeEventListener('mousedown', this._onMouseDown);
+        this._labelValue.dom.removeEventListener('focus', this._onFocus);
+        this._labelValue.dom.removeEventListener('blur', this._onBlur);
+
+        this._containerOptions.dom.removeEventListener('wheel', this._onWheel);
+
+        window.removeEventListener('keydown', this._onKeyDown);
+        window.removeEventListener('mousedown', this._onWindowMouseDown);
+
+        if (this._timeoutLabelValueTabIndex) {
+            cancelAnimationFrame(this._timeoutLabelValueTabIndex);
+            this._timeoutLabelValueTabIndex = null;
+        }
+
+        super.destroy();
+    }
+
     protected _initializeCreateLabel() {
         const container = new Container({
             class: CLASS_CREATE_NEW,
@@ -939,27 +960,6 @@ class SelectInput extends Element implements IBindable, IFocusable {
         if (!this._containerOptions.hidden) {
             this.close();
         }
-    }
-
-    destroy() {
-        if (this._destroyed) return;
-
-        this._labelValue.dom.removeEventListener('keydown', this._onKeyDown);
-        this._labelValue.dom.removeEventListener('mousedown', this._onMouseDown);
-        this._labelValue.dom.removeEventListener('focus', this._onFocus);
-        this._labelValue.dom.removeEventListener('blur', this._onBlur);
-
-        this._containerOptions.dom.removeEventListener('wheel', this._onWheel);
-
-        window.removeEventListener('keydown', this._onKeyDown);
-        window.removeEventListener('mousedown', this._onWindowMouseDown);
-
-        if (this._timeoutLabelValueTabIndex) {
-            cancelAnimationFrame(this._timeoutLabelValueTabIndex);
-            this._timeoutLabelValueTabIndex = null;
-        }
-
-        super.destroy();
     }
 
     set options(value) {

--- a/src/components/SelectInput/index.ts
+++ b/src/components/SelectInput/index.ts
@@ -186,10 +186,10 @@ class SelectInput extends Element implements IBindable, IFocusable {
             tabIndex: 0
         });
         this._labelValue.on('click', () => {
-            if (!this.enabled || this.readOnly) return;
-
-            // toggle dropdown list
-            this.toggle();
+            if (this.enabled && !this.readOnly) {
+                // toggle dropdown list
+                this.toggle();
+            }
         });
         this._containerValue.append(this._labelValue);
 

--- a/src/components/SelectInput/index.ts
+++ b/src/components/SelectInput/index.ts
@@ -127,18 +127,6 @@ class SelectInput extends Element implements IBindable, IFocusable {
 
     protected _containerTags: Container;
 
-    protected _domEvtKeyDown: any;
-
-    protected _domEvtFocus: any;
-
-    protected _domEvtBlur: any;
-
-    protected _domEvtMouseDown: any;
-
-    protected _domEvtWindowMouseDown: any;
-
-    protected _domEvtWheel: any;
-
     protected _type: string;
 
     protected _optionsIndex: { [key: string]: string };
@@ -197,7 +185,12 @@ class SelectInput extends Element implements IBindable, IFocusable {
             class: CLASS_VALUE,
             tabIndex: 0
         });
-        this._labelValue.on('click', this._onValueClick.bind(this));
+        this._labelValue.on('click', () => {
+            if (!this.enabled || this.readOnly) return;
+
+            // toggle dropdown list
+            this.toggle();
+        });
         this._containerValue.append(this._labelValue);
 
         this._timeoutLabelValueTabIndex = null;
@@ -219,10 +212,10 @@ class SelectInput extends Element implements IBindable, IFocusable {
 
         this._lastInputValue = '';
         this._suspendInputChange = false;
-        this._input.on('change', this._onInputChange.bind(this));
-        this._input.on('keydown', this._onInputKeyDown.bind(this));
-        this._input.on('focus', this._onFocus.bind(this));
-        this._input.on('blur', this._onBlur.bind(this));
+        this._input.on('change', this._onInputChange);
+        this._input.on('keydown', this._onInputKeyDown);
+        this._input.on('focus', this._onFocus);
+        this._input.on('blur', this._onBlur);
 
         if (args.placeholder) {
             this.placeholder = args.placeholder;
@@ -250,21 +243,16 @@ class SelectInput extends Element implements IBindable, IFocusable {
         }
 
         // events
-        this._domEvtKeyDown = this._onKeyDown.bind(this);
-        this._domEvtFocus = this._onFocus.bind(this);
-        this._domEvtBlur = this._onBlur.bind(this);
-        this._domEvtMouseDown = this._onMouseDown.bind(this);
-        this._domEvtWindowMouseDown = this._onWindowMouseDown.bind(this);
-        this._domEvtWheel = this._onWheel.bind(this);
+        this._labelValue.dom.addEventListener('keydown', this._onKeyDown);
+        this._labelValue.dom.addEventListener('focus', this._onFocus);
+        this._labelValue.dom.addEventListener('blur', this._onBlur);
+        this._labelValue.dom.addEventListener('mousedown', this._onMouseDown);
 
-        this._labelValue.dom.addEventListener('keydown', this._domEvtKeyDown);
-        this._labelValue.dom.addEventListener('focus', this._domEvtFocus);
-        this._labelValue.dom.addEventListener('blur', this._domEvtBlur);
-        this._labelValue.dom.addEventListener('mousedown', this._domEvtMouseDown);
+        this._containerOptions.dom.addEventListener('wheel', this._onWheel, { passive: true });
 
-        this._containerOptions.dom.addEventListener('wheel', this._domEvtWheel, { passive: true });
-
-        this.on('hide', this.close.bind(this));
+        this.on('hide', () => {
+            this.close();
+        });
 
         this._type = args.type;
 
@@ -393,13 +381,6 @@ class SelectInput extends Element implements IBindable, IFocusable {
         }
 
         return this._convertSingleValue(value);
-    }
-
-    // toggle dropdown list
-    protected _onValueClick() {
-        if (!this.enabled || this.readOnly) return;
-
-        this.toggle();
     }
 
     // Update our value with the specified selected option
@@ -606,7 +587,7 @@ class SelectInput extends Element implements IBindable, IFocusable {
         }
     }
 
-    protected _onInputChange(value: any) {
+    protected _onInputChange = (value: any) => {
         if (this._suspendInputChange) return;
 
         if (this._lastInputValue === value) return;
@@ -616,7 +597,7 @@ class SelectInput extends Element implements IBindable, IFocusable {
         this._lastInputValue = value;
 
         this._filterOptions(value);
-    }
+    };
 
     protected _filterOptions(filter: any) {
         // first remove all options
@@ -654,7 +635,7 @@ class SelectInput extends Element implements IBindable, IFocusable {
         this._resizeShadow();
     }
 
-    protected _onInputKeyDown(evt: KeyboardEvent) {
+    protected _onInputKeyDown = (evt: KeyboardEvent) => {
         if (evt.key === 'Enter' && this.enabled && !this.readOnly) {
             evt.stopPropagation();
             evt.preventDefault();
@@ -687,14 +668,15 @@ class SelectInput extends Element implements IBindable, IFocusable {
         }
 
         this._onKeyDown(evt);
-    }
+    };
 
-    protected _onWindowMouseDown(evt: MouseEvent) {
-        if (this.dom.contains(evt.target as Node)) return;
-        this.close();
-    }
+    protected _onWindowMouseDown = (evt: MouseEvent) => {
+        if (!this.dom.contains(evt.target as Node)) {
+            this.close();
+        }
+    };
 
-    protected _onKeyDown(evt: KeyboardEvent) {
+    protected _onKeyDown = (evt: KeyboardEvent) => {
         // close options on ESC and blur
         if (evt.key === 'Escape') {
             this.close();
@@ -769,36 +751,36 @@ class SelectInput extends Element implements IBindable, IFocusable {
                 }
             }
         }
-    }
+    };
 
     protected _resizeShadow() {
         this._domShadow.style.height = (this._containerValue.height + this._containerOptions.height) + 'px';
     }
 
-    protected _onMouseDown() {
+    protected _onMouseDown = () => {
         if (!this._allowInput) {
             this.focus();
         }
-    }
+    };
 
-    protected _onFocus() {
+    protected _onFocus = () => {
         this.class.add(pcuiClass.FOCUS);
         this.emit('focus');
         if (!this._input.hidden) {
             this.open();
         }
-    }
+    };
 
-    protected _onBlur() {
+    protected _onBlur = () => {
         this.class.remove(pcuiClass.FOCUS);
         this.emit('blur');
-    }
+    };
 
-    protected _onWheel(evt: WheelEvent) {
+    protected _onWheel = (evt: WheelEvent) => {
         // prevent scrolling on other stuff like the viewport
         // when we are scrolling on the select input
         evt.stopPropagation();
-    }
+    };
 
     protected _updateInputFieldsVisibility(focused?: boolean) {
         let showInput = false;
@@ -883,9 +865,9 @@ class SelectInput extends Element implements IBindable, IFocusable {
         this.class.add(CLASS_OPEN);
 
         // register keydown on entire window
-        window.addEventListener('keydown', this._domEvtKeyDown);
+        window.addEventListener('keydown', this._onKeyDown);
         // register mousedown on entire window
-        window.addEventListener('mousedown', this._domEvtWindowMouseDown);
+        window.addEventListener('mousedown', this._onWindowMouseDown);
 
         // if the dropdown list goes below the window show it above the field
         const startField = this._allowInput ? this._input.dom : this._labelValue.dom;
@@ -936,8 +918,8 @@ class SelectInput extends Element implements IBindable, IFocusable {
         this._domShadow.style.height = '';
 
         this.class.remove(CLASS_OPEN);
-        window.removeEventListener('keydown', this._domEvtKeyDown);
-        window.removeEventListener('mousedown', this._domEvtWindowMouseDown);
+        window.removeEventListener('keydown', this._onKeyDown);
+        window.removeEventListener('mousedown', this._onWindowMouseDown);
     }
 
     /**
@@ -962,15 +944,15 @@ class SelectInput extends Element implements IBindable, IFocusable {
     destroy() {
         if (this._destroyed) return;
 
-        this._labelValue.dom.removeEventListener('keydown', this._domEvtKeyDown);
-        this._labelValue.dom.removeEventListener('mousedown', this._domEvtMouseDown);
-        this._labelValue.dom.removeEventListener('focus', this._domEvtFocus);
-        this._labelValue.dom.removeEventListener('blur', this._domEvtBlur);
+        this._labelValue.dom.removeEventListener('keydown', this._onKeyDown);
+        this._labelValue.dom.removeEventListener('mousedown', this._onMouseDown);
+        this._labelValue.dom.removeEventListener('focus', this._onFocus);
+        this._labelValue.dom.removeEventListener('blur', this._onBlur);
 
-        this._containerOptions.dom.removeEventListener('wheel', this._domEvtWheel);
+        this._containerOptions.dom.removeEventListener('wheel', this._onWheel);
 
-        window.removeEventListener('keydown', this._domEvtKeyDown);
-        window.removeEventListener('mousedown', this._domEvtWindowMouseDown);
+        window.removeEventListener('keydown', this._onKeyDown);
+        window.removeEventListener('mousedown', this._onWindowMouseDown);
 
         if (this._timeoutLabelValueTabIndex) {
             cancelAnimationFrame(this._timeoutLabelValueTabIndex);
@@ -1099,7 +1081,9 @@ class SelectInput extends Element implements IBindable, IFocusable {
 
     /* eslint accessor-pairs: 0 */
     set values(values: Array<any>) {
-        values = values.map(this._convertValue.bind(this));
+        values = values.map((value) => {
+            return this._convertValue(value);
+        });
 
         let different = false;
         const value = values[0];

--- a/src/components/SliderInput/index.ts
+++ b/src/components/SliderInput/index.ts
@@ -225,8 +225,9 @@ class SliderInput extends Element implements IBindable, IFocusable {
 
         for (let i = 0; i < evt.changedTouches.length; i++) {
             const touch = evt.changedTouches[i];
-            // @ts-ignore
-            if (!touch.target.ui || touch.target.ui !== this)
+            const node = touch.target as Node;
+
+            if (!node.ui || node.ui !== this)
                 continue;
 
             this._touchId = touch.identifier;

--- a/src/components/SliderInput/index.ts
+++ b/src/components/SliderInput/index.ts
@@ -133,14 +133,7 @@ class SliderInput extends Element implements IBindable, IFocusable {
 
         // propagate change event
         this._numericInput.on('change', (value: number) => {
-            this._updateHandle(value);
-            if (!this._suppressChange) {
-                this.emit('change', value);
-            }
-
-            if (this._binding) {
-                this._binding.setValue(value);
-            }
+            this._onValueChange(value);
         });
 
         // propagate focus / blur events
@@ -298,6 +291,17 @@ class SliderInput extends Element implements IBindable, IFocusable {
         const left = Math.max(0, Math.min(1, ((value || 0) - this._sliderMin) / (this._sliderMax - this._sliderMin))) * 100;
         const handleWidth = this._domHandle.getBoundingClientRect().width;
         this._domHandle.style.left = `calc(${left}% + ${handleWidth / 2}px)`;
+    }
+
+    protected _onValueChange(value: number) {	
+        this._updateHandle(value);	
+        if (!this._suppressChange) {	
+            this.emit('change', value);	
+        }	
+
+        if (this._binding) {	
+            this._binding.setValue(value);	
+        }	
     }
 
     // Calculates the distance in pixels between

--- a/src/components/SliderInput/index.ts
+++ b/src/components/SliderInput/index.ts
@@ -293,15 +293,15 @@ class SliderInput extends Element implements IBindable, IFocusable {
         this._domHandle.style.left = `calc(${left}% + ${handleWidth / 2}px)`;
     }
 
-    protected _onValueChange(value: number) {	
-        this._updateHandle(value);	
-        if (!this._suppressChange) {	
-            this.emit('change', value);	
-        }	
+    protected _onValueChange(value: number) {
+        this._updateHandle(value);
+        if (!this._suppressChange) {
+            this.emit('change', value);
+        }
 
-        if (this._binding) {	
-            this._binding.setValue(value);	
-        }	
+        if (this._binding) {
+            this._binding.setValue(value);
+        }
     }
 
     // Calculates the distance in pixels between

--- a/src/components/TextAreaInput/index.ts
+++ b/src/components/TextAreaInput/index.ts
@@ -53,13 +53,13 @@ class TextAreaInput extends TextInput {
         }
     }
 
-    protected _onInputKeyDown = (evt: KeyboardEvent) => {
+    protected _onInputKeyDown(evt: KeyboardEvent) {
         if ((evt.key === 'Escape' && this.blurOnEscape) || (evt.key === 'Enter' && this.blurOnEnter && !evt.shiftKey)) {
             this._domInput.blur();
         }
 
         this.emit('keydown', evt);
-    };
+    }
 }
 
 Element.register('text', TextAreaInput, { renderChanges: true });

--- a/src/components/TextAreaInput/index.ts
+++ b/src/components/TextAreaInput/index.ts
@@ -53,13 +53,13 @@ class TextAreaInput extends TextInput {
         }
     }
 
-    protected _onInputKeyDown(evt: KeyboardEvent) {
+    protected _onInputKeyDown = (evt: KeyboardEvent) => {
         if ((evt.key === 'Escape' && this.blurOnEscape) || (evt.key === 'Enter' && this.blurOnEnter && !evt.shiftKey)) {
             this._domInput.blur();
         }
 
         this.emit('keydown', evt);
-    }
+    };
 }
 
 Element.register('text', TextAreaInput, { renderChanges: true });

--- a/src/components/TextInput/index.ts
+++ b/src/components/TextInput/index.ts
@@ -58,6 +58,8 @@ class TextInput extends Input implements IFocusable, IPlaceholder {
 
     protected _blurOnEscape: boolean;
 
+    protected _onInputKeyDownEvt: (evt: KeyboardEvent) => void;
+
     constructor(args: TextInputArgs = TextInput.defaultArgs) {
         args = { ...TextInput.defaultArgs, ...args };
         super(args.dom, args);
@@ -74,10 +76,12 @@ class TextInput extends Input implements IFocusable, IPlaceholder {
         input.tabIndex = 0;
         input.autocomplete = "off";
 
+        this._onInputKeyDownEvt = this._onInputKeyDown.bind(this);
+
         input.addEventListener('change', this._onInputChange);
         input.addEventListener('focus', this._onInputFocus);
         input.addEventListener('blur', this._onInputBlur);
-        input.addEventListener('keydown', this._onInputKeyDown);
+        input.addEventListener('keydown', this._onInputKeyDownEvt);
         input.addEventListener('contextmenu', this._onInputCtxMenu, false);
 
         this.dom.appendChild(input);
@@ -119,7 +123,7 @@ class TextInput extends Input implements IFocusable, IPlaceholder {
         input.removeEventListener('change', this._onInputChange);
         input.removeEventListener('focus', this._onInputFocus);
         input.removeEventListener('blur', this._onInputBlur);
-        input.removeEventListener('keydown', this._onInputKeyDown);
+        input.removeEventListener('keydown', this._onInputKeyDownEvt);
         input.removeEventListener('keyup', this._onInputKeyUp);
         input.removeEventListener('contextmenu', this._onInputCtxMenu);
 
@@ -159,7 +163,7 @@ class TextInput extends Input implements IFocusable, IPlaceholder {
         this.emit('blur', evt);
     };
 
-    protected _onInputKeyDown = (evt: KeyboardEvent) => {
+    protected _onInputKeyDown(evt: KeyboardEvent) {
         if (evt.key === 'Enter' && this.blurOnEnter) {
             // do not fire input change event on blur
             // if keyChange is true (because a change event)
@@ -185,7 +189,7 @@ class TextInput extends Input implements IFocusable, IPlaceholder {
         }
 
         this.emit('keydown', evt);
-    };
+    }
 
     protected _onInputKeyUp = (evt: KeyboardEvent) => {
         if (evt.key !== 'Escape') {

--- a/src/components/TextInput/index.ts
+++ b/src/components/TextInput/index.ts
@@ -44,18 +44,6 @@ class TextInput extends Input implements IFocusable, IPlaceholder {
 
     protected _domInput: HTMLInputElement;
 
-    protected _domEvtChange: any;
-
-    protected _domEvtFocus: any;
-
-    protected _domEvtBlur: any;
-
-    protected _domEvtKeyDown: any;
-
-    protected _domEvtKeyUp: any;
-
-    protected _domEvtCtxMenu: any;
-
     protected _suspendInputChangeEvt: boolean;
 
     protected _prevValue: any;
@@ -85,21 +73,16 @@ class TextInput extends Input implements IFocusable, IPlaceholder {
         input.ui = this;
         input.tabIndex = 0;
         input.autocomplete = "off";
+
+        input.addEventListener('change', this._onInputChange);
+        input.addEventListener('focus', this._onInputFocus);
+        input.addEventListener('blur', this._onInputBlur);
+        input.addEventListener('keydown', this._onInputKeyDown);
+        input.addEventListener('contextmenu', this._onInputCtxMenu, false);
+
+        this.dom.appendChild(input);
+
         this._domInput = input;
-
-        this._domEvtChange = this._onInputChange.bind(this);
-        this._domEvtFocus = this._onInputFocus.bind(this);
-        this._domEvtBlur = this._onInputBlur.bind(this);
-        this._domEvtKeyDown = this._onInputKeyDown.bind(this);
-        this._domEvtKeyUp = this._onInputKeyUp.bind(this);
-        this._domEvtCtxMenu = this._onInputCtxMenu.bind(this);
-
-        this._domInput.addEventListener('change', this._domEvtChange);
-        this._domInput.addEventListener('focus', this._domEvtFocus);
-        this._domInput.addEventListener('blur', this._domEvtBlur);
-        this._domInput.addEventListener('keydown', this._domEvtKeyDown);
-        this._domInput.addEventListener('contextmenu', this._domEvtCtxMenu, false);
-        this.dom.appendChild(this._domInput);
 
         this._suspendInputChangeEvt = false;
 
@@ -122,14 +105,30 @@ class TextInput extends Input implements IFocusable, IPlaceholder {
                 this.flash();
             }
         });
-        this.on('disable', this._updateInputReadOnly.bind(this));
-        this.on('enable', this._updateInputReadOnly.bind(this));
-        this.on('readOnly', this._updateInputReadOnly.bind(this));
+        this.on('disable', this._updateInputReadOnly);
+        this.on('enable', this._updateInputReadOnly);
+        this.on('readOnly', this._updateInputReadOnly);
 
         this._updateInputReadOnly();
     }
 
-    protected _onInputChange(evt: Event) {
+    destroy() {
+        if (this._destroyed) return;
+
+        const input = this._domInput;
+        input.removeEventListener('change', this._onInputChange);
+        input.removeEventListener('focus', this._onInputFocus);
+        input.removeEventListener('blur', this._onInputBlur);
+        input.removeEventListener('keydown', this._onInputKeyDown);
+        input.removeEventListener('keyup', this._onInputKeyUp);
+        input.removeEventListener('contextmenu', this._onInputCtxMenu);
+
+        this._domInput = null;
+
+        super.destroy();
+    }
+
+    protected _onInputChange = (evt: Event) => {
         if (this._suspendInputChangeEvt) return;
 
         if (this._onValidate) {
@@ -147,20 +146,20 @@ class TextInput extends Input implements IFocusable, IPlaceholder {
         if (this._binding) {
             this._binding.setValue(this.value);
         }
-    }
+    };
 
-    protected _onInputFocus(evt: FocusEvent) {
+    protected _onInputFocus = (evt: FocusEvent) => {
         this.class.add(pcuiClass.FOCUS);
         this.emit('focus', evt);
         this._prevValue = this.value;
-    }
+    };
 
-    protected _onInputBlur(evt: FocusEvent) {
+    protected _onInputBlur = (evt: FocusEvent) => {
         this.class.remove(pcuiClass.FOCUS);
         this.emit('blur', evt);
-    }
+    };
 
-    protected _onInputKeyDown(evt: KeyboardEvent) {
+    protected _onInputKeyDown = (evt: KeyboardEvent) => {
         if (evt.key === 'Enter' && this.blurOnEnter) {
             // do not fire input change event on blur
             // if keyChange is true (because a change event)
@@ -186,28 +185,28 @@ class TextInput extends Input implements IFocusable, IPlaceholder {
         }
 
         this.emit('keydown', evt);
-    }
+    };
 
-    protected _onInputKeyUp(evt: KeyboardEvent) {
+    protected _onInputKeyUp = (evt: KeyboardEvent) => {
         if (evt.key !== 'Escape') {
             this._onInputChange(evt);
         }
 
         this.emit('keyup', evt);
-    }
+    };
 
-    protected _onInputCtxMenu(evt: MouseEvent) {
+    protected _onInputCtxMenu = (evt: MouseEvent) => {
         this._domInput.select();
-    }
+    };
 
-    protected _updateInputReadOnly() {
+    protected _updateInputReadOnly = () => {
         const readOnly = !this.enabled || this.readOnly;
         if (readOnly) {
             this._domInput.setAttribute('readonly', 'true');
         } else {
             this._domInput.removeAttribute('readonly');
         }
-    }
+    };
 
     protected _updateValue(value: string | number | Array<string | number>) {
         this.class.remove(pcuiClass.MULTIPLE_VALUES);
@@ -250,19 +249,6 @@ class TextInput extends Input implements IFocusable, IPlaceholder {
 
     blur() {
         this._domInput.blur();
-    }
-
-    destroy() {
-        if (this._destroyed) return;
-        this._domInput.removeEventListener('change', this._domEvtChange);
-        this._domInput.removeEventListener('focus', this._domEvtFocus);
-        this._domInput.removeEventListener('blur', this._domEvtBlur);
-        this._domInput.removeEventListener('keydown', this._domEvtKeyDown);
-        this._domInput.removeEventListener('keyup', this._domEvtKeyUp);
-        this._domInput.removeEventListener('contextmenu', this._domEvtCtxMenu);
-        this._domInput = null;
-
-        super.destroy();
     }
 
     set value(value: string | number | Array<string | number>) {
@@ -322,9 +308,9 @@ class TextInput extends Input implements IFocusable, IPlaceholder {
 
         this._keyChange = value;
         if (value) {
-            this._domInput.addEventListener('keyup', this._domEvtKeyUp);
+            this._domInput.addEventListener('keyup', this._onInputKeyUp);
         } else {
-            this._domInput.removeEventListener('keyup', this._domEvtKeyUp);
+            this._domInput.removeEventListener('keyup', this._onInputKeyUp);
         }
     }
 

--- a/src/components/TreeViewItem/index.ts
+++ b/src/components/TreeViewItem/index.ts
@@ -110,26 +110,6 @@ class TreeViewItem extends Container {
 
     protected _treeOrder: number;
 
-    protected _domEvtFocus: any;
-
-    protected _domEvtBlur: any;
-
-    protected _domEvtKeyDown: any;
-
-    protected _domEvtDragStart: any;
-
-    protected _domEvtMouseDown: any;
-
-    protected _domEvtMouseUp: any;
-
-    protected _domEvtMouseOver: any;
-
-    protected _domEvtClick: any;
-
-    protected _domEvtDblClick: any;
-
-    protected _domEvtContextMenu: any;
-
     protected _treeView: any;
 
     protected _allowDrag: boolean;
@@ -190,26 +170,35 @@ class TreeViewItem extends Container {
         // used the the parent treeview
         this._treeOrder = -1;
 
-        this._domEvtFocus = this._onContentFocus.bind(this);
-        this._domEvtBlur = this._onContentBlur.bind(this);
-        this._domEvtKeyDown = this._onContentKeyDown.bind(this);
-        this._domEvtDragStart = this._onContentDragStart.bind(this);
-        this._domEvtMouseDown = this._onContentMouseDown.bind(this);
-        this._domEvtMouseUp = this._onContentMouseUp.bind(this);
-        this._domEvtMouseOver = this._onContentMouseOver.bind(this);
-        this._domEvtClick = this._onContentClick.bind(this);
-        this._domEvtDblClick = this._onContentDblClick.bind(this);
-        this._domEvtContextMenu = this._onContentContextMenu.bind(this);
+        const dom = this._containerContents.dom;
+        dom.addEventListener('focus', this._onContentFocus);
+        dom.addEventListener('blur', this._onContentBlur);
+        dom.addEventListener('keydown', this._onContentKeyDown);
+        dom.addEventListener('dragstart', this._onContentDragStart);
+        dom.addEventListener('mousedown', this._onContentMouseDown);
+        dom.addEventListener('mouseover', this._onContentMouseOver);
+        dom.addEventListener('click', this._onContentClick);
+        dom.addEventListener('dblclick', this._onContentDblClick);
+        dom.addEventListener('contextmenu', this._onContentContextMenu);
+    }
 
-        this._containerContents.dom.addEventListener('focus', this._domEvtFocus);
-        this._containerContents.dom.addEventListener('blur', this._domEvtBlur);
-        this._containerContents.dom.addEventListener('keydown', this._domEvtKeyDown);
-        this._containerContents.dom.addEventListener('dragstart', this._domEvtDragStart);
-        this._containerContents.dom.addEventListener('mousedown', this._domEvtMouseDown);
-        this._containerContents.dom.addEventListener('mouseover', this._domEvtMouseOver);
-        this._containerContents.dom.addEventListener('click', this._domEvtClick);
-        this._containerContents.dom.addEventListener('dblclick', this._domEvtDblClick);
-        this._containerContents.dom.addEventListener('contextmenu', this._domEvtContextMenu);
+    destroy() {
+        if (this._destroyed) return;
+
+        const dom = this._containerContents.dom;
+        dom.removeEventListener('focus', this._onContentFocus);
+        dom.removeEventListener('blur', this._onContentBlur);
+        dom.removeEventListener('keydown', this._onContentKeyDown);
+        dom.removeEventListener('dragstart', this._onContentDragStart);
+        dom.removeEventListener('mousedown', this._onContentMouseDown);
+        dom.removeEventListener('mouseover', this._onContentMouseOver);
+        dom.removeEventListener('click', this._onContentClick);
+        dom.removeEventListener('dblclick', this._onContentDblClick);
+        dom.removeEventListener('contextmenu', this._onContentContextMenu);
+
+        window.removeEventListener('mouseup', this._onContentMouseUp);
+
+        super.destroy();
     }
 
     protected _onAppendChild(element: any) {
@@ -240,7 +229,7 @@ class TreeViewItem extends Container {
         super._onRemoveChild(element);
     }
 
-    protected _onContentKeyDown(evt: KeyboardEvent) {
+    protected _onContentKeyDown = (evt: KeyboardEvent) => {
         const element = evt.target as HTMLElement;
         if (element.tagName.toLowerCase() === 'input') return;
 
@@ -249,26 +238,26 @@ class TreeViewItem extends Container {
         if (this._treeView) {
             this._treeView._onChildKeyDown(evt, this);
         }
-    }
+    };
 
-    protected _onContentMouseDown(evt: MouseEvent) {
+    protected _onContentMouseDown = (evt: MouseEvent) => {
         if (!this._treeView || !this._treeView.allowDrag || !this._allowDrag) return;
 
         this._treeView._updateModifierKeys(evt);
         evt.stopPropagation();
-    }
+    };
 
-    protected _onContentMouseUp(evt: MouseEvent) {
+    protected _onContentMouseUp = (evt: MouseEvent) => {
         evt.stopPropagation();
         evt.preventDefault();
 
-        window.removeEventListener('mouseup', this._domEvtMouseUp);
+        window.removeEventListener('mouseup', this._onContentMouseUp);
         if (this._treeView) {
             this._treeView._onChildDragEnd(evt, this);
         }
-    }
+    };
 
-    protected _onContentMouseOver(evt: MouseEvent) {
+    protected _onContentMouseOver = (evt: MouseEvent) => {
         evt.stopPropagation();
 
         if (this._treeView) {
@@ -277,9 +266,9 @@ class TreeViewItem extends Container {
 
         // allow hover event
         super._onMouseOver(evt);
-    }
+    };
 
-    protected _onContentDragStart(evt: DragEvent) {
+    protected _onContentDragStart = (evt: DragEvent) => {
         evt.stopPropagation();
         evt.preventDefault();
 
@@ -289,10 +278,10 @@ class TreeViewItem extends Container {
 
         this._treeView._onChildDragStart(evt, this);
 
-        window.addEventListener('mouseup', this._domEvtMouseUp);
-    }
+        window.addEventListener('mouseup', this._onContentMouseUp);
+    };
 
-    protected _onContentClick(evt: MouseEvent) {
+    protected _onContentClick = (evt: MouseEvent) => {
         if (!this.allowSelect || evt.button !== 0) return;
 
         const element = evt.target as HTMLElement;
@@ -313,7 +302,7 @@ class TreeViewItem extends Container {
         } else if (this._treeView) {
             this._treeView._onChildClick(evt, this);
         }
-    }
+    };
 
     protected _dfs(fn: (item: TreeViewItem) => void) {
         fn(this);
@@ -324,7 +313,7 @@ class TreeViewItem extends Container {
         }
     }
 
-    protected _onContentDblClick(evt: MouseEvent) {
+    protected _onContentDblClick = (evt: MouseEvent) => {
         if (!this._treeView || !this._treeView.allowRenaming || evt.button !== 0) return;
 
         const element = evt.target as HTMLElement;
@@ -342,21 +331,21 @@ class TreeViewItem extends Container {
         }
 
         this.rename();
-    }
+    };
 
-    protected _onContentContextMenu(evt: MouseEvent) {
+    protected _onContentContextMenu = (evt: MouseEvent) => {
         if (this._treeView && this._treeView._onContextMenu) {
             this._treeView._onContextMenu(evt, this);
         }
-    }
+    };
 
-    protected _onContentFocus(evt: FocusEvent) {
+    protected _onContentFocus = (evt: FocusEvent) => {
         this.emit('focus');
-    }
+    };
 
-    protected _onContentBlur(evt: FocusEvent) {
+    protected _onContentBlur = (evt: FocusEvent) => {
         this.emit('blur');
-    }
+    };
 
     rename() {
         this.classAdd(CLASS_RENAME);
@@ -402,24 +391,6 @@ class TreeViewItem extends Container {
 
     blur() {
         this._containerContents.dom.blur();
-    }
-
-    destroy() {
-        if (this._destroyed) return;
-
-        this._containerContents.dom.removeEventListener('focus', this._domEvtFocus);
-        this._containerContents.dom.removeEventListener('blur', this._domEvtBlur);
-        this._containerContents.dom.removeEventListener('keydown', this._domEvtKeyDown);
-        this._containerContents.dom.removeEventListener('mousedown', this._domEvtMouseDown);
-        this._containerContents.dom.removeEventListener('dragstart', this._domEvtDragStart);
-        this._containerContents.dom.removeEventListener('mouseover', this._domEvtMouseOver);
-        this._containerContents.dom.removeEventListener('click', this._domEvtClick);
-        this._containerContents.dom.removeEventListener('dblclick', this._domEvtDblClick);
-        this._containerContents.dom.removeEventListener('contextmenu', this._domEvtContextMenu);
-
-        window.removeEventListener('mouseup', this._domEvtMouseUp);
-
-        super.destroy();
     }
 
     /**

--- a/src/components/VectorInput/index.ts
+++ b/src/components/VectorInput/index.ts
@@ -61,7 +61,6 @@ class VectorInput extends Element implements IBindable, IFocusable, IPlaceholder
 
         const dimensions = Math.max(2, Math.min(4, args.dimensions));
 
-        const onInputChange = this._onInputChange.bind(this);
         this._inputs = new Array(dimensions);
         for (let i = 0; i < this._inputs.length; i++) {
             this._inputs[i] = new NumericInput({
@@ -73,7 +72,7 @@ class VectorInput extends Element implements IBindable, IFocusable, IPlaceholder
                 renderChanges: args.renderChanges,
                 placeholder: args.placeholder ? (Array.isArray(args.placeholder) ? args.placeholder[i] : args.placeholder) : null
             });
-            this._inputs[i].on('change', onInputChange);
+            this._inputs[i].on('change', this._onInputChange);
             this._inputs[i].on('focus', () => {
                 this.emit('focus');
             });
@@ -97,7 +96,7 @@ class VectorInput extends Element implements IBindable, IFocusable, IPlaceholder
         }
     }
 
-    protected _onInputChange() {
+    protected _onInputChange = () => {
         if (this._applyingChange) return;
 
         // check if any of our inputs have the multiple_values class
@@ -117,7 +116,7 @@ class VectorInput extends Element implements IBindable, IFocusable, IPlaceholder
         }
 
         this.emit('change', this.value);
-    }
+    };
 
     protected _updateValue(value: number[]) {
         this.class.remove(pcuiClass.MULTIPLE_VALUES);

--- a/src/components/VectorInput/index.ts
+++ b/src/components/VectorInput/index.ts
@@ -72,7 +72,9 @@ class VectorInput extends Element implements IBindable, IFocusable, IPlaceholder
                 renderChanges: args.renderChanges,
                 placeholder: args.placeholder ? (Array.isArray(args.placeholder) ? args.placeholder[i] : args.placeholder) : null
             });
-            this._inputs[i].on('change', this._onInputChange);
+            this._inputs[i].on('change', () => {
+                this._onInputChange();
+            });
             this._inputs[i].on('focus', () => {
                 this.emit('focus');
             });
@@ -96,7 +98,7 @@ class VectorInput extends Element implements IBindable, IFocusable, IPlaceholder
         }
     }
 
-    protected _onInputChange = () => {
+    protected _onInputChange() {
         if (this._applyingChange) return;
 
         // check if any of our inputs have the multiple_values class
@@ -116,7 +118,7 @@ class VectorInput extends Element implements IBindable, IFocusable, IPlaceholder
         }
 
         this.emit('change', this.value);
-    };
+    }
 
     protected _updateValue(value: number[]) {
         this.class.remove(pcuiClass.MULTIPLE_VALUES);


### PR DESCRIPTION
* Remove almost all occurrences of `.bind(this)` which is considered bad practice in TypeScript since the `bind` function throws away the type of a function. It's a useless indirection anyway because an arrow function will bind the `this` reference.
* Remove many more `any` types. Using `any` is considered bad practice in TypeScript and should only be used when porting JS to TS.
* Remove 3 more `@ts-ignore`s.
* Remove `NumericInput`'s `moz` prefixing of the Pointer Lock DOM event. Firefox has supported Pointer Lock without prefixing since [Sep 2015](https://caniuse.com/pointerlock).
* Move each element's `destroy` function to immediately after the `constructor`. This makes it easier to spot if created resources are destroyed and registered event handlers are removed.

All in all, this is quite an attractive refactor since it removes a reasonable amount of code and makes DOM event handling easier to visually parse.