### PR TITLE
Improve `Menu#position` docs

### DIFF
--- a/examples/overlay.html
+++ b/examples/overlay.html
@@ -43,7 +43,7 @@
         const btnYes = new Button({
             text: 'Yes'
         });
-        btnYes.on('click', function () {
+        btnYes.on('click', () => {
             overlay.hidden = true;
             setTimeout(() => {
                 overlay.hidden = false;

--- a/src/components/Menu/index.ts
+++ b/src/components/Menu/index.ts
@@ -166,10 +166,21 @@ class Menu extends Container implements IFocusable {
     }
 
     /**
-     * Positions the menu at the specified coordinates.
+     * Positions the top-left corner of the menu at the specified coordinates.
      *
      * @param x - The x coordinate.
      * @param y - The y coordinate.
+     * @example
+     * ```ts
+     * // open a context menu at the mouse position
+     * window.addEventListener('contextmenu', (event) => {
+     *     event.stopPropagation();
+     *     event.preventDefault();
+     *
+     *     menu.hidden = false;
+     *     menu.position(event.clientX, event.clientY);
+     * });
+     * ```
      */
     position(x: number, y: number) {
         const rect = this._containerMenuItems.dom.getBoundingClientRect();


### PR DESCRIPTION
Small improvements to the docs for `Menu#position` including a code sample.
This PR also switches a function to an arrow function in the examples.