### PR TITLE
Fix `Button` font when adding to body element

### DIFF
--- a/src/components/Button/style.scss
+++ b/src/components/Button/style.scss
@@ -2,7 +2,6 @@
 .pcui-button {
     @extend .pcui-no-select;
 
-    font-family: inherit;
     display: inline-block;
     border: 1px solid $bcg-darkest;
     border-radius: 2px;


### PR DESCRIPTION
The `Button` CSS was inheriting `font-family` from the parent element, in this case `document.body`. This was the default font and was overriding the `font-regular` font specified by `pcui-element` [here](https://github.com/playcanvas/pcui/blob/af103365533c30dec9f8d1e27fbf627429a7ff10/src/components/Element/style.scss#L8). If the button is a child of any other PCUI element, the bug would not occur.

Fixes #233 