### PR TITLE
Remove empty objects from constructor calls

### DIFF
--- a/src/components/GradientPicker/index.ts
+++ b/src/components/GradientPicker/index.ts
@@ -214,7 +214,7 @@ class GradientPicker extends Element {
             }
         };
 
-        this._panel = new Panel({});
+        this._panel = new Panel();
         this._panel.class.add('color-panel');
         this.dom.appendChild(this._panel.dom);
 
@@ -274,7 +274,7 @@ class GradientPicker extends Element {
         this._bField = numberField.call(this, 'b');
         this._aField = numberField.call(this, 'a');
 
-        this._hexField = new TextInput({});
+        this._hexField = new TextInput();
         this._hexField.renderChanges = false;
         this._hexField.placeholder = '#';
         this._hexField.on('change', this.hexChangeHandler);
@@ -301,12 +301,12 @@ class GradientPicker extends Element {
 
         this.UI = {
             root: this.dom,
-            overlay: new Overlay({}),
+            overlay: new Overlay(),
             panel: document.createElement('div'),
             gradient: new Canvas({ useDevicePixelRatio: true }),
             checkerPattern: this.createCheckerPattern(),
             anchors: new Canvas({ useDevicePixelRatio: true }),
-            footer: new Panel({}),
+            footer: new Panel(),
             typeLabel: new Label({ text: 'Type' }),
             typeCombo: new SelectInput({
                 options: [{ t: '0', v: 'placeholder' }],
@@ -314,9 +314,9 @@ class GradientPicker extends Element {
             }),
             positionLabel: new Label({ text: 'Position' }),
             positionEdit: new NumericInput({ min: 0, max: 100, step: 1 }),
-            copyButton: new Button({}),
-            pasteButton: new Button({}),
-            deleteButton: new Button({}),
+            copyButton: new Button(),
+            pasteButton: new Button(),
+            deleteButton: new Button(),
             showSelectedPosition: new NumericInput({ min: 0, max: 100, step: 1, hideSlider: true }),
             showCrosshairPosition: document.createElement('div'),
             anchorAddCrossHair: document.createElement('div'),

--- a/src/components/GridViewItem/index.ts
+++ b/src/components/GridViewItem/index.ts
@@ -66,7 +66,7 @@ class GridViewItem extends Container implements IFocusable {
 
             this._radioButton = new RadioButton({
                 class: CLASS_RADIO_BUTTON,
-                binding: new BindingObserversToElement({})
+                binding: new BindingObserversToElement()
             });
 
             // @ts-ignore Remove radio button click event listener
@@ -80,7 +80,7 @@ class GridViewItem extends Container implements IFocusable {
 
         this._labelText = new Label({
             class: CLASS_TEXT,
-            binding: new BindingObserversToElement({})
+            binding: new BindingObserversToElement()
         });
 
         this.append(this._labelText);

--- a/src/components/MenuItem/index.ts
+++ b/src/components/MenuItem/index.ts
@@ -94,7 +94,7 @@ class MenuItem extends Container implements IBindable {
 
         this._icon = null;
 
-        this._labelText = new Label({});
+        this._labelText = new Label();
         this._containerContent.append(this._labelText);
 
         this._containerItems = new Container({

--- a/src/examples/BidirectionalBinding/index.stories.tsx
+++ b/src/examples/BidirectionalBinding/index.stories.tsx
@@ -22,8 +22,8 @@ const observer = new Observer({ text: 'Hello World' });
 export const Main = () => {
     return (
         <Container class="observer-container">
-            <TextInput link={{ observer, path: 'text' }} binding={new BindingTwoWay({})} value={observer.get('text')} />
-            <TextInput link={{ observer, path: 'text' }} binding={new BindingTwoWay({})} value={observer.get('text')} />
+            <TextInput link={{ observer, path: 'text' }} binding={new BindingTwoWay()} value={observer.get('text')} />
+            <TextInput link={{ observer, path: 'text' }} binding={new BindingTwoWay()} value={observer.get('text')} />
         </Container>
     );
 };

--- a/src/examples/Observer/index.stories.tsx
+++ b/src/examples/Observer/index.stories.tsx
@@ -24,8 +24,8 @@ const observer = new Observer({ text: 'Hello World' });
 export const Main = () => {
     return (
         <Container class="observer-container">
-            <TextInput class="observer-text-input" link={{ observer, path: 'text' }} binding={new BindingElementToObservers({})} value={observer.get('text')} />
-            <Label link={{ observer, path: 'text' }} binding={new BindingObserversToElement({})} />
+            <TextInput class="observer-text-input" link={{ observer, path: 'text' }} binding={new BindingElementToObservers()} value={observer.get('text')} />
+            <Label link={{ observer, path: 'text' }} binding={new BindingObserversToElement()} />
         </Container>
     );
 };


### PR DESCRIPTION
PCUI constructors can all handle undefined options objects. Specifying an empty object is redundant.