### PR TITLE
Refactor `SliderInput`

### DIFF
--- a/src/components/TextInput/index.ts
+++ b/src/components/TextInput/index.ts
@@ -50,7 +50,7 @@ class TextInput extends Input implements IFocusable, IPlaceholder {
 
     protected _onValidate: any;
 
-    protected _keyChange: any;
+    protected _keyChange: boolean;
 
     protected _renderChanges: boolean;
 

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -18,28 +18,6 @@ export function deepCopy(data: any) {
     return obj;
 }
 
-/**
- * Creates new properties on the target class that get / set the properties of the member.
- *
- * @param targetClass - The target class.
- * @param memberName - The name of the member of the target class that properties will be proxied to.
- * @param properties - A list of properties to be proxied.
- * @example
- * proxy(pcui.SliderInput, '_numericInput', ['max', 'min', 'placeholder']);
- */
-export function proxy(targetClass: any, memberName: string, properties: Array<string>) {
-    properties.forEach((property) => {
-        Object.defineProperty(targetClass.prototype, property, {
-            get: function () {
-                return this[memberName][property];
-            },
-            set: function (value) {
-                this[memberName][property] = value;
-            }
-        });
-    });
-}
-
 export function arrayEquals(lhs: Array<any>, rhs: Array<any>) {
     if (!lhs)
         return false;


### PR DESCRIPTION
* Eliminate uses of `Object.defineProperty` to programmatically add getters/setters to `SliderInput`. This prevents them from appearing in the docs or the types.
* Remove the `pre` property of the `SliderInput` args object (there for backwards compatibility of `precision`). I don't see it used by any other projects.
* Remove the utility `proxy` function which is no longer used.