### PR TITLE
Merge both build types scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "build:docsite:local": "cd docs && bundle exec jekyll build --config _config_local.yml && mkdir _site/storybook && cd .. && ENVIRONMENT=production build-storybook --no-dll -o ./docs/_site/storybook && cp -r ./typedocs ./docs/_site/typedocs",
     "build:docsite:production": "cd docs && bundle exec jekyll build --config _config.yml && mkdir _site/storybook && cd .. && ENVIRONMENT=production build-storybook --no-dll -o ./docs/_site/storybook && cp -r ./typedocs ./docs/_site/typedocs",
     "docsite:serve": "serve docs/_site -p 3497",
-    "build:types": "tsc --project ./tsconfig.json --declaration --emitDeclarationOnly --outDir types",
+    "build:types": "tsc --project ./tsconfig.json --declaration --emitDeclarationOnly --outDir types && tsc --project ./react/tsconfig.json --declaration --emitDeclarationOnly --outDir ./react/types",
     "build:typedocs": "typedoc --tsconfig ./tsconfig.json",
     "storybook": "start-storybook -p 9009 -s public"
   },

--- a/react/package.json
+++ b/react/package.json
@@ -14,8 +14,5 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/playcanvas/pcui.git"
-  },
-  "scripts": {
-    "build:types": "tsc --project ./tsconfig.json --declaration --emitDeclarationOnly --outDir types"
   }
 }


### PR DESCRIPTION
The library contains two scripts to build types, one for the main module build and another for the react module build. Currently the react build script is hidden within its own package.json file. Instead this can be built along with the main type declarations.