### PR TITLE
package.json exports field

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,11 @@
   "description": "This library enables the creation of reliable and visually pleasing user interfaces by providing fully styled components that you can use directly on your site. The components are useful in a wide range of use cases, from creating simple forms to building graphical user interfaces for complex web tools.",
   "license": "MIT",
   "main": "dist/module/src/index.mjs",
+  "exports": {
+    ".": "./dist/module/src/index.mjs",
+    "./react": "./react/dist/module/src/index.mjs",
+    "./styles": "./styles/dist/index.mjs"
+  },
   "types": "types/index.d.ts",
   "bugs": {
     "url": "https://github.com/playcanvas/pcui/issues"


### PR DESCRIPTION
Include an exports field in the package.json file which can be used to locate the subpaths of the PCUI library.