### PR TITLE
Switch examples from unpkg to skypack

### DIFF
--- a/examples/arrayinput.html
+++ b/examples/arrayinput.html
@@ -16,9 +16,8 @@
     <script type="importmap">
         {
             "imports": {
-                "@playcanvas/observer": "https://unpkg.com/@playcanvas/observer/dist/index.mjs",
-                "@playcanvas/pcui": "https://unpkg.com/@playcanvas/pcui/dist/module/src/index.mjs",
-                "@playcanvas/pcui/styles": "https://unpkg.com/@playcanvas/pcui/styles/dist/index.mjs"
+                "@playcanvas/pcui": "https://cdn.skypack.dev/@playcanvas/pcui",
+                "@playcanvas/pcui/styles": "https://cdn.skypack.dev/@playcanvas/pcui/styles"
             }
         }
     </script>

--- a/examples/booleaninput.html
+++ b/examples/booleaninput.html
@@ -16,9 +16,8 @@
     <script type="importmap">
         {
             "imports": {
-                "@playcanvas/observer": "https://unpkg.com/@playcanvas/observer/dist/index.mjs",
-                "@playcanvas/pcui": "https://unpkg.com/@playcanvas/pcui/dist/module/src/index.mjs",
-                "@playcanvas/pcui/styles": "https://unpkg.com/@playcanvas/pcui/styles/dist/index.mjs"
+                "@playcanvas/pcui": "https://cdn.skypack.dev/@playcanvas/pcui",
+                "@playcanvas/pcui/styles": "https://cdn.skypack.dev/@playcanvas/pcui/styles"
             }
         }
     </script>

--- a/examples/button.html
+++ b/examples/button.html
@@ -16,9 +16,8 @@
     <script type="importmap">
         {
             "imports": {
-                "@playcanvas/observer": "https://unpkg.com/@playcanvas/observer/dist/index.mjs",
-                "@playcanvas/pcui": "https://unpkg.com/@playcanvas/pcui/dist/module/src/index.mjs",
-                "@playcanvas/pcui/styles": "https://unpkg.com/@playcanvas/pcui/styles/dist/index.mjs"
+                "@playcanvas/pcui": "https://cdn.skypack.dev/@playcanvas/pcui",
+                "@playcanvas/pcui/styles": "https://cdn.skypack.dev/@playcanvas/pcui/styles"
             }
         }
     </script>

--- a/examples/canvas.html
+++ b/examples/canvas.html
@@ -16,9 +16,8 @@
     <script type="importmap">
         {
             "imports": {
-                "@playcanvas/observer": "https://unpkg.com/@playcanvas/observer/dist/index.mjs",
-                "@playcanvas/pcui": "https://unpkg.com/@playcanvas/pcui/dist/module/src/index.mjs",
-                "@playcanvas/pcui/styles": "https://unpkg.com/@playcanvas/pcui/styles/dist/index.mjs"
+                "@playcanvas/pcui": "https://cdn.skypack.dev/@playcanvas/pcui",
+                "@playcanvas/pcui/styles": "https://cdn.skypack.dev/@playcanvas/pcui/styles"
             }
         }
     </script>

--- a/examples/code.html
+++ b/examples/code.html
@@ -16,9 +16,8 @@
     <script type="importmap">
         {
             "imports": {
-                "@playcanvas/observer": "https://unpkg.com/@playcanvas/observer/dist/index.mjs",
-                "@playcanvas/pcui": "https://unpkg.com/@playcanvas/pcui/dist/module/src/index.mjs",
-                "@playcanvas/pcui/styles": "https://unpkg.com/@playcanvas/pcui/styles/dist/index.mjs"
+                "@playcanvas/pcui": "https://cdn.skypack.dev/@playcanvas/pcui",
+                "@playcanvas/pcui/styles": "https://cdn.skypack.dev/@playcanvas/pcui/styles"
             }
         }
     </script>

--- a/examples/colorpicker.html
+++ b/examples/colorpicker.html
@@ -20,9 +20,8 @@
     <script type="importmap">
         {
             "imports": {
-                "@playcanvas/observer": "https://unpkg.com/@playcanvas/observer/dist/index.mjs",
-                "@playcanvas/pcui": "https://unpkg.com/@playcanvas/pcui/dist/module/src/index.mjs",
-                "@playcanvas/pcui/styles": "https://unpkg.com/@playcanvas/pcui/styles/dist/index.mjs"
+                "@playcanvas/pcui": "https://cdn.skypack.dev/@playcanvas/pcui",
+                "@playcanvas/pcui/styles": "https://cdn.skypack.dev/@playcanvas/pcui/styles"
             }
         }
     </script>

--- a/examples/divider.html
+++ b/examples/divider.html
@@ -16,9 +16,8 @@
     <script type="importmap">
         {
             "imports": {
-                "@playcanvas/observer": "https://unpkg.com/@playcanvas/observer/dist/index.mjs",
-                "@playcanvas/pcui": "https://unpkg.com/@playcanvas/pcui/dist/module/src/index.mjs",
-                "@playcanvas/pcui/styles": "https://unpkg.com/@playcanvas/pcui/styles/dist/index.mjs"
+                "@playcanvas/pcui": "https://cdn.skypack.dev/@playcanvas/pcui",
+                "@playcanvas/pcui/styles": "https://cdn.skypack.dev/@playcanvas/pcui/styles"
             }
         }
     </script>

--- a/examples/gradientpicker.html
+++ b/examples/gradientpicker.html
@@ -16,9 +16,8 @@
     <script type="importmap">
         {
             "imports": {
-                "@playcanvas/observer": "https://unpkg.com/@playcanvas/observer/dist/index.mjs",
-                "@playcanvas/pcui": "https://unpkg.com/@playcanvas/pcui/dist/module/src/index.mjs",
-                "@playcanvas/pcui/styles": "https://unpkg.com/@playcanvas/pcui/styles/dist/index.mjs"
+                "@playcanvas/pcui": "https://cdn.skypack.dev/@playcanvas/pcui",
+                "@playcanvas/pcui/styles": "https://cdn.skypack.dev/@playcanvas/pcui/styles"
             }
         }
     </script>

--- a/examples/gridview.html
+++ b/examples/gridview.html
@@ -16,9 +16,8 @@
     <script type="importmap">
         {
             "imports": {
-                "@playcanvas/observer": "https://unpkg.com/@playcanvas/observer/dist/index.mjs",
-                "@playcanvas/pcui": "https://unpkg.com/@playcanvas/pcui/dist/module/src/index.mjs",
-                "@playcanvas/pcui/styles": "https://unpkg.com/@playcanvas/pcui/styles/dist/index.mjs"
+                "@playcanvas/pcui": "https://cdn.skypack.dev/@playcanvas/pcui",
+                "@playcanvas/pcui/styles": "https://cdn.skypack.dev/@playcanvas/pcui/styles"
             }
         }
     </script>

--- a/examples/index.html
+++ b/examples/index.html
@@ -30,9 +30,8 @@
     <script type="importmap">
         {
             "imports": {
-                "@playcanvas/observer": "https://unpkg.com/@playcanvas/observer/dist/index.mjs",
-                "@playcanvas/pcui": "https://unpkg.com/@playcanvas/pcui/dist/module/src/index.mjs",
-                "@playcanvas/pcui/styles": "https://unpkg.com/@playcanvas/pcui/styles/dist/index.mjs"
+                "@playcanvas/pcui": "https://cdn.skypack.dev/@playcanvas/pcui",
+                "@playcanvas/pcui/styles": "https://cdn.skypack.dev/@playcanvas/pcui/styles"
             }
         }
     </script>

--- a/examples/infobox.html
+++ b/examples/infobox.html
@@ -16,9 +16,8 @@
     <script type="importmap">
         {
             "imports": {
-                "@playcanvas/observer": "https://unpkg.com/@playcanvas/observer/dist/index.mjs",
-                "@playcanvas/pcui": "https://unpkg.com/@playcanvas/pcui/dist/module/src/index.mjs",
-                "@playcanvas/pcui/styles": "https://unpkg.com/@playcanvas/pcui/styles/dist/index.mjs"
+                "@playcanvas/pcui": "https://cdn.skypack.dev/@playcanvas/pcui",
+                "@playcanvas/pcui/styles": "https://cdn.skypack.dev/@playcanvas/pcui/styles"
             }
         }
     </script>

--- a/examples/label.html
+++ b/examples/label.html
@@ -16,9 +16,8 @@
     <script type="importmap">
         {
             "imports": {
-                "@playcanvas/observer": "https://unpkg.com/@playcanvas/observer/dist/index.mjs",
-                "@playcanvas/pcui": "https://unpkg.com/@playcanvas/pcui/dist/module/src/index.mjs",
-                "@playcanvas/pcui/styles": "https://unpkg.com/@playcanvas/pcui/styles/dist/index.mjs"
+                "@playcanvas/pcui": "https://cdn.skypack.dev/@playcanvas/pcui",
+                "@playcanvas/pcui/styles": "https://cdn.skypack.dev/@playcanvas/pcui/styles"
             }
         }
     </script>

--- a/examples/labelgroup.html
+++ b/examples/labelgroup.html
@@ -16,9 +16,8 @@
     <script type="importmap">
         {
             "imports": {
-                "@playcanvas/observer": "https://unpkg.com/@playcanvas/observer/dist/index.mjs",
-                "@playcanvas/pcui": "https://unpkg.com/@playcanvas/pcui/dist/module/src/index.mjs",
-                "@playcanvas/pcui/styles": "https://unpkg.com/@playcanvas/pcui/styles/dist/index.mjs"
+                "@playcanvas/pcui": "https://cdn.skypack.dev/@playcanvas/pcui",
+                "@playcanvas/pcui/styles": "https://cdn.skypack.dev/@playcanvas/pcui/styles"
             }
         }
     </script>

--- a/examples/numericinput.html
+++ b/examples/numericinput.html
@@ -16,9 +16,8 @@
     <script type="importmap">
         {
             "imports": {
-                "@playcanvas/observer": "https://unpkg.com/@playcanvas/observer/dist/index.mjs",
-                "@playcanvas/pcui": "https://unpkg.com/@playcanvas/pcui/dist/module/src/index.mjs",
-                "@playcanvas/pcui/styles": "https://unpkg.com/@playcanvas/pcui/styles/dist/index.mjs"
+                "@playcanvas/pcui": "https://cdn.skypack.dev/@playcanvas/pcui",
+                "@playcanvas/pcui/styles": "https://cdn.skypack.dev/@playcanvas/pcui/styles"
             }
         }
     </script>

--- a/examples/overlay.html
+++ b/examples/overlay.html
@@ -20,9 +20,8 @@
     <script type="importmap">
         {
             "imports": {
-                "@playcanvas/observer": "https://unpkg.com/@playcanvas/observer/dist/index.mjs",
-                "@playcanvas/pcui": "https://unpkg.com/@playcanvas/pcui/dist/module/src/index.mjs",
-                "@playcanvas/pcui/styles": "https://unpkg.com/@playcanvas/pcui/styles/dist/index.mjs"
+                "@playcanvas/pcui": "https://cdn.skypack.dev/@playcanvas/pcui",
+                "@playcanvas/pcui/styles": "https://cdn.skypack.dev/@playcanvas/pcui/styles"
             }
         }
     </script>

--- a/examples/panel.html
+++ b/examples/panel.html
@@ -16,9 +16,8 @@
     <script type="importmap">
         {
             "imports": {
-                "@playcanvas/observer": "https://unpkg.com/@playcanvas/observer/dist/index.mjs",
-                "@playcanvas/pcui": "https://unpkg.com/@playcanvas/pcui/dist/module/src/index.mjs",
-                "@playcanvas/pcui/styles": "https://unpkg.com/@playcanvas/pcui/styles/dist/index.mjs"
+                "@playcanvas/pcui": "https://cdn.skypack.dev/@playcanvas/pcui",
+                "@playcanvas/pcui/styles": "https://cdn.skypack.dev/@playcanvas/pcui/styles"
             }
         }
     </script>

--- a/examples/progress.html
+++ b/examples/progress.html
@@ -16,9 +16,8 @@
     <script type="importmap">
         {
             "imports": {
-                "@playcanvas/observer": "https://unpkg.com/@playcanvas/observer/dist/index.mjs",
-                "@playcanvas/pcui": "https://unpkg.com/@playcanvas/pcui/dist/module/src/index.mjs",
-                "@playcanvas/pcui/styles": "https://unpkg.com/@playcanvas/pcui/styles/dist/index.mjs"
+                "@playcanvas/pcui": "https://cdn.skypack.dev/@playcanvas/pcui",
+                "@playcanvas/pcui/styles": "https://cdn.skypack.dev/@playcanvas/pcui/styles"
             }
         }
     </script>

--- a/examples/radiobutton.html
+++ b/examples/radiobutton.html
@@ -16,9 +16,8 @@
     <script type="importmap">
         {
             "imports": {
-                "@playcanvas/observer": "https://unpkg.com/@playcanvas/observer/dist/index.mjs",
-                "@playcanvas/pcui": "https://unpkg.com/@playcanvas/pcui/dist/module/src/index.mjs",
-                "@playcanvas/pcui/styles": "https://unpkg.com/@playcanvas/pcui/styles/dist/index.mjs"
+                "@playcanvas/pcui": "https://cdn.skypack.dev/@playcanvas/pcui",
+                "@playcanvas/pcui/styles": "https://cdn.skypack.dev/@playcanvas/pcui/styles"
             }
         }
     </script>

--- a/examples/selectinput.html
+++ b/examples/selectinput.html
@@ -16,9 +16,8 @@
     <script type="importmap">
         {
             "imports": {
-                "@playcanvas/observer": "https://unpkg.com/@playcanvas/observer/dist/index.mjs",
-                "@playcanvas/pcui": "https://unpkg.com/@playcanvas/pcui/dist/module/src/index.mjs",
-                "@playcanvas/pcui/styles": "https://unpkg.com/@playcanvas/pcui/styles/dist/index.mjs"
+                "@playcanvas/pcui": "https://cdn.skypack.dev/@playcanvas/pcui",
+                "@playcanvas/pcui/styles": "https://cdn.skypack.dev/@playcanvas/pcui/styles"
             }
         }
     </script>

--- a/examples/sliderinput.html
+++ b/examples/sliderinput.html
@@ -16,9 +16,8 @@
     <script type="importmap">
         {
             "imports": {
-                "@playcanvas/observer": "https://unpkg.com/@playcanvas/observer/dist/index.mjs",
-                "@playcanvas/pcui": "https://unpkg.com/@playcanvas/pcui/dist/module/src/index.mjs",
-                "@playcanvas/pcui/styles": "https://unpkg.com/@playcanvas/pcui/styles/dist/index.mjs"
+                "@playcanvas/pcui": "https://cdn.skypack.dev/@playcanvas/pcui",
+                "@playcanvas/pcui/styles": "https://cdn.skypack.dev/@playcanvas/pcui/styles"
             }
         }
     </script>

--- a/examples/spinner.html
+++ b/examples/spinner.html
@@ -16,9 +16,8 @@
     <script type="importmap">
         {
             "imports": {
-                "@playcanvas/observer": "https://unpkg.com/@playcanvas/observer/dist/index.mjs",
-                "@playcanvas/pcui": "https://unpkg.com/@playcanvas/pcui/dist/module/src/index.mjs",
-                "@playcanvas/pcui/styles": "https://unpkg.com/@playcanvas/pcui/styles/dist/index.mjs"
+                "@playcanvas/pcui": "https://cdn.skypack.dev/@playcanvas/pcui",
+                "@playcanvas/pcui/styles": "https://cdn.skypack.dev/@playcanvas/pcui/styles"
             }
         }
     </script>

--- a/examples/textareainput.html
+++ b/examples/textareainput.html
@@ -16,9 +16,8 @@
     <script type="importmap">
         {
             "imports": {
-                "@playcanvas/observer": "https://unpkg.com/@playcanvas/observer/dist/index.mjs",
-                "@playcanvas/pcui": "https://unpkg.com/@playcanvas/pcui/dist/module/src/index.mjs",
-                "@playcanvas/pcui/styles": "https://unpkg.com/@playcanvas/pcui/styles/dist/index.mjs"
+                "@playcanvas/pcui": "https://cdn.skypack.dev/@playcanvas/pcui",
+                "@playcanvas/pcui/styles": "https://cdn.skypack.dev/@playcanvas/pcui/styles"
             }
         }
     </script>

--- a/examples/textinput.html
+++ b/examples/textinput.html
@@ -16,9 +16,8 @@
     <script type="importmap">
         {
             "imports": {
-                "@playcanvas/observer": "https://unpkg.com/@playcanvas/observer/dist/index.mjs",
-                "@playcanvas/pcui": "https://unpkg.com/@playcanvas/pcui/dist/module/src/index.mjs",
-                "@playcanvas/pcui/styles": "https://unpkg.com/@playcanvas/pcui/styles/dist/index.mjs"
+                "@playcanvas/pcui": "https://cdn.skypack.dev/@playcanvas/pcui",
+                "@playcanvas/pcui/styles": "https://cdn.skypack.dev/@playcanvas/pcui/styles"
             }
         }
     </script>

--- a/examples/treeview.html
+++ b/examples/treeview.html
@@ -21,9 +21,8 @@
     <script type="importmap">
         {
             "imports": {
-                "@playcanvas/observer": "https://unpkg.com/@playcanvas/observer/dist/index.mjs",
-                "@playcanvas/pcui": "https://unpkg.com/@playcanvas/pcui/dist/module/src/index.mjs",
-                "@playcanvas/pcui/styles": "https://unpkg.com/@playcanvas/pcui/styles/dist/index.mjs"
+                "@playcanvas/pcui": "https://cdn.skypack.dev/@playcanvas/pcui",
+                "@playcanvas/pcui/styles": "https://cdn.skypack.dev/@playcanvas/pcui/styles"
             }
         }
     </script>

--- a/examples/vectorinput.html
+++ b/examples/vectorinput.html
@@ -16,9 +16,8 @@
     <script type="importmap">
         {
             "imports": {
-                "@playcanvas/observer": "https://unpkg.com/@playcanvas/observer/dist/index.mjs",
-                "@playcanvas/pcui": "https://unpkg.com/@playcanvas/pcui/dist/module/src/index.mjs",
-                "@playcanvas/pcui/styles": "https://unpkg.com/@playcanvas/pcui/styles/dist/index.mjs"
+                "@playcanvas/pcui": "https://cdn.skypack.dev/@playcanvas/pcui",
+                "@playcanvas/pcui/styles": "https://cdn.skypack.dev/@playcanvas/pcui/styles"
             }
         }
     </script>


### PR DESCRIPTION
Skypack respects the `exports` field in `package.json`, meaning:

* `@playcanvas/observer` is no longer needed in the importmap
* the path into the package is no longer needed in the importmap