### PR TITLE
VectorInput default precision value

### DIFF
--- a/src/components/VectorInput/index.ts
+++ b/src/components/VectorInput/index.ts
@@ -41,7 +41,8 @@ export interface VectorInputArgs extends ElementArgs, IPlaceholderArgs, IBindabl
 class VectorInput extends Element implements IBindable, IFocusable, IPlaceholder {
     static readonly defaultArgs: VectorInputArgs = {
         ...Element.defaultArgs,
-        dimensions: 3
+        dimensions: 3,
+        precision: 7
     };
 
     protected _inputs: NumericInput[] = [];


### PR DESCRIPTION
The VectorInput should have a default precision of value of 7 to match that of the NumericInput.

Fixes #253 