### PR TITLE
Fix wheel event handler warning for `NumericInput`

### DIFF
--- a/src/components/NumericInput/index.ts
+++ b/src/components/NumericInput/index.ts
@@ -143,7 +143,7 @@ class NumericInput extends TextInput {
             this._sliderControl.dom.removeEventListener('mouseup', this._onSliderMouseUp);
 
             this._sliderControl.dom.removeEventListener("mousemove", this._onSliderMouseMove, false);
-            this._sliderControl.dom.removeEventListener("wheel", this._onSliderMouseWheel, false);
+            this._sliderControl.dom.removeEventListener("wheel", this._onSliderMouseWheel);
 
             document.removeEventListener('pointerlockchange', this._onPointerLockChange, false);
         }
@@ -221,11 +221,11 @@ class NumericInput extends TextInput {
     protected _onPointerLockChange = () => {
         if (this._isScrolling()) {
             this._sliderControl.dom.addEventListener("mousemove", this._onSliderMouseMove, false);
-            this._sliderControl.dom.addEventListener("wheel", this._onSliderMouseWheel, false);
+            this._sliderControl.dom.addEventListener("wheel", this._onSliderMouseWheel, { passive: true });
             this._sliderControl.class.add(CLASS_NUMERIC_INPUT_SLIDER_CONTROL_ACTIVE);
         } else {
             this._sliderControl.dom.removeEventListener("mousemove", this._onSliderMouseMove, false);
-            this._sliderControl.dom.removeEventListener("wheel", this._onSliderMouseWheel, false);
+            this._sliderControl.dom.removeEventListener("wheel", this._onSliderMouseWheel);
             this._sliderControl.class.remove(CLASS_NUMERIC_INPUT_SLIDER_CONTROL_ACTIVE);
         }
     };


### PR DESCRIPTION
Warning is no longer shown in the console.
Also, the `NumericInput` value now changes fluidly in response to mouse wheel rotation:

![passivefux](https://user-images.githubusercontent.com/697563/210284120-3ef58a5b-aa4e-4e2a-9c79-5573f48853e0.gif)

Fixes #240
