### PR TITLE
Simplify test for array element equality

### DIFF
--- a/src/components/BooleanInput/index.ts
+++ b/src/components/BooleanInput/index.ts
@@ -140,21 +140,14 @@ class BooleanInput extends Input implements IBindable, IFocusable {
     }
 
     /* eslint accessor-pairs: 0 */
-    set values(values: Array<boolean>) {
-        let different = false;
-        const value = values[0];
-        for (let i = 1; i < values.length; i++) {
-            if (values[i] !== value) {
-                different = true;
-                break;
-            }
-        }
+    set values(values: boolean[]) {
+        const allSame = values.every(v => v === values[0]);
 
-        if (different) {
+        if (allSame) {
+            this._updateValue(values[0]);
+        } else {
             this._updateValue(null);
             this.class.add(pcuiClass.MULTIPLE_VALUES);
-        } else {
-            this._updateValue(values[0]);
         }
     }
 }

--- a/src/components/BooleanInput/index.ts
+++ b/src/components/BooleanInput/index.ts
@@ -141,13 +141,13 @@ class BooleanInput extends Input implements IBindable, IFocusable {
 
     /* eslint accessor-pairs: 0 */
     set values(values: boolean[]) {
-        const allSame = values.every(v => v === values[0]);
+        const different = values.some(v => v !== values[0]);
 
-        if (allSame) {
-            this._updateValue(values[0]);
-        } else {
+        if (different) {
             this._updateValue(null);
             this.class.add(pcuiClass.MULTIPLE_VALUES);
+        } else {
+            this._updateValue(values[0]);
         }
     }
 }

--- a/src/components/ColorPicker/index.ts
+++ b/src/components/ColorPicker/index.ts
@@ -1,3 +1,5 @@
+import { EventHandle } from '@playcanvas/observer';
+
 import Element, { ElementArgs, IBindable, IBindableArgs } from '../Element/index';
 import Overlay from '../Overlay/index';
 import NumericInput from '../NumericInput/index';
@@ -37,7 +39,7 @@ class ColorPicker extends Element implements IBindable {
 
     protected _historyCombine: boolean;
 
-    protected _historyPostfix: any;
+    protected _historyPostfix: string;
 
     protected _value: number[];
 
@@ -79,13 +81,13 @@ class ColorPicker extends Element implements IBindable {
 
     protected _panelFields: HTMLDivElement;
 
-    protected _evtColorPick: any;
+    protected _evtColorPick: EventHandle;
 
-    protected _evtColorToPicker: any;
+    protected _evtColorToPicker: EventHandle;
 
-    protected _evtColorPickStart: any;
+    protected _evtColorPickStart: EventHandle;
 
-    protected _evtColorPickEnd: any;
+    protected _evtColorPickEnd: EventHandle;
 
     protected _fieldHex: TextInput;
 

--- a/src/components/Label/index.ts
+++ b/src/components/Label/index.ts
@@ -124,13 +124,13 @@ class Label extends Input implements IPlaceholder {
 
     /* eslint accessor-pairs: 0 */
     set values(values: string[]) {
-        const allSame = values.every(v => v === values[0]);
+        const different = values.some(v => v !== values[0]);
 
-        if (allSame) {
-            this._updateText(values[0]);
-        } else {
+        if (different) {
             this._updateText('');
             this.class.add(pcuiClass.MULTIPLE_VALUES);
+        } else {
+            this._updateText(values[0]);
         }
     }
 

--- a/src/components/Label/index.ts
+++ b/src/components/Label/index.ts
@@ -123,21 +123,14 @@ class Label extends Input implements IPlaceholder {
     }
 
     /* eslint accessor-pairs: 0 */
-    set values(values: Array<string>) {
-        let different = false;
-        const value = values[0];
-        for (let i = 1; i < values.length; i++) {
-            if (values[i] !== value) {
-                different = true;
-                break;
-            }
-        }
+    set values(values: string[]) {
+        const allSame = values.every(v => v === values[0]);
 
-        if (different) {
+        if (allSame) {
+            this._updateText(values[0]);
+        } else {
             this._updateText('');
             this.class.add(pcuiClass.MULTIPLE_VALUES);
-        } else {
-            this._updateText(values[0]);
         }
     }
 

--- a/src/components/NumericInput/index.ts
+++ b/src/components/NumericInput/index.ts
@@ -322,25 +322,19 @@ class NumericInput extends TextInput {
 
     /* eslint accessor-pairs: 0 */
     set values(values: Array<number>) {
-        let different = false;
-        const value = this._normalizeValue(values[0]);
-        for (let i = 1; i < values.length; i++) {
-            if (value !== this._normalizeValue(values[i])) {
-                different = true;
-                break;
-            }
-        }
+        const normalizedValues = values.map(v => this._normalizeValue(v));
+        const allSame = normalizedValues.every(v => value === normalizedValues[0]);
 
-        if (different) {
+        if (allSame) {
+            this._updateValue(normalizedValues[0]);
+            if (this._sliderControl) {
+                this._sliderControl.class.remove(CLASS_NUMERIC_INPUT_SLIDER_CONTROL_HIDDEN);
+            }
+        } else {
             this._updateValue(null);
             this.class.add(pcuiClass.MULTIPLE_VALUES);
             if (this._sliderControl) {
                 this._sliderControl.class.add(CLASS_NUMERIC_INPUT_SLIDER_CONTROL_HIDDEN);
-            }
-        } else {
-            this._updateValue(value);
-            if (this._sliderControl) {
-                this._sliderControl.class.remove(CLASS_NUMERIC_INPUT_SLIDER_CONTROL_HIDDEN);
             }
         }
     }

--- a/src/components/NumericInput/index.ts
+++ b/src/components/NumericInput/index.ts
@@ -323,18 +323,18 @@ class NumericInput extends TextInput {
     /* eslint accessor-pairs: 0 */
     set values(values: Array<number>) {
         const normalizedValues = values.map(v => this._normalizeValue(v));
-        const allSame = normalizedValues.every(v => value === normalizedValues[0]);
+        const different = normalizedValues.some(v => v !== normalizedValues[0]);
 
-        if (allSame) {
-            this._updateValue(normalizedValues[0]);
-            if (this._sliderControl) {
-                this._sliderControl.class.remove(CLASS_NUMERIC_INPUT_SLIDER_CONTROL_HIDDEN);
-            }
-        } else {
+        if (different) {
             this._updateValue(null);
             this.class.add(pcuiClass.MULTIPLE_VALUES);
             if (this._sliderControl) {
                 this._sliderControl.class.add(CLASS_NUMERIC_INPUT_SLIDER_CONTROL_HIDDEN);
+            }
+        } else {
+            this._updateValue(normalizedValues[0]);
+            if (this._sliderControl) {
+                this._sliderControl.class.remove(CLASS_NUMERIC_INPUT_SLIDER_CONTROL_HIDDEN);
             }
         }
     }

--- a/src/components/NumericInput/index.ts
+++ b/src/components/NumericInput/index.ts
@@ -321,7 +321,7 @@ class NumericInput extends TextInput {
     }
 
     /* eslint accessor-pairs: 0 */
-    set values(values: Array<number>) {
+    set values(values: number[]) {
         const normalizedValues = values.map(v => this._normalizeValue(v));
         const different = normalizedValues.some(v => v !== normalizedValues[0]);
 

--- a/src/components/RadioButton/index.ts
+++ b/src/components/RadioButton/index.ts
@@ -125,21 +125,14 @@ class RadioButton extends Element implements IBindable, IFocusable {
     }
 
     /* eslint accessor-pairs: 0 */
-    set values(values: Array<boolean>) {
-        let different = false;
-        const value = values[0];
-        for (let i = 1; i < values.length; i++) {
-            if (values[i] !== value) {
-                different = true;
-                break;
-            }
-        }
+    set values(values: boolean[]) {
+        const allSame = values.every(v => v === values[0]);
 
-        if (different) {
+        if (allSame) {
+            this._updateValue(values[0]);
+        } else {
             this._updateValue(null);
             this.class.add(pcuiClass.MULTIPLE_VALUES);
-        } else {
-            this._updateValue(values[0]);
         }
     }
 

--- a/src/components/RadioButton/index.ts
+++ b/src/components/RadioButton/index.ts
@@ -126,13 +126,13 @@ class RadioButton extends Element implements IBindable, IFocusable {
 
     /* eslint accessor-pairs: 0 */
     set values(values: boolean[]) {
-        const allSame = values.every(v => v === values[0]);
+        const different = values.some(v => v !== values[0]);
 
-        if (allSame) {
-            this._updateValue(values[0]);
-        } else {
+        if (different) {
             this._updateValue(null);
             this.class.add(pcuiClass.MULTIPLE_VALUES);
+        } else {
+            this._updateValue(values[0]);
         }
     }
 

--- a/src/components/TextInput/index.ts
+++ b/src/components/TextInput/index.ts
@@ -277,13 +277,13 @@ class TextInput extends Input implements IFocusable, IPlaceholder {
 
     /* eslint accessor-pairs: 0 */
     set values(values: Array<string | number>) {
-        const allSame = values.every(v => v === values[0]);
+        const different = values.some(v => v !== values[0]);
 
-        if (allSame) {
-            this._updateValue(values[0]);
-        } else {
+        if (different) {
             this._updateValue(null);
             this.class.add(pcuiClass.MULTIPLE_VALUES);
+        } else {
+            this._updateValue(values[0]);
         }
     }
 

--- a/src/components/TextInput/index.ts
+++ b/src/components/TextInput/index.ts
@@ -277,20 +277,13 @@ class TextInput extends Input implements IFocusable, IPlaceholder {
 
     /* eslint accessor-pairs: 0 */
     set values(values: Array<string | number>) {
-        let different = false;
-        const value = values[0];
-        for (let i = 1; i < values.length; i++) {
-            if (values[i] !== value) {
-                different = true;
-                break;
-            }
-        }
+        const allSame = values.every(v => v === values[0]);
 
-        if (different) {
+        if (allSame) {
+            this._updateValue(values[0]);
+        } else {
             this._updateValue(null);
             this.class.add(pcuiClass.MULTIPLE_VALUES);
-        } else {
-            this._updateValue(values[0]);
         }
     }
 


### PR DESCRIPTION
The current algorithm to test if any two elements in an array are different is quite verbose. This refactor switches to use `Array#some` to perform the check instead which is far more succinct.