### PR TITLE
@playcanvas/observer as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ A full guide to using the PCUI library can be found [here](https://playcanvas.gi
 To install PCUI in your project, run the following npm commands:
 
 ```
-npm install --save @playcanvas/observer
 npm install --save @playcanvas/pcui
 ```
 

--- a/docs/pages/1-getting-started.markdown
+++ b/docs/pages/1-getting-started.markdown
@@ -10,7 +10,6 @@ nav_order: 1
 To add PCUI to your `package.json`, run the following in the project's directory:
 
 ```
-npm install --save-dev @playcanvas/observer
 npm install --save-dev @playcanvas/pcui
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,14 @@
       "name": "@playcanvas/pcui",
       "version": "3.0.0",
       "license": "MIT",
+      "dependencies": {
+        "@playcanvas/observer": "^1.3.5"
+      },
       "devDependencies": {
         "@babel/core": "^7.20.7",
         "@babel/preset-env": "^7.16.11",
         "@babel/preset-react": "^7.16.7",
         "@playcanvas/eslint-config": "^1.0.16",
-        "@playcanvas/observer": "^1.3.5",
         "@rollup/plugin-babel": "^6.0.3",
         "@rollup/plugin-node-resolve": "^15.0.1",
         "@rollup/plugin-replace": "^5.0.2",
@@ -4238,8 +4240,7 @@
     "node_modules/@playcanvas/observer": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@playcanvas/observer/-/observer-1.3.5.tgz",
-      "integrity": "sha512-+CXmz0XoyeebBhro+wW/fKdX8hbKchmoqb+BfB8UfzicnGAYM0cihvkhf57PH/U7FktN0xWXLCMDx0ImD0ecVQ==",
-      "dev": true
+      "integrity": "sha512-+CXmz0XoyeebBhro+wW/fKdX8hbKchmoqb+BfB8UfzicnGAYM0cihvkhf57PH/U7FktN0xWXLCMDx0ImD0ecVQ=="
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.5.9",
@@ -40855,8 +40856,7 @@
     "@playcanvas/observer": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@playcanvas/observer/-/observer-1.3.5.tgz",
-      "integrity": "sha512-+CXmz0XoyeebBhro+wW/fKdX8hbKchmoqb+BfB8UfzicnGAYM0cihvkhf57PH/U7FktN0xWXLCMDx0ImD0ecVQ==",
-      "dev": true
+      "integrity": "sha512-+CXmz0XoyeebBhro+wW/fKdX8hbKchmoqb+BfB8UfzicnGAYM0cihvkhf57PH/U7FktN0xWXLCMDx0ImD0ecVQ=="
     },
     "@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.5.9",

--- a/package.json
+++ b/package.json
@@ -83,12 +83,14 @@
       }
     }
   },
+  "dependencies": {
+    "@playcanvas/observer": "^1.3.5"
+  },
   "devDependencies": {
     "@babel/core": "^7.20.7",
     "@babel/preset-env": "^7.16.11",
     "@babel/preset-react": "^7.16.7",
     "@playcanvas/eslint-config": "^1.0.16",
-    "@playcanvas/observer": "^1.3.5",
     "@rollup/plugin-babel": "^6.0.3",
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@rollup/plugin-replace": "^5.0.2",


### PR DESCRIPTION
Set the observer as a package.json dependency so that users will not need to install it themselves when using the PCUI library.

Fixes #255 