### PR TITLE
Correctly handle non-numeric values entered into NumericInput

### DIFF
--- a/src/components/NumericInput/index.ts
+++ b/src/components/NumericInput/index.ts
@@ -194,7 +194,7 @@ class NumericInput extends TextInput {
         }
     };
 
-    protected _onInputChange = (evt: any) => {
+    protected _onInputChange(evt: any) {
         // get the content of the input and pass it
         // @ts-ignore through our value setter
         this.value = this._domInput.value;

--- a/src/components/NumericInput/index.ts
+++ b/src/components/NumericInput/index.ts
@@ -198,7 +198,7 @@ class NumericInput extends TextInput {
         // get the content of the input and pass it
         // @ts-ignore through our value setter
         this.value = this._domInput.value;
-    };
+    }
 
     protected _onInputKeyDown = (evt: KeyboardEvent) => {
         if (!this.enabled || this.readOnly) return super._onInputKeyDown(evt);

--- a/src/components/TextInput/index.ts
+++ b/src/components/TextInput/index.ts
@@ -60,6 +60,8 @@ class TextInput extends Input implements IFocusable, IPlaceholder {
 
     protected _onInputKeyDownEvt: (evt: KeyboardEvent) => void;
 
+    protected _onInputChangeEvt: (evt: Event) => void;
+
     constructor(args: TextInputArgs = TextInput.defaultArgs) {
         args = { ...TextInput.defaultArgs, ...args };
         super(args.dom, args);
@@ -77,8 +79,9 @@ class TextInput extends Input implements IFocusable, IPlaceholder {
         input.autocomplete = "off";
 
         this._onInputKeyDownEvt = this._onInputKeyDown.bind(this);
+        this._onInputChangeEvt = this._onInputChange.bind(this);
 
-        input.addEventListener('change', this._onInputChange);
+        input.addEventListener('change', this._onInputChangeEvt);
         input.addEventListener('focus', this._onInputFocus);
         input.addEventListener('blur', this._onInputBlur);
         input.addEventListener('keydown', this._onInputKeyDownEvt);
@@ -120,7 +123,7 @@ class TextInput extends Input implements IFocusable, IPlaceholder {
         if (this._destroyed) return;
 
         const input = this._domInput;
-        input.removeEventListener('change', this._onInputChange);
+        input.removeEventListener('change', this._onInputChangeEvt);
         input.removeEventListener('focus', this._onInputFocus);
         input.removeEventListener('blur', this._onInputBlur);
         input.removeEventListener('keydown', this._onInputKeyDownEvt);
@@ -132,7 +135,7 @@ class TextInput extends Input implements IFocusable, IPlaceholder {
         super.destroy();
     }
 
-    protected _onInputChange = (evt: Event) => {
+    protected _onInputChange(evt: Event) {
         if (this._suspendInputChangeEvt) return;
 
         if (this._onValidate) {

--- a/src/components/TextInput/index.ts
+++ b/src/components/TextInput/index.ts
@@ -153,7 +153,7 @@ class TextInput extends Input implements IFocusable, IPlaceholder {
         if (this._binding) {
             this._binding.setValue(this.value);
         }
-    };
+    }
 
     protected _onInputFocus = (evt: FocusEvent) => {
         this.class.add(pcuiClass.FOCUS);


### PR DESCRIPTION
`_onInputChange` is overriding a method in the `TextInput` superclass so it must be a regular class method on the prototype and can't be an arrow function.

This bug is a regression introduced in #222