### PR TITLE
More Stylelint fixes

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -2,17 +2,13 @@
     "extends": "stylelint-config-standard-scss",
     "rules": {
         "indentation": 4,
-        "color-function-notation": null,
-        "declaration-block-no-redundant-longhand-properties": null,
+        "color-function-notation": "legacy",
         "font-family-no-missing-generic-family-keyword": null,
-        "max-line-length": null,
         "no-descending-specificity": null,
         "no-duplicate-selectors": null,
-        "property-no-unknown": null,
         "scss/dollar-variable-pattern": null,
         "scss/no-global-function-names": null,
         "scss/at-extend-no-missing-placeholder": null,
-        "selector-class-pattern": null,
         "string-quotes": "single"
     }
 }

--- a/src/components/Button/style.scss
+++ b/src/components/Button/style.scss
@@ -1,6 +1,6 @@
 // buttons
 .pcui-button {
-    @extend .noSelect;
+    @extend .pcui-no-select;
 
     font-family: inherit;
     display: inline-block;

--- a/src/components/Canvas/style.scss
+++ b/src/components/Canvas/style.scss
@@ -1,3 +1,3 @@
 .pcui-canvas {
-    @extend .noSelect;
+    @extend .pcui-no-select;
 }

--- a/src/components/ColorPicker/style.scss
+++ b/src/components/ColorPicker/style.scss
@@ -1,6 +1,6 @@
 // color input
 .pcui-color-input {
-    @extend .noSelect;
+    @extend .pcui-no-select;
 
     position: relative;
     display: inline-block;
@@ -102,7 +102,7 @@
         transition: none;
 
         > .pick-rect {
-            @extend .noSelect;
+            @extend .pcui-no-select;
 
             position: relative;
             display: none;
@@ -146,7 +146,7 @@
         }
 
         > .pick-hue {
-            @extend .noSelect;
+            @extend .pcui-no-select;
 
             position: relative;
             display: none;
@@ -183,7 +183,7 @@
         }
 
         > .pick-opacity {
-            @extend .noSelect;
+            @extend .pcui-no-select;
 
             position: relative;
             display: none;

--- a/src/components/GridView/style.scss
+++ b/src/components/GridView/style.scss
@@ -1,8 +1,7 @@
 .pcui-gridview {
     @extend .pcui-flex;
 
-    flex-direction: row;
-    flex-wrap: wrap;
+    flex-flow: row wrap;
     align-content: flex-start;
 }
 

--- a/src/components/Label/style.scss
+++ b/src/components/Label/style.scss
@@ -24,7 +24,7 @@
         color: $text-secondary;
         white-space: nowrap;
 
-        @extend .fixedFont;
+        @extend .fixed-font;
 
         font-size: 12px;
     }
@@ -39,7 +39,7 @@
         color: $text-active;
         text-decoration: underline;
 
-        @extend .noSelect;
+        @extend .pcui-no-select;
     }
 }
 

--- a/src/components/LabelGroup/style.scss
+++ b/src/components/LabelGroup/style.scss
@@ -2,8 +2,7 @@
     @extend .pcui-flex;
 
     align-items: center;
-    flex-direction: row;
-    flex-wrap: nowrap;
+    flex-flow: row nowrap;
     margin: $element-margin;
 
     // set width for label and don't let it shrink

--- a/src/components/Overlay/style.scss
+++ b/src/components/Overlay/style.scss
@@ -16,7 +16,7 @@
 }
 
 .pcui-overlay-inner {
-    @extend .noSelect;
+    @extend .pcui-no-select;
 
     position: absolute;
     width: auto;

--- a/src/components/Panel/style.scss
+++ b/src/components/Panel/style.scss
@@ -5,8 +5,6 @@
 
 // header of panel
 .pcui-panel-header {
-    @extend .font-smooth;
-
     background-color: $bcg-darker;
     color: $text-primary;
     font-size: 12px;
@@ -20,9 +18,6 @@
     overflow: hidden;
     text-overflow: ellipsis;
     flex: 1;
-
-    @extend .font-smooth;
-
     color: inherit;
     font-size: inherit;
     white-space: inherit;

--- a/src/components/Progress/style.scss
+++ b/src/components/Progress/style.scss
@@ -12,7 +12,18 @@
         $second: rgba(darken($text-active, 17%), 1);
 
         background: $text-active;
-        background: linear-gradient(135deg, $first 0%, $first 25%, $second 26%, $second 50%, $first 51%, $first 75%, $second 76%, $second 100%);
+        background:
+            linear-gradient(
+                135deg,
+                $first 0%,
+                $first 25%,
+                $second 26%,
+                $second 50%,
+                $first 51%,
+                $first 75%,
+                $second 76%,
+                $second 100%
+            );
         background-position: 0 0;
         background-size: 24px 24px;
         background-repeat: repeat;
@@ -28,7 +39,18 @@
         $second: rgba(darken(#f77, 17%), 1);
 
         background: $text-active;
-        background: linear-gradient(135deg, $first 0%, $first 25%, $second 26%, $second 50%, $first 51%, $first 75%, $second 76%, $second 100%);
+        background:
+            linear-gradient(
+                135deg,
+                $first 0%,
+                $first 25%,
+                $second 26%,
+                $second 50%,
+                $first 51%,
+                $first 75%,
+                $second 76%,
+                $second 100%
+            );
         background-position: 0 0;
         background-size: 24px 24px;
         background-repeat: repeat;

--- a/src/components/SelectInput/style.scss
+++ b/src/components/SelectInput/style.scss
@@ -46,7 +46,7 @@
     line-height: 24px;
     font-size: 12px;
 
-    @extend .fixedFont;
+    @extend .fixed-font;
 
     transition: background-color 100ms, color 100ms;
 }
@@ -116,7 +116,7 @@
 
         font-size: 12px;
 
-        @extend .fixedFont;
+        @extend .fixed-font;
 
         height: 22px;
         line-height: 22px;
@@ -175,7 +175,7 @@
     > .pcui-label {
         padding: 0 5px 0 8px;
 
-        @extend .fixedFont;
+        @extend .fixed-font;
     }
 
     > .pcui-button {

--- a/src/components/SliderInput/style.scss
+++ b/src/components/SliderInput/style.scss
@@ -1,5 +1,5 @@
 .pcui-slider {
-    @extend .noSelect;
+    @extend .pcui-no-select;
 
     display: inline-flex;
     height: 24px;

--- a/src/components/TextAreaInput/style.scss
+++ b/src/components/TextAreaInput/style.scss
@@ -14,7 +14,7 @@
         outline: none;
         box-shadow: none;
 
-        @extend .fixedFont;
+        @extend .fixed-font;
 
         min-height: 44px;
         min-width: 172px;

--- a/src/components/TextInput/style.scss
+++ b/src/components/TextInput/style.scss
@@ -23,7 +23,7 @@
         outline: none;
         box-shadow: none;
 
-        @extend .fixedFont;
+        @extend .fixed-font;
     }
 
     &::before {
@@ -38,7 +38,7 @@
         content: '...';
         white-space: nowrap;
 
-        @extend .fixedFont;
+        @extend .fixed-font;
 
         top: 5px;
         font-size: 12px;

--- a/src/components/TreeView/style.scss
+++ b/src/components/TreeView/style.scss
@@ -1,5 +1,5 @@
 .pcui-treeview {
-    @extend .noSelect;
+    @extend .pcui-no-select;
 
     // make sure our width covers the largest visible tree item child
     // this does not work on Edge

--- a/src/scss/_pcui-common.scss
+++ b/src/scss/_pcui-common.scss
@@ -1,4 +1,4 @@
-.noSelect {
+.pcui-no-select {
     -webkit-touch-callout: none;
     user-select: none;
 }

--- a/src/scss/font-icon.scss
+++ b/src/scss/font-icon.scss
@@ -7,14 +7,6 @@
     font-style: normal;
 }
 
-.font-smooth {
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    font-smoothing: antialiased;
-}
-
 .font-icon {
     font-family: pc-icon;
-
-    @extend .font-smooth;
 }

--- a/src/scss/fonts-storybook.scss
+++ b/src/scss/fonts-storybook.scss
@@ -6,6 +6,7 @@
     font-weight: 100;
     font-display: swap;
     src: local('Montserrat Thin'), local('Montserrat-Thin'), url('https://fonts.gstatic.com/s/montserrat/v15/JTUQjIg1_i6t8kCHKm45_QpRyS7m0dR9pA.woff2') format('woff2');
+    /* stylelint-disable-next-line max-line-length */
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
@@ -15,6 +16,7 @@
     font-weight: 300;
     font-display: swap;
     src: local('Montserrat Light'), local('Montserrat-Light'), url('https://fonts.gstatic.com/s/montserrat/v15/JTURjIg1_i6t8kCHKm45_cJD3gnD_vx3rCs.woff2') format('woff2');
+    /* stylelint-disable-next-line max-line-length */
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
@@ -24,6 +26,7 @@
     font-weight: 400;
     font-display: swap;
     src: local('Montserrat Regular'), local('Montserrat-Regular'), url('https://fonts.gstatic.com/s/montserrat/v15/JTUSjIg1_i6t8kCHKm459WlhyyTh89Y.woff2') format('woff2');
+    /* stylelint-disable-next-line max-line-length */
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
@@ -33,6 +36,7 @@
     font-weight: 700;
     font-display: swap;
     src: local('Montserrat Bold'), local('Montserrat-Bold'), url('https://fonts.gstatic.com/s/montserrat/v15/JTURjIg1_i6t8kCHKm45_dJE3gnD_vx3rCs.woff2') format('woff2');
+    /* stylelint-disable-next-line max-line-length */
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
@@ -60,7 +64,7 @@
     font-style: normal;
 }
 
-.fixedFont {
+.fixed-font {
     font-family: inconsolatamedium, Monaco, Menlo, 'Ubuntu Mono', Consolas, source-code-pro, monospace;
     font-weight: normal;
     font-size: 12px;

--- a/src/scss/fonts.scss
+++ b/src/scss/fonts.scss
@@ -20,7 +20,7 @@
     font-style: normal;
 }
 
-.fixedFont {
+.fixed-font {
     font-family: inconsolatamedium, Monaco, Menlo, 'Ubuntu Mono', Consolas, source-code-pro, monospace;
     font-weight: normal;
     font-size: 12px;


### PR DESCRIPTION
5 more Styelint rules enabled:

* [color-function-notation](https://stylelint.io/user-guide/rules/color-function-notation)
* [declaration-block-no-redundant-longhand-properties](https://stylelint.io/user-guide/rules/declaration-block-no-redundant-longhand-properties)
* [max-line-length](https://stylelint.io/user-guide/rules/max-line-length)
* [property-no-unknown](https://stylelint.io/user-guide/rules/property-no-unknown)
* [selector-class-pattern](https://stylelint.io/user-guide/rules/selector-class-pattern)

Notes:
* Kebab-case naming for selectors is now enforced:
  * `noSelect` is now `pcui-no-select`
  * `fixedFont` is now `fixed-font` (wondering if this should really be `pcui-fixed-font`...)
* Font smoothing has been removed from the icon font. This might cause a visual change to the icon font in Webkit based browsers. However, my eyes can't discern any difference. For now, I'm removing it. This is especially since the selector was specifying the `font-smoothing` property which doesn't even exist! The property is actually called [`font-smooth`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-smooth) but PCUI has never used that. Also note that the MDN page also says: `Non-standard: This feature is non-standard and is not on a standards track. Do not use it on production sites facing the Web: it will not work for every user.`
