### PR TITLE
Fix `mouseover` handling of `TreeViewItem`s

### DIFF
--- a/src/components/TreeView/index.ts
+++ b/src/components/TreeView/index.ts
@@ -18,15 +18,15 @@ const DRAG_AREA_AFTER = 'after';
  */
 export interface TreeViewArgs extends ContainerArgs {
     /**
-     * Whether dragging a {@link TreeViewItem} is allowed.
+     * Whether dragging a {@link TreeViewItem} is allowed. Defaults to `true`.
      */
     allowDrag?: boolean,
     /**
-     * Whether reordering {@link TreeViewItem}s is allowed.
+     * Whether reordering {@link TreeViewItem}s is allowed. Defaults to `true`.
      */
     allowReordering?: boolean,
     /**
-     * Whether renaming {@link TreeViewItem}s is allowed by double clicking on them.
+     * Whether renaming {@link TreeViewItem}s is allowed by double clicking on them. Defaults to `false`.
      */
     allowRenaming?: boolean,
     /**
@@ -142,7 +142,7 @@ class TreeView extends Container {
 
     protected _filter: string;
 
-    protected _filterResults: any[];
+    protected _filterResults: TreeViewItem[];
 
     protected _wasDraggingAllowedBeforeFiltering: boolean;
 
@@ -397,16 +397,16 @@ class TreeView extends Container {
     }
 
     // Called when a key is down on a child TreeViewItem.
-    protected _onChildKeyDown(evt: KeyboardEvent, element: any) {
+    protected _onChildKeyDown(evt: KeyboardEvent, item: TreeViewItem) {
         if (['Tab', 'ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].indexOf(evt.key) === -1) return;
 
         evt.preventDefault();
         evt.stopPropagation();
 
         if (evt.key === 'ArrowDown') {
-            // down - select next tree item
+            // select next tree item
             if (this._selectedItems.length) {
-                const next = this._findNextVisibleTreeItem(element);
+                const next = this._findNextVisibleTreeItem(item);
                 if (next) {
                     if (this._pressedShift || this._pressedCtrl) {
                         next.selected = true;
@@ -416,9 +416,9 @@ class TreeView extends Container {
                 }
             }
         } else if (evt.key === 'ArrowUp') {
-            // up - select previous tree item
+            // select previous tree item
             if (this._selectedItems.length) {
-                const prev = this._findPreviousVisibleTreeItem(element);
+                const prev = this._findPreviousVisibleTreeItem(item);
                 if (prev) {
                     if (this._pressedShift || this._pressedCtrl) {
                         prev.selected = true;
@@ -429,13 +429,13 @@ class TreeView extends Container {
             }
 
         } else if (evt.key === 'ArrowLeft') {
-            // left (close)
-            if (element.parent !== this) {
-                element.open = false;
+            // close selected tree item
+            if (item.parent !== this) {
+                item.open = false;
             }
         } else if (evt.key === 'ArrowRight') {
-            // right (open)
-            element.open = true;
+            // open selected tree item
+            item.open = true;
         } else if (evt.key === 'Tab') {
             // tab
             // skip
@@ -443,24 +443,24 @@ class TreeView extends Container {
     }
 
     // Called when we click on a child TreeViewItem
-    protected _onChildClick(evt: MouseEvent, element: TreeViewItem) {
+    protected _onChildClick(evt: MouseEvent, item: TreeViewItem) {
         if (evt.button !== 0) return;
-        if (!element.allowSelect) return;
+        if (!item.allowSelect) return;
 
         if (this._pressedCtrl) {
             // toggle selection when Ctrl is pressed
-            element.selected = !element.selected;
+            item.selected = !item.selected;
         } else if (this._pressedShift) {
             // on shift add to selection
-            if (!this._selectedItems.length || this._selectedItems.length === 1 && this._selectedItems[0] === element) {
-                element.selected = true;
+            if (!this._selectedItems.length || this._selectedItems.length === 1 && this._selectedItems[0] === item) {
+                item.selected = true;
                 return;
             }
 
             const selected = this._selectedItems[this._selectedItems.length - 1];
             this._openHierarchy(selected);
 
-            const children = this._getChildrenRange(selected, element);
+            const children = this._getChildrenRange(selected, item);
             children.forEach((child) => {
                 if (child.allowSelect) {
                     child.selected = true;
@@ -469,7 +469,7 @@ class TreeView extends Container {
 
         } else {
             // deselect other items
-            this._selectSingleItem(element);
+            this._selectSingleItem(item);
         }
     }
 
@@ -511,7 +511,7 @@ class TreeView extends Container {
         });
     }
 
-    protected _getChildIndex(item: { dom: any; }, parent: { dom: { childNodes: any; }; }) {
+    protected _getChildIndex(item: TreeViewItem, parent: TreeViewItem) {
         return Array.prototype.indexOf.call(parent.dom.childNodes, item.dom) - 1;
     }
 
@@ -770,14 +770,14 @@ class TreeView extends Container {
     };
 
     // Scroll treeview if we are dragging towards the edges
-    protected _scrollWhileDragging = () => {
+    protected _scrollWhileDragging() {
         if (!this._dragging) return;
         if (this._dragScroll === 0) return;
 
         this._dragScrollElement.dom.scrollTop += this._dragScroll * 8;
         this._dragOverItem = null;
         this._updateDragHandle();
-    };
+    }
 
     // Called while we drag the drag handle
     protected _onDragMove = (evt: MouseEvent) => {
@@ -955,7 +955,7 @@ class TreeView extends Container {
         const results = searchItems(searchArr, filter);
         if (!results.length) return;
 
-        results.forEach((item: any) => {
+        results.forEach((item: TreeViewItem) => {
             this._filterResults.push(item);
             item.class.add(CLASS_FILTER_RESULT);
         });
@@ -1088,7 +1088,9 @@ class TreeView extends Container {
                 window.removeEventListener('mousemove', this._onMouseMove);
                 window.addEventListener('mousemove', this._onMouseMove);
                 if (!this._dragScrollInterval) {
-                    this._dragScrollInterval = window.setInterval(this._scrollWhileDragging, 1000 / 60);
+                    this._dragScrollInterval = window.setInterval(() => {
+                        this._scrollWhileDragging();
+                    }, 1000 / 60);
                 }
             }
         } else {

--- a/src/components/TreeViewItem/index.ts
+++ b/src/components/TreeViewItem/index.ts
@@ -365,7 +365,7 @@ class TreeViewItem extends Container {
             this.focus();
         });
 
-        textInput.on('change', (value: any) => {
+        textInput.on('change', (value: string) => {
             value = value.trim();
             if (value) {
                 this.text = value;

--- a/src/components/TreeViewItem/index.ts
+++ b/src/components/TreeViewItem/index.ts
@@ -56,7 +56,7 @@ export interface TreeViewItemArgs extends ContainerArgs {
 }
 
 /**
- * Represents a Tree View Item to be added to a {@link TreeView}.
+ * A TreeViewItem is a single node in a hierarchical {@link TreeView} control.
  */
 class TreeViewItem extends Container {
     static readonly defaultArgs: TreeViewItemArgs = {

--- a/src/components/TreeViewItem/index.ts
+++ b/src/components/TreeViewItem/index.ts
@@ -231,7 +231,7 @@ class TreeViewItem extends Container {
 
     protected _onContentKeyDown = (evt: KeyboardEvent) => {
         const element = evt.target as HTMLElement;
-        if (element.tagName.toLowerCase() === 'input') return;
+        if (element.tagName === 'INPUT') return;
 
         if (!this.allowSelect) return;
 
@@ -264,8 +264,7 @@ class TreeViewItem extends Container {
             this._treeView._onChildDragOver(evt, this);
         }
 
-        // allow hover event
-        super._onMouseOver(evt);
+        this.emit('hover', evt);
     };
 
     protected _onContentDragStart = (evt: DragEvent) => {
@@ -285,7 +284,7 @@ class TreeViewItem extends Container {
         if (!this.allowSelect || evt.button !== 0) return;
 
         const element = evt.target as HTMLElement;
-        if (element.tagName.toLowerCase() === 'input') return;
+        if (element.tagName === 'INPUT') return;
 
         evt.stopPropagation();
 
@@ -317,7 +316,7 @@ class TreeViewItem extends Container {
         if (!this._treeView || !this._treeView.allowRenaming || evt.button !== 0) return;
 
         const element = evt.target as HTMLElement;
-        if (element.tagName.toLowerCase() === 'input') return;
+        if (element.tagName === 'INPUT') return;
 
         evt.stopPropagation();
         const rect = this._containerContents.dom.getBoundingClientRect();


### PR DESCRIPTION
Fix an issue introduced by #222 where `mouseover` events of `TreeViewItem`s would throw an exception.

Also took the opportunity to improve docs and types of `TreeView` related code.