### PR TITLE
Remove the defaultArgs property from components

### DIFF
--- a/src/components/ArrayInput/index.ts
+++ b/src/components/ArrayInput/index.ts
@@ -39,11 +39,11 @@ export interface ArrayInputArgs extends ElementArgs, IBindableArgs {
      */
     fixedSize?: boolean;
     /**
-     * If `true` then the array will be rendered using panels.
+     * If `true` then the array will be rendered using panels. Defaults to false.
      */
     usePanels?: boolean;
     /**
-     * Used to specify the default values for each element in the array. Can be left null.
+     * Used to specify the default values for each element in the array. Defaults to null.
      */
     getDefaultFn?: () => any;
 }
@@ -52,12 +52,6 @@ export interface ArrayInputArgs extends ElementArgs, IBindableArgs {
  * Element that allows editing an array of values.
  */
 class ArrayInput extends Element implements IFocusable, IBindable {
-    static readonly defaultArgs: ArrayInputArgs = {
-        ...Element.defaultArgs,
-        getDefaultFn: null,
-        usePanels: false
-    };
-
     /**
      * Fired when an array element is linked to observers.
      *
@@ -123,9 +117,7 @@ class ArrayInput extends Element implements IFocusable, IBindable {
 
     protected _renderChanges: boolean;
 
-    constructor(args: ArrayInputArgs = ArrayInput.defaultArgs) {
-        args = { ...ArrayInput.defaultArgs, ...args };
-
+    constructor(args: ArrayInputArgs = {}) {
         // remove binding because we want to set it later
         const binding = args.binding;
         delete args.binding;
@@ -142,7 +134,7 @@ class ArrayInput extends Element implements IFocusable, IBindable {
 
         this.class.add(CLASS_ARRAY_INPUT, CLASS_ARRAY_EMPTY);
 
-        this._usePanels = args.usePanels;
+        this._usePanels = args.usePanels ?? false;
 
         this._fixedSize = !!args.fixedSize;
 
@@ -182,7 +174,7 @@ class ArrayInput extends Element implements IFocusable, IBindable {
         this._suspendArrayElementEvts = false;
         this._arrayElementChangeTimeout = null;
 
-        this._getDefaultFn = args.getDefaultFn;
+        this._getDefaultFn = args.getDefaultFn ?? null;
 
         // @ts-ignore
         let valueType = args.elementArgs && args.elementArgs.type || args.type;

--- a/src/components/ArrayInput/index.ts
+++ b/src/components/ArrayInput/index.ts
@@ -43,7 +43,7 @@ export interface ArrayInputArgs extends ElementArgs, IBindableArgs {
      */
     usePanels?: boolean;
     /**
-     * Used to specify the default values for each element in the array. Defaults to null.
+     * Used to specify the default values for each element in the array. Defaults to `null`.
      */
     getDefaultFn?: () => any;
 }

--- a/src/components/ArrayInput/index.ts
+++ b/src/components/ArrayInput/index.ts
@@ -39,7 +39,7 @@ export interface ArrayInputArgs extends ElementArgs, IBindableArgs {
      */
     fixedSize?: boolean;
     /**
-     * If `true` then the array will be rendered using panels. Defaults to false.
+     * If `true` then the array will be rendered using panels. Defaults to `false`.
      */
     usePanels?: boolean;
     /**

--- a/src/components/BooleanInput/component.tsx
+++ b/src/components/BooleanInput/component.tsx
@@ -5,7 +5,7 @@ import BaseComponent from '../Element/component';
  * A checkbox element.
  */
 class Component extends BaseComponent <BooleanInputArgs, any> {
-    constructor(props: BooleanInputArgs = Element.defaultArgs) {
+    constructor(props: BooleanInputArgs = {}) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/BooleanInput/index.ts
+++ b/src/components/BooleanInput/index.ts
@@ -11,6 +11,10 @@ const CLASS_BOOLEAN_INPUT_TOGGLE = CLASS_BOOLEAN_INPUT + '-toggle';
  */
 export interface BooleanInputArgs extends ElementArgs, IBindableArgs {
     /**
+     * Gets / sets the tabIndex of the {@link BooleanInput}. Defaults to 0.
+     */
+    tabIndex?: number,
+    /**
      * The type of checkbox. Currently can be `null` or 'toggle'.
      */
     type?: string
@@ -20,19 +24,11 @@ export interface BooleanInputArgs extends ElementArgs, IBindableArgs {
  * A checkbox element.
  */
 class BooleanInput extends Input implements IBindable, IFocusable {
-    static readonly defaultArgs: BooleanInputArgs = {
-        ...Element.defaultArgs,
-        renderChanges: false,
-        value: false,
-        tabIndex: 0,
-        dom: 'div'
-    };
-
     protected _value: boolean;
 
-    constructor(args: BooleanInputArgs = BooleanInput.defaultArgs) {
-        args = { ...BooleanInput.defaultArgs, ...args };
-        super(args.dom, args);
+    constructor(args: BooleanInputArgs = {}) {
+        args.tabIndex = args.tabIndex ?? 0;
+        super(args.dom ?? 'div', args);
 
         if (args.type === 'toggle') {
             this.class.add(CLASS_BOOLEAN_INPUT_TOGGLE);
@@ -50,7 +46,7 @@ class BooleanInput extends Input implements IBindable, IFocusable {
             this.value = args.value;
         }
 
-        this.renderChanges = args.renderChanges;
+        this.renderChanges = args.renderChanges ?? false;
     }
 
     destroy() {

--- a/src/components/BooleanInput/index.ts
+++ b/src/components/BooleanInput/index.ts
@@ -28,7 +28,7 @@ class BooleanInput extends Input implements IBindable, IFocusable {
 
     constructor(args: BooleanInputArgs = {}) {
         args.tabIndex = args.tabIndex ?? 0;
-        super(args.dom ?? 'div', args);
+        super(args.dom, args);
 
         if (args.type === 'toggle') {
             this.class.add(CLASS_BOOLEAN_INPUT_TOGGLE);

--- a/src/components/BooleanInput/index.ts
+++ b/src/components/BooleanInput/index.ts
@@ -11,7 +11,7 @@ const CLASS_BOOLEAN_INPUT_TOGGLE = CLASS_BOOLEAN_INPUT + '-toggle';
  */
 export interface BooleanInputArgs extends ElementArgs, IBindableArgs {
     /**
-     * Gets / sets the tabIndex of the {@link BooleanInput}. Defaults to 0.
+     * Sets the tabIndex of the {@link BooleanInput}. Defaults to 0.
      */
     tabIndex?: number,
     /**

--- a/src/components/Button/component.tsx
+++ b/src/components/Button/component.tsx
@@ -6,7 +6,7 @@ import BaseComponent from '../Element/component';
  * User input with click interaction
  */
 class Component extends BaseComponent <ButtonArgs, any> {
-    constructor(props: ButtonArgs = Element.defaultArgs) {
+    constructor(props: ButtonArgs = {}) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/Button/index.ts
+++ b/src/components/Button/index.ts
@@ -30,15 +30,6 @@ export interface ButtonArgs extends ElementArgs {
  * User input with click interaction.
  */
 class Button extends Element {
-    static readonly defaultArgs: ButtonArgs = {
-        ...Element.defaultArgs,
-        text: '',
-        icon: '',
-        unsafe: false,
-        size: null,
-        dom: 'button'
-    };
-
     protected _unsafe: boolean;
 
     protected _text: string;
@@ -47,9 +38,8 @@ class Button extends Element {
 
     protected _size: string | null;
 
-    constructor(args: ButtonArgs = Button.defaultArgs) {
-        args = { ...Button.defaultArgs, ...args };
-        super(args.dom, args);
+    constructor(args: ButtonArgs = {}) {
+        super(args.dom ?? 'button', args);
 
         this.class.add(CLASS_BUTTON);
 

--- a/src/components/Button/index.ts
+++ b/src/components/Button/index.ts
@@ -21,7 +21,7 @@ export interface ButtonArgs extends ElementArgs {
      */
     icon?: string,
     /**
-     * Gets / sets the 'size' type of the button. Can be 'small' or `null`. Defaults to `null`.
+     * Sets the 'size' type of the button. Can be 'small' or `null`. Defaults to `null`.
      */
     size?: 'small'
 }

--- a/src/components/Canvas/component.tsx
+++ b/src/components/Canvas/component.tsx
@@ -6,7 +6,7 @@ import BaseComponent from '../Element/component';
  * Represents a Canvas
  */
 class Component extends BaseComponent <CanvasArgs, any> {
-    constructor(props: CanvasArgs = Element.defaultArgs) {
+    constructor(props: CanvasArgs = {}) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/Canvas/index.ts
+++ b/src/components/Canvas/index.ts
@@ -15,20 +15,14 @@ export interface CanvasArgs extends ElementArgs {
  * Represents a Canvas.
  */
 class Canvas extends Element {
-    static readonly defaultArgs: CanvasArgs = {
-        ...Element.defaultArgs,
-        dom: 'canvas'
-    };
-
     protected _width: number;
 
     protected _height: number;
 
     protected _ratio: number;
 
-    constructor(args: CanvasArgs = Canvas.defaultArgs) {
-        args = { ...Canvas.defaultArgs, ...args };
-        super(args.dom, args);
+    constructor(args: CanvasArgs = {}) {
+        super(args.dom ?? 'canvas', args);
 
         const canvas = this._dom as HTMLCanvasElement;
         canvas.classList.add('pcui-canvas');

--- a/src/components/Code/index.ts
+++ b/src/components/Code/index.ts
@@ -19,16 +19,11 @@ export interface CodeArgs extends ContainerArgs {
  * Represents a code block.
  */
 class Code extends Container {
-    static readonly defaultArgs: CodeArgs = {
-        ...Container.defaultArgs
-    };
-
     protected _inner: Label;
 
     protected _text: string;
 
-    constructor(args: CodeArgs = Code.defaultArgs) {
-        args = { ...Code.defaultArgs, ...args };
+    constructor(args: CodeArgs = {}) {
         super(args);
         this.class.add(CLASS_ROOT);
 

--- a/src/components/ColorPicker/index.ts
+++ b/src/components/ColorPicker/index.ts
@@ -28,13 +28,6 @@ export interface ColorPickerArgs extends ElementArgs, IBindableArgs {
  * Represents a color picker.
  */
 class ColorPicker extends Element implements IBindable {
-    static readonly defaultArgs: ColorPickerArgs = {
-        ...Element.defaultArgs,
-        channels: 3,
-        value: [0, 0, 255, 1],
-        renderChanges: false
-    };
-
     protected _domColor: HTMLDivElement;
 
     protected _historyCombine: boolean;
@@ -93,8 +86,7 @@ class ColorPicker extends Element implements IBindable {
 
     protected _renderChanges: boolean;
 
-    constructor(args: ColorPickerArgs = ColorPicker.defaultArgs) {
-        args = { ...ColorPicker.defaultArgs, ...args };
+    constructor(args: ColorPickerArgs = {}) {
         super(args.dom, args);
 
         this._size = 144;
@@ -128,11 +120,11 @@ class ColorPicker extends Element implements IBindable {
         this._historyCombine = false;
         this._historyPostfix = null;
 
-        this._value = args.value;
-        this._channels = args.channels;
+        this._value = args.value ?? [0, 0, 255, 1];
+        this._channels = args.channels ?? 3;
         this._setValue(this._value);
 
-        this.renderChanges = args.renderChanges;
+        this.renderChanges = args.renderChanges ?? false;
 
         this.on('change', () => {
             if (this.renderChanges) {

--- a/src/components/Container/component.tsx
+++ b/src/components/Container/component.tsx
@@ -7,7 +7,7 @@ import BaseComponent from '../Element/component';
  * A container can contain any other element including other containers.
  */
 class Component extends BaseComponent <ContainerArgs, any> {
-    constructor(props: ContainerArgs = Element.defaultArgs) {
+    constructor(props: ContainerArgs = {}) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/Container/index.ts
+++ b/src/components/Container/index.ts
@@ -141,7 +141,7 @@ class Container extends Element {
     protected _draggedHeight: number;
 
     constructor(args: ContainerArgs = {}) {
-        super(args.dom ?? 'div', args);
+        super(args.dom, args);
 
         this.class.add(CLASS_CONTAINER);
 

--- a/src/components/Container/index.ts
+++ b/src/components/Container/index.ts
@@ -24,7 +24,7 @@ const CLASS_DRAGGED_CHILD = CLASS_DRAGGED + '-child';
 export interface ContainerArgs extends ElementArgs, IParentArgs, IFlexArgs {
     /**
      * Sets whether the {@link Container} is resizable and where the resize handle is located. Can
-     * be one of 'top', 'bottom', 'right', 'left'. Set to null to disable resizing.
+     * be one of 'top', 'bottom', 'right', 'left'. Defaults to null which disables resizing.
      */
     resizable?: string,
     /**
@@ -58,12 +58,6 @@ export interface ContainerArgs extends ElementArgs, IParentArgs, IFlexArgs {
  * container can contain any other element including other containers.
  */
 class Container extends Element {
-    static readonly defaultArgs: ContainerArgs = {
-        ...Element.defaultArgs,
-        resizable: null,
-        dom: 'div'
-    };
-
     /**
      * Fired when a child Element gets added to the Container.
      *
@@ -146,9 +140,8 @@ class Container extends Element {
 
     protected _draggedHeight: number;
 
-    constructor(args: ContainerArgs = Container.defaultArgs) {
-        args = { ...Container.defaultArgs, ...args };
-        super(args.dom, args);
+    constructor(args: ContainerArgs = {}) {
+        super(args.dom ?? 'div', args);
 
         this.class.add(CLASS_CONTAINER);
 
@@ -181,7 +174,7 @@ class Container extends Element {
         this._resizeData = null;
         this._resizeHorizontally = true;
 
-        this.resizable = args.resizable;
+        this.resizable = args.resizable ?? null;
         this._resizeMin = 100;
         this._resizeMax = 300;
 

--- a/src/components/Container/index.ts
+++ b/src/components/Container/index.ts
@@ -24,7 +24,7 @@ const CLASS_DRAGGED_CHILD = CLASS_DRAGGED + '-child';
 export interface ContainerArgs extends ElementArgs, IParentArgs, IFlexArgs {
     /**
      * Sets whether the {@link Container} is resizable and where the resize handle is located. Can
-     * be one of 'top', 'bottom', 'right', 'left'. Defaults to null which disables resizing.
+     * be one of 'top', 'bottom', 'right', 'left'. Defaults to `null` which disables resizing.
      */
     resizable?: string,
     /**

--- a/src/components/Divider/index.ts
+++ b/src/components/Divider/index.ts
@@ -12,7 +12,7 @@ export interface DividerArgs extends ElementArgs {}
  */
 class Divider extends Element {
     constructor(args: DividerArgs = {}) {
-        super(args.dom ?? 'div', args);
+        super(args.dom, args);
 
         this.class.add(CLASS_ROOT);
     }

--- a/src/components/Divider/index.ts
+++ b/src/components/Divider/index.ts
@@ -11,13 +11,8 @@ export interface DividerArgs extends ElementArgs {}
  * Represents a vertical division between two elements.
  */
 class Divider extends Element {
-    static readonly defaultArgs: DividerArgs = {
-        ...Element.defaultArgs
-    };
-
-    constructor(args: ElementArgs = Divider.defaultArgs) {
-        args = { ...Divider.defaultArgs, ...args };
-        super(args.dom ? args.dom : document.createElement('div'), args);
+    constructor(args: DividerArgs = {}) {
+        super(args.dom ?? 'div', args);
 
         this.class.add(CLASS_ROOT);
     }

--- a/src/components/Element/component.tsx
+++ b/src/components/Element/component.tsx
@@ -5,8 +5,6 @@ import Element, { ElementArgs } from './index';
  * The base class for all UI elements. Wraps a DOM element with the PCUI interface.
  */
 class Component <P extends ElementArgs, S> extends React.Component <P, S> {
-    static defaultArgs = Element.defaultArgs;
-
     static ctor: any;
 
     element: any;
@@ -46,7 +44,6 @@ class Component <P extends ElementArgs, S> extends React.Component <P, S> {
             this.element = new this.elementClass(
                 nodeElement,
                 {
-                    ...this.elementClass.defaultArgs,
                     ...this.props,
                     container: containerElement,
                     parent: undefined
@@ -54,7 +51,6 @@ class Component <P extends ElementArgs, S> extends React.Component <P, S> {
             );
         } else {
             this.element = new this.elementClass({
-                ...this.elementClass.defaultArgs,
                 ...this.props,
                 dom: nodeElement,
                 content: containerElement,

--- a/src/components/Element/index.ts
+++ b/src/components/Element/index.ts
@@ -175,11 +175,11 @@ export interface ElementArgs {
      */
     height?: number | null,
     /**
-     * Gets / sets the tabIndex of the {@link Element}.
+     * Sets the tabIndex of the {@link Element}.
      */
     tabIndex?: number,
     /**
-     * Gets / sets whether the {@link Element} is in an error state.
+     * Sets whether the {@link Element} is in an error state.
      */
     error?: boolean,
     /**

--- a/src/components/Element/index.ts
+++ b/src/components/Element/index.ts
@@ -163,7 +163,7 @@ export interface ElementArgs {
      */
     hidden?: boolean,
     /**
-     * If `true`, this {@link Element} will ignore its parent's enabled value when determining whether this element is enabled. Defaults to false.
+     * If `true`, this {@link Element} will ignore its parent's enabled value when determining whether this element is enabled. Defaults to `false`.
      */
     ignoreParent?: boolean,
     /**

--- a/src/components/Element/index.ts
+++ b/src/components/Element/index.ts
@@ -187,7 +187,7 @@ export interface ElementArgs {
      */
     style?: string,
     /**
-     * Whether this {@link Element} is read only or not. Defaults to false.
+     * Whether this {@link Element} is read only or not. Defaults to `false`.
      */
     readOnly?: boolean
 }

--- a/src/components/Element/index.ts
+++ b/src/components/Element/index.ts
@@ -159,11 +159,11 @@ export interface ElementArgs {
      */
     enabled?: boolean,
     /**
-     * Sets whether this {@link Element} is hidden.
+     * Sets whether this {@link Element} is hidden. Defaults to false.
      */
     hidden?: boolean,
     /**
-     * If `true`, this {@link Element} will ignore its parent's enabled value when determining whether this element is enabled.
+     * If `true`, this {@link Element} will ignore its parent's enabled value when determining whether this element is enabled. Defaults to false.
      */
     ignoreParent?: boolean,
     /**
@@ -187,7 +187,7 @@ export interface ElementArgs {
      */
     style?: string,
     /**
-     * Whether this {@link Element} is read only or not.
+     * Whether this {@link Element} is read only or not. Defaults to false.
      */
     readOnly?: boolean
 }
@@ -196,12 +196,6 @@ export interface ElementArgs {
  * The base class for all UI elements.
  */
 class Element extends Events {
-    public static defaultArgs: ElementArgs = {
-        hidden: false,
-        readOnly: false,
-        ignoreParent: false
-    };
-
     /**
      * Fired when the Element gets enabled.
      *
@@ -406,8 +400,7 @@ class Element extends Events {
 
     protected _onClickEvt: () => void;
 
-    constructor(dom: HTMLElement | string, args: ElementArgs = Element.defaultArgs) {
-        args = { ...Element.defaultArgs, ...args };
+    constructor(dom: HTMLElement | string, args: ElementArgs = {}) {
         super();
 
         this._destroyed = false;
@@ -463,9 +456,9 @@ class Element extends Events {
 
         this.enabled = args.enabled !== undefined ? args.enabled : true;
         this._hiddenParents = !args.isRoot;
-        this.hidden = args.hidden;
-        this.readOnly = args.readOnly;
-        this.ignoreParent = args.ignoreParent;
+        this.hidden = args.hidden ?? false;
+        this.readOnly = args.readOnly ?? false;
+        this.ignoreParent = args.ignoreParent ?? false;
 
         if (args.width !== undefined) {
             this.width = args.width;

--- a/src/components/Element/index.ts
+++ b/src/components/Element/index.ts
@@ -159,7 +159,7 @@ export interface ElementArgs {
      */
     enabled?: boolean,
     /**
-     * Sets whether this {@link Element} is hidden. Defaults to false.
+     * Sets whether this {@link Element} is hidden. Defaults to `false`.
      */
     hidden?: boolean,
     /**

--- a/src/components/GradientPicker/index.ts
+++ b/src/components/GradientPicker/index.ts
@@ -25,7 +25,7 @@ const CLASS_GRADIENT = 'pcui-gradient';
  */
 export interface GradientPickerArgs extends ElementArgs {
     /**
-     * If true, the picker will render changes to the gradient as they happen. Defaults to true.
+     * If true, the picker will render changes to the gradient as they happen. Defaults to `true`.
      */
     renderChanges?: boolean;
     /**

--- a/src/components/GradientPicker/index.ts
+++ b/src/components/GradientPicker/index.ts
@@ -119,7 +119,7 @@ class GradientPicker extends Element {
      * be set through the constructor.
      */
     constructor(args: GradientPickerArgs = {}) {
-        super(args.dom ?? 'div', args);
+        super(args.dom, args);
 
         this.class.add(CLASS_GRADIENT);
 

--- a/src/components/GradientPicker/index.ts
+++ b/src/components/GradientPicker/index.ts
@@ -24,6 +24,9 @@ const CLASS_GRADIENT = 'pcui-gradient';
  * The arguments for the {@link GradientPicker} constructor.
  */
 export interface GradientPickerArgs extends ElementArgs {
+    /**
+     * If true, the picker will render changes to the gradient as they happen. Defaults to true.
+     */
     renderChanges?: boolean;
     /**
      * An array of 4 integers containing the RGBA values the picker should be initialized to.
@@ -39,12 +42,6 @@ export interface GradientPickerArgs extends ElementArgs {
  * Represents a gradient picker.
  */
 class GradientPicker extends Element {
-    static readonly defaultArgs: GradientPickerArgs = {
-        ...Element.defaultArgs,
-        renderChanges: true,
-        dom: 'div'
-    };
-
     protected _canvas: Canvas;
 
     protected _checkerboardPattern: CanvasPattern;
@@ -121,9 +118,8 @@ class GradientPicker extends Element {
      * @param args - The arguments. Extends the Element arguments. Any settable property can also
      * be set through the constructor.
      */
-    constructor(args: GradientPickerArgs = GradientPicker.defaultArgs) {
-        args = { ...GradientPicker.defaultArgs, ...args };
-        super(args.dom, args);
+    constructor(args: GradientPickerArgs = {}) {
+        super(args.dom ?? 'div', args);
 
         this.class.add(CLASS_GRADIENT);
 
@@ -151,7 +147,7 @@ class GradientPicker extends Element {
             this._openGradientPicker();
         });
 
-        this.renderChanges = args.renderChanges;
+        this.renderChanges = args.renderChanges ?? true;
 
         this.on('change', () => {
             if (this.renderChanges) {

--- a/src/components/GradientPicker/index.ts
+++ b/src/components/GradientPicker/index.ts
@@ -25,7 +25,7 @@ const CLASS_GRADIENT = 'pcui-gradient';
  */
 export interface GradientPickerArgs extends ElementArgs {
     /**
-     * If true, the picker will render changes to the gradient as they happen. Defaults to `true`.
+     * If `true`, the picker will render changes to the gradient as they happen. Defaults to `true`.
      */
     renderChanges?: boolean;
     /**

--- a/src/components/GridView/index.ts
+++ b/src/components/GridView/index.ts
@@ -16,11 +16,11 @@ export interface GridViewArgs extends ContainerArgs {
      */
     vertical?: boolean;
     /**
-     * If `true`, the layout will allow for multiple options to be selected.
+     * If `true`, the layout will allow for multiple options to be selected. Defaults to true.
      */
     multiSelect?: boolean;
     /**
-     * If `true` and `multiSelect` is set to `false`, the layout will allow options to be deselected.
+     * If `true` and `multiSelect` is set to `false`, the layout will allow options to be deselected. Defaults to true.
      */
     allowDeselect?: boolean;
     /**
@@ -34,12 +34,6 @@ export interface GridViewArgs extends ContainerArgs {
  * Contains {@link GridViewItem}s.
  */
 class GridView extends Container {
-    static readonly defaultArgs: GridViewArgs = {
-        ...Container.defaultArgs,
-        multiSelect: true,
-        allowDeselect: true
-    };
-
     protected _vertical: boolean;
 
     protected _filterFn: (item: GridViewItem) => boolean;
@@ -56,8 +50,7 @@ class GridView extends Container {
 
     protected _clickFn: any;
 
-    constructor(args: GridViewArgs = GridView.defaultArgs) {
-        args = { ...GridView.defaultArgs, ...args };
+    constructor(args: GridViewArgs = {}) {
         super(args);
 
         this._vertical = !!args.vertical;
@@ -79,8 +72,8 @@ class GridView extends Container {
         this._filterCanceled = false;
 
         // Default options for GridView layout
-        this._multiSelect = args.multiSelect;
-        this._allowDeselect = args.allowDeselect;
+        this._multiSelect = args.multiSelect ?? true;
+        this._allowDeselect = args.allowDeselect ?? true;
 
         this._selected = [];
     }

--- a/src/components/GridView/index.ts
+++ b/src/components/GridView/index.ts
@@ -20,7 +20,7 @@ export interface GridViewArgs extends ContainerArgs {
      */
     multiSelect?: boolean;
     /**
-     * If `true` and `multiSelect` is set to `false`, the layout will allow options to be deselected. Defaults to true.
+     * If `true` and `multiSelect` is set to `false`, the layout will allow options to be deselected. Defaults to `true`.
      */
     allowDeselect?: boolean;
     /**

--- a/src/components/GridView/index.ts
+++ b/src/components/GridView/index.ts
@@ -16,7 +16,7 @@ export interface GridViewArgs extends ContainerArgs {
      */
     vertical?: boolean;
     /**
-     * If `true`, the layout will allow for multiple options to be selected. Defaults to true.
+     * If `true`, the layout will allow for multiple options to be selected. Defaults to `true`.
      */
     multiSelect?: boolean;
     /**

--- a/src/components/GridViewItem/index.ts
+++ b/src/components/GridViewItem/index.ts
@@ -31,19 +31,16 @@ export interface GridViewItemArgs extends ContainerArgs {
      * The text of the item. Defaults to ''.
      */
     text?: string;
+    /**
+     * Gets / sets the tabIndex of the {@link GridViewItem}. Defaults to 0.
+     */
+    tabIndex?: number;
 }
 
 /**
  *  Represents a grid view item used in {@link GridView}.
  */
 class GridViewItem extends Container implements IFocusable {
-    static readonly defaultArgs: GridViewItemArgs = {
-        ...Container.defaultArgs,
-        allowSelect: true,
-        text: '',
-        tabIndex: 0
-    };
-
     protected _selected: boolean;
 
     protected _radioButton: RadioButton;
@@ -54,11 +51,12 @@ class GridViewItem extends Container implements IFocusable {
 
     protected _allowSelect: boolean;
 
-    constructor(args: GridViewItemArgs = GridViewItem.defaultArgs) {
-        args = { ...GridViewItem.defaultArgs, ...args };
+    constructor(args: GridViewItemArgs = {}) {
+        args.tabIndex = args.tabIndex ?? 0;
         super(args);
 
-        this.allowSelect = args.allowSelect;
+        this.allowSelect = args.allowSelect ?? true;
+        this._type = args.type ?? null;
         this._selected = false;
 
         if (args.type === 'radio') {
@@ -80,13 +78,11 @@ class GridViewItem extends Container implements IFocusable {
 
         this._labelText = new Label({
             class: CLASS_TEXT,
-            binding: new BindingObserversToElement()
+            binding: new BindingObserversToElement(),
+            text: args.text ?? ''
         });
 
         this.append(this._labelText);
-
-        this.text = args.text;
-        this._type = args.type;
 
         this.dom.addEventListener('focus', this._onFocus);
         this.dom.addEventListener('blur', this._onBlur);

--- a/src/components/GridViewItem/index.ts
+++ b/src/components/GridViewItem/index.ts
@@ -32,7 +32,7 @@ export interface GridViewItemArgs extends ContainerArgs {
      */
     text?: string;
     /**
-     * Gets / sets the tabIndex of the {@link GridViewItem}. Defaults to 0.
+     * Sets the tabIndex of the {@link GridViewItem}. Defaults to 0.
      */
     tabIndex?: number;
 }

--- a/src/components/InfoBox/index.ts
+++ b/src/components/InfoBox/index.ts
@@ -35,14 +35,6 @@ export interface InfoBoxArgs extends ContainerArgs {
  * Represents an information box.
  */
 class InfoBox extends Container {
-    static readonly defaultArgs: InfoBoxArgs = {
-        ...Container.defaultArgs,
-        unsafe: false,
-        icon: '',
-        title: '',
-        text: ''
-    };
-
     protected _titleElement: Element;
 
     protected _textElement: Element;
@@ -55,8 +47,7 @@ class InfoBox extends Container {
 
     protected _text: string;
 
-    constructor(args: InfoBoxArgs = InfoBox.defaultArgs) {
-        args = { ...InfoBox.defaultArgs, ...args };
+    constructor(args: InfoBoxArgs = {}) {
         super(args);
 
         this.class.add(CLASS_INFOBOX);
@@ -65,11 +56,10 @@ class InfoBox extends Container {
         this.append(this._titleElement);
         this.append(this._textElement);
 
-        this._unsafe = args.unsafe;
-
-        this.icon = args.icon;
-        this.title = args.title;
-        this.text = args.text;
+        this._unsafe = args.unsafe ?? false;
+        this.icon = args.icon ?? '';
+        this.title = args.title ?? '';
+        this.text = args.text ?? '';
     }
 
     /**

--- a/src/components/InfoBox/index.ts
+++ b/src/components/InfoBox/index.ts
@@ -16,11 +16,11 @@ export interface InfoBoxArgs extends ContainerArgs {
      */
     icon?: string;
     /**
-     * Gets / sets the 'title' of the {@link InfoBox}. Defaults to ''.
+     * Sets the 'title' of the {@link InfoBox}. Defaults to ''.
      */
     title?: string;
     /**
-     * Gets / sets the 'text' of the {@link InfoBox}. Defaults to ''.
+     * Sets the 'text' of the {@link InfoBox}. Defaults to ''.
      */
     text?: string;
     /**

--- a/src/components/Label/component.tsx
+++ b/src/components/Label/component.tsx
@@ -6,7 +6,7 @@ import BaseComponent from '../Element/component';
  * The Label is a simple span element that displays some text.
  */
 class Component extends BaseComponent <LabelArgs, any> {
-    constructor(props: LabelArgs = Element.defaultArgs) {
+    constructor(props: LabelArgs = {}) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/Label/index.ts
+++ b/src/components/Label/index.ts
@@ -25,39 +25,34 @@ export interface LabelArgs extends ElementArgs, IBindableArgs, IPlaceholderArgs,
     /**
      * If `true` then the label can be clicked to select text. Defaults to `false`.
      */
-    allowTextSelection?: boolean
+    allowTextSelection?: boolean,
+    /**
+     * The dom element or its type to use for this component. Defaults to 'span'.
+     */
+    dom?: HTMLElement | string,
+    /**
+     * Sets the value of the Label. Defaults to ''.
+     */
+    value?: any,
 }
 
 /**
  * The Label is a simple span element that displays some text.
  */
 class Label extends Input implements IPlaceholder {
-    static readonly defaultArgs: LabelArgs = {
-        ...Element.defaultArgs,
-        value: '',
-        text: '',
-        unsafe: false,
-        nativeTooltip: false,
-        allowTextSelection: false,
-        renderChanges: false,
-        placeholder: null,
-        dom: 'span'
-    };
-
     protected _unsafe: boolean;
 
     protected _text: string;
 
     _optionValue: any;
 
-    constructor(args: LabelArgs = Label.defaultArgs) {
-        args = { ...Label.defaultArgs, ...args };
-        super(args.dom, args);
+    constructor(args: LabelArgs = {}) {
+        super(args.dom ?? 'span', args);
 
         this.class.add(CLASS_LABEL);
 
-        this._unsafe = args.unsafe;
-        this.text = args.text || args.value;
+        this._unsafe = args.unsafe ?? false;
+        this.text = args.text ?? args.value ?? '';
 
         if (args.allowTextSelection) {
             this.class.add(pcuiClass.DEFAULT_MOUSEDOWN);

--- a/src/components/Label/index.ts
+++ b/src/components/Label/index.ts
@@ -27,7 +27,7 @@ export interface LabelArgs extends ElementArgs, IBindableArgs, IPlaceholderArgs,
      */
     allowTextSelection?: boolean,
     /**
-     * The dom element or its type to use for this component. Defaults to 'span'.
+     * The DOM element or its type to use for this component. Defaults to 'span'.
      */
     dom?: HTMLElement | string,
     /**

--- a/src/components/LabelGroup/component.tsx
+++ b/src/components/LabelGroup/component.tsx
@@ -17,7 +17,6 @@ class LabelGroup extends BaseComponent <LabelGroupArgs, any> {
             throw new Error('A LabelGroup must contain a single child react component');
         }
         this.element = new this.elementClass({
-            ...this.elementClass.defaultArgs,
             ...this.props,
             dom: nodeElement,
             container: containerElement,

--- a/src/components/LabelGroup/index.ts
+++ b/src/components/LabelGroup/index.ts
@@ -10,7 +10,7 @@ const CLASS_LABEL_TOP = CLASS_LABEL_GROUP + '-align-top';
  */
 export interface LabelGroupArgs extends ContainerArgs {
     /**
-     * The label text.
+     * The label text. Defaults to 'Label'.
      */
     text?: string;
     /**
@@ -31,30 +31,22 @@ export interface LabelGroupArgs extends ContainerArgs {
  * Represents a group of an {@link Element} and a {@link Label}. Useful for rows of labeled fields.
  */
 class LabelGroup extends Container {
-    static readonly defaultArgs: LabelGroupArgs = {
-        ...Container.defaultArgs,
-        text: 'Label',
-        field: null,
-        labelAlignTop: false
-    };
-
     protected _label: Label;
 
     protected _field: Element;
 
-    constructor(args: LabelGroupArgs = LabelGroup.defaultArgs) {
-        args = { ...LabelGroup.defaultArgs, ...args };
+    constructor(args: LabelGroupArgs = {}) {
         super(args);
 
         this.class.add(CLASS_LABEL_GROUP);
 
         this._label = new Label({
-            text: args.text,
+            text: args.text ?? 'Label',
             nativeTooltip: args.nativeTooltip
         });
         this.append(this._label);
 
-        this._field = args.field;
+        this._field = args.field ?? null;
         if (this._field) {
             this.append(this._field);
         }

--- a/src/components/Menu/index.ts
+++ b/src/components/Menu/index.ts
@@ -15,7 +15,7 @@ export interface MenuArgs extends ContainerArgs {
      */
     items?: MenuItemArgs[];
     /**
-     * Sets whether this {@link Menu} is hidden. Defaults to true.
+     * Sets whether this {@link Menu} is hidden. Defaults to `true`.
      */
     hidden?: boolean;
     /**

--- a/src/components/Menu/index.ts
+++ b/src/components/Menu/index.ts
@@ -19,7 +19,7 @@ export interface MenuArgs extends ContainerArgs {
      */
     hidden?: boolean;
     /**
-     * Gets / sets the tabIndex of the {@link Menu}. Defaults to 1.
+     * Sets the tabIndex of the {@link Menu}. Defaults to 1.
      */
     tabIndex?: number;
 }

--- a/src/components/Menu/index.ts
+++ b/src/components/Menu/index.ts
@@ -11,9 +11,17 @@ const CLASS_MENU_ITEMS = CLASS_MENU + '-items';
 export interface MenuArgs extends ContainerArgs {
     /**
      * An array of {@link MenuItemArgs}. If these are passed then new MenuItems will be created
-     * and appended to the menu. Defaults to an empty array.
+     * and appended to the menu.
      */
-    items: MenuItemArgs[];
+    items?: MenuItemArgs[];
+    /**
+     * Sets whether this {@link Menu} is hidden. Defaults to true.
+     */
+    hidden?: boolean;
+    /**
+     * Gets / sets the tabIndex of the {@link Menu}. Defaults to 1.
+     */
+    tabIndex?: number;
 }
 
 /**
@@ -22,18 +30,13 @@ export interface MenuArgs extends ContainerArgs {
  * positioned accordingly.
  */
 class Menu extends Container implements IFocusable {
-    static readonly defaultArgs: MenuArgs = {
-        ...Container.defaultArgs,
-        hidden: true,
-        tabIndex: 1,
-        items: []
-    };
-
     protected _containerMenuItems: Container;
 
-    constructor(args: MenuArgs = Menu.defaultArgs) {
-        args = { ...Menu.defaultArgs, ...args };
+    constructor(args: MenuArgs = {}) {
+        args.tabIndex = args.tabIndex ?? 1;
         super(args);
+
+        this.hidden = args.hidden ?? true;
 
         this.class.add(CLASS_MENU);
 

--- a/src/components/MenuItem/index.ts
+++ b/src/components/MenuItem/index.ts
@@ -53,10 +53,6 @@ export interface MenuItemArgs extends ContainerArgs {
  * Menus.
  */
 class MenuItem extends Container implements IBindable {
-    static readonly defaultArgs: MenuItemArgs = {
-        ...Container.defaultArgs
-    };
-
     protected _containerContent: Container;
 
     protected _numChildren: number;
@@ -77,8 +73,7 @@ class MenuItem extends Container implements IBindable {
 
     protected _renderChanges: boolean;
 
-    constructor(args: MenuItemArgs = MenuItem.defaultArgs) {
-        args = { ...MenuItem.defaultArgs, ...args };
+    constructor(args: MenuItemArgs = {}) {
         super(args);
 
         this.class.add(CLASS_MENU_ITEM);

--- a/src/components/MenuItem/index.ts
+++ b/src/components/MenuItem/index.ts
@@ -18,27 +18,27 @@ export interface MenuItemArgs extends ContainerArgs {
      */
     hasChildren?: boolean;
     /**
-     * Gets / sets the text shown on the MenuItem.
+     * Sets the text shown on the MenuItem.
      */
     text?: string;
     /**
-     * Gets / sets the CSS code for an icon for the MenuItem. e.g. 'E401' (notice we omit the '\\' character).
+     * Sets the CSS code for an icon for the MenuItem. e.g. 'E401' (notice we omit the '\\' character).
      */
     icon?: string;
     /**
-     * Gets / sets the parent Menu Element.
+     * Sets the parent Menu Element.
      */
     menu?: any;
     /**
-     * Gets / sets the function called when we select the MenuItem.
+     * Sets the function called when we select the MenuItem.
      */
     onSelect?: (evt?: MouseEvent) => void;
     /**
-     * Gets / sets the function that determines whether the MenuItem should be enabled when the Menu is shown.
+     * Sets the function that determines whether the MenuItem should be enabled when the Menu is shown.
      */
     onIsEnabled?: () => boolean;
     /**
-     * Gets / sets the function that determines whether the MenuItem should be visible when the Menu is shown.
+     * Sets the function that determines whether the MenuItem should be visible when the Menu is shown.
      */
     onIsVisible?: () => boolean;
     /**

--- a/src/components/NumericInput/index.ts
+++ b/src/components/NumericInput/index.ts
@@ -89,7 +89,7 @@ class NumericInput extends TextInput {
 
         this._min = args.min ?? null;
         this._max = args.max ?? null;
-        this._allowNull = args.allowNull ?? null;
+        this._allowNull = args.allowNull ?? false;
         this._precision = args.precision ?? 7;
 
         if (Number.isFinite(args.step)) {

--- a/src/components/NumericInput/index.ts
+++ b/src/components/NumericInput/index.ts
@@ -22,7 +22,7 @@ export interface NumericInputArgs extends TextInputArgs {
      */
     max?: number,
     /**
-     * Sets the maximum value this field can take.
+     * Sets the decimal precision of this field. Defaults to 7.
      */
     precision?: number,
     /**
@@ -47,15 +47,6 @@ export interface NumericInputArgs extends TextInputArgs {
  * The NumericInput represents an input element that holds numbers.
  */
 class NumericInput extends TextInput {
-    static readonly defaultArgs: NumericInputArgs = {
-        ...TextInput.defaultArgs,
-        precision: 7,
-        min: null,
-        max: null,
-        renderChanges: false,
-        allowNull: false
-    };
-
     protected _min: number;
 
     protected _max: number;
@@ -82,8 +73,7 @@ class NumericInput extends TextInput {
 
     protected _sliderUsed = false;
 
-    constructor(args: NumericInputArgs = NumericInput.defaultArgs) {
-        args = { ...NumericInput.defaultArgs, ...args };
+    constructor(args: NumericInputArgs = {}) {
         // make copy of args
         args = Object.assign({}, args);
         const value = args.value;
@@ -97,10 +87,10 @@ class NumericInput extends TextInput {
 
         this.class.add(CLASS_NUMERIC_INPUT);
 
-        this._min = args.min;
-        this._max = args.max;
-        this._allowNull = args.allowNull;
-        this._precision = args.precision;
+        this._min = args.min ?? null;
+        this._max = args.max ?? null;
+        this._allowNull = args.allowNull ?? null;
+        this._precision = args.precision ?? 7;
 
         if (Number.isFinite(args.step)) {
             this._step = args.step;

--- a/src/components/Overlay/index.ts
+++ b/src/components/Overlay/index.ts
@@ -25,14 +25,9 @@ export interface OverlayArgs extends ElementArgs {
  * An overlay element.
  */
 class Overlay extends Container {
-    static readonly defaultArgs: OverlayArgs = {
-        ...Element.defaultArgs
-    };
-
     protected _domClickableOverlay: HTMLDivElement;
 
-    constructor(args: OverlayArgs = Overlay.defaultArgs) {
-        args = { ...Overlay.defaultArgs, ...args };
+    constructor(args: OverlayArgs = {}) {
         super(args);
 
         this.class.add(CLASS_OVERLAY);

--- a/src/components/Panel/component.tsx
+++ b/src/components/Panel/component.tsx
@@ -12,7 +12,7 @@ class Component extends BaseComponent <PanelArgs, any> {
 
     containerElement: any;
 
-    constructor(props: PanelArgs = Element.defaultArgs) {
+    constructor(props: PanelArgs = {}) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/Panel/index.ts
+++ b/src/components/Panel/index.ts
@@ -92,11 +92,6 @@ class Panel extends Container {
      */
     public static readonly EVENT_EXPAND = 'expand';
 
-    static readonly defaultArgs: PanelArgs = {
-        ...Container.defaultArgs,
-        headerSize: 32
-    };
-
     protected _suspendReflow: boolean;
 
     protected _reflowTimeout: number;
@@ -133,8 +128,7 @@ class Panel extends Container {
      * @param args - The arguments. Extends the Container constructor arguments. All settable
      * properties can also be set through the constructor.
      */
-    constructor(args: PanelArgs = Panel.defaultArgs) {
-        args = { ...Panel.defaultArgs, ...args };
+    constructor(args: PanelArgs = {}) {
 
         const panelArgs = Object.assign({}, args);
         panelArgs.flex = true;
@@ -161,7 +155,7 @@ class Panel extends Container {
         this._initializeContent(args);
 
         // header size
-        this.headerSize = args.headerSize !== undefined ? args.headerSize : 32;
+        this.headerSize = args.headerSize ?? 32;
 
         // collapse related
         this._reflowTimeout = null;

--- a/src/components/Progress/index.ts
+++ b/src/components/Progress/index.ts
@@ -18,16 +18,11 @@ export interface ProgressArgs extends ContainerArgs {
  * Represents a bar that can highlight progress of an activity.
  */
 class Progress extends Container {
-    static readonly defaultArgs: ProgressArgs = {
-        ...Container.defaultArgs
-    };
-
     protected _inner: Element;
 
     protected _value: number;
 
-    constructor(args: ProgressArgs = Progress.defaultArgs) {
-        args = { ...Progress.defaultArgs, ...args };
+    constructor(args: ProgressArgs = {}) {
         super(args);
         this.class.add(CLASS_ROOT);
 

--- a/src/components/Progress/index.ts
+++ b/src/components/Progress/index.ts
@@ -9,7 +9,7 @@ const CLASS_INNER = CLASS_ROOT + '-inner';
  */
 export interface ProgressArgs extends ContainerArgs {
     /**
-     * Gets / sets the value of the progress bar (between 0 and 100).
+     * Sets the value of the progress bar (between 0 and 100).
      */
     value?: number
 }

--- a/src/components/RadioButton/index.ts
+++ b/src/components/RadioButton/index.ts
@@ -13,18 +13,12 @@ export interface RadioButtonArgs extends ElementArgs, IBindableArgs {}
  * A radio button element.
  */
 class RadioButton extends Element implements IBindable, IFocusable {
-    static readonly defaultArgs: RadioButtonArgs = {
-        ...Element.defaultArgs,
-        value: null,
-        tabIndex: 0
-    };
-
     protected _value: boolean;
 
     protected _renderChanges: boolean;
 
-    constructor(args: RadioButtonArgs = RadioButton.defaultArgs) {
-        args = { ...RadioButton.defaultArgs, ...args };
+    constructor(args: RadioButtonArgs = {}) {
+        args.tabIndex = args.tabIndex ?? 0;
         super(args.dom, args);
 
         this.class.add(CLASS_RADIO_BUTTON);

--- a/src/components/SelectInput/index.ts
+++ b/src/components/SelectInput/index.ts
@@ -82,21 +82,6 @@ export interface SelectInputArgs extends ElementArgs, IBindableArgs, IPlaceholde
  * An input that allows selecting from a dropdown or entering tags.
  */
 class SelectInput extends Element implements IBindable, IFocusable {
-    static readonly defaultArgs: SelectInputArgs = {
-        ...Element.defaultArgs,
-        optionsFn: null,
-        defaultValue: null,
-        multiSelect: false,
-        options: [],
-        invalidOptions: [],
-        allowNull: false,
-        allowInput: false,
-        allowCreate: false,
-        createFn: null,
-        type: 'string',
-        renderChanges: false
-    };
-
     protected _container: Container;
 
     protected _containerValue: Container;
@@ -151,8 +136,7 @@ class SelectInput extends Element implements IBindable, IFocusable {
 
     protected _renderChanges: boolean;
 
-    constructor(args: SelectInputArgs = SelectInput.defaultArgs) {
-        args = { ...SelectInput.defaultArgs, ...args };
+    constructor(args: SelectInputArgs = {}) {
         // main container
         const container = new Container({ dom: args.dom });
         super(container.dom, args);
@@ -254,13 +238,13 @@ class SelectInput extends Element implements IBindable, IFocusable {
             this.close();
         });
 
-        this._type = args.type;
+        this._type = args.type ?? 'string';
 
         this._optionsIndex = {};
         this._labelsIndex = {};
         this._labelHighlighted = null;
-        this.invalidOptions = args.invalidOptions;
-        this.options = args.options || [];
+        this.invalidOptions = args.invalidOptions ?? [];
+        this.options = args.options ?? [];
         this._optionsFn = args.optionsFn;
 
         this._allowNull = args.allowNull;

--- a/src/components/SliderInput/index.ts
+++ b/src/components/SliderInput/index.ts
@@ -15,19 +15,19 @@ const IS_CHROME = /Chrome\//.test(navigator.userAgent);
  */
 export interface SliderInputArgs extends ElementArgs, IBindableArgs, IFlexArgs {
     /**
-     * Gets / sets the minimum value that the numeric input field can take.
+     * Gets / sets the minimum value that the numeric input field can take. Defaults to 0.
      */
     min?: number,
     /**
-     * Gets / sets the maximum value that the numeric input field can take.
+     * Gets / sets the maximum value that the numeric input field can take. Defaults to 1.
      */
     max?: number,
     /**
-     * Gets / sets the minimum value that the slider field can take.
+     * Gets / sets the minimum value that the slider field can take. Defaults to 0.
      */
     sliderMin?: number,
     /**
-     * Gets / sets the maximum value that the slider field can take.
+     * Gets / sets the maximum value that the slider field can take. Defaults to 1.
      */
     sliderMax?: number,
     /**
@@ -83,8 +83,8 @@ class SliderInput extends Element implements IBindable, IFocusable {
         const numericInput = new NumericInput({
             allowNull: args.allowNull,
             hideSlider: true,
-            max: args.max,
-            min: args.min,
+            min: args.min ?? 0,
+            max: args.max ?? 1,
             // @ts-ignore
             keyChange: args.keyChange,
             // @ts-ignore
@@ -112,8 +112,8 @@ class SliderInput extends Element implements IBindable, IFocusable {
 
         this._numericInput = numericInput;
 
-        this._sliderMin = args.sliderMin ?? args.min;
-        this._sliderMax = args.sliderMax ?? args.max;
+        this._sliderMin = args.sliderMin ?? args.min ?? 0;
+        this._sliderMax = args.sliderMax ?? args.max ?? 1;
 
         this._domSlider = document.createElement('div');
         this._domSlider.classList.add(CLASS_SLIDER_CONTAINER);

--- a/src/components/SliderInput/index.ts
+++ b/src/components/SliderInput/index.ts
@@ -15,32 +15,32 @@ const IS_CHROME = /Chrome\//.test(navigator.userAgent);
  */
 export interface SliderInputArgs extends ElementArgs, IBindableArgs, IFlexArgs {
     /**
-     * Gets / sets the minimum value that the numeric input field can take. Defaults to 0.
+     * Sets the minimum value that the numeric input field can take. Defaults to 0.
      */
     min?: number,
     /**
-     * Gets / sets the maximum value that the numeric input field can take. Defaults to 1.
+     * Sets the maximum value that the numeric input field can take. Defaults to 1.
      */
     max?: number,
     /**
-     * Gets / sets the minimum value that the slider field can take. Defaults to 0.
+     * Sets the minimum value that the slider field can take. Defaults to 0.
      */
     sliderMin?: number,
     /**
-     * Gets / sets the maximum value that the slider field can take. Defaults to 1.
+     * Sets the maximum value that the slider field can take. Defaults to 1.
      */
     sliderMax?: number,
     /**
-     * Gets / sets the maximum number of decimals a value can take. Defaults to 2.
+     * Sets the maximum number of decimals a value can take. Defaults to 2.
      */
     precision?: number,
     /**
-     * Gets / sets the amount that the value will be increased or decreased when using the arrow
+     * Sets the amount that the value will be increased or decreased when using the arrow
      * keys. Holding Shift will use 10x the step.
      */
     step?: number,
     /**
-     * Gets / sets whether the value can be null. If not then it will be 0 instead of null.
+     * Sets whether the value can be null. If not then it will be 0 instead of null.
      */
     allowNull?: boolean
 }

--- a/src/components/SliderInput/index.ts
+++ b/src/components/SliderInput/index.ts
@@ -15,11 +15,11 @@ const IS_CHROME = /Chrome\//.test(navigator.userAgent);
  */
 export interface SliderInputArgs extends ElementArgs, IBindableArgs, IFlexArgs {
     /**
-     * Gets / sets the minimum value that the numeric input field can take. Defaults to 0.
+     * Gets / sets the minimum value that the numeric input field can take.
      */
     min?: number,
     /**
-     * Gets / sets the maximum value that the numeric input field can take. Defaults to 1.
+     * Gets / sets the maximum value that the numeric input field can take.
      */
     max?: number,
     /**
@@ -31,7 +31,7 @@ export interface SliderInputArgs extends ElementArgs, IBindableArgs, IFlexArgs {
      */
     sliderMax?: number,
     /**
-     * Gets / sets the maximum number of decimals a value can take.
+     * Gets / sets the maximum number of decimals a value can take. Defaults to 2.
      */
     precision?: number,
     /**
@@ -50,12 +50,6 @@ export interface SliderInputArgs extends ElementArgs, IBindableArgs, IFlexArgs {
  * NumericInput.
  */
 class SliderInput extends Element implements IBindable, IFocusable {
-    static readonly defaultArgs: SliderInputArgs = {
-        ...Element.defaultArgs,
-        min: 0,
-        max: 1
-    };
-
     protected _historyCombine = false;
 
     protected _historyPostfix: any = null;
@@ -81,8 +75,7 @@ class SliderInput extends Element implements IBindable, IFocusable {
      *
      * @param args - The arguments.
      */
-    constructor(args: SliderInputArgs = SliderInput.defaultArgs) {
-        args = { ...SliderInput.defaultArgs, ...args };
+    constructor(args: SliderInputArgs = {}) {
         super(args.dom, args);
 
         this.class.add(CLASS_SLIDER);

--- a/src/components/Spinner/index.ts
+++ b/src/components/Spinner/index.ts
@@ -33,22 +33,15 @@ export interface SpinnerArgs extends ElementArgs {
 class Spinner extends Element {
     static TYPE_SMALL_THICK = 'small-thick';
 
-    static readonly defaultArgs: SpinnerArgs = {
-        ...Element.defaultArgs,
-        type: 'small-thick'
-    };
-
     /**
      * Sets the pixel size of the spinner
      *
      * @param args - The arguments.
      */
-    constructor(args: SpinnerArgs = Spinner.defaultArgs) {
-        args = { ...Spinner.defaultArgs, ...args };
+    constructor(args: SpinnerArgs = {}) {
         let dom = null;
-
-        if (args.type === Spinner.TYPE_SMALL_THICK) {
-            dom = createSmallThick(args.size || 12, args.dom);
+        if ((args.type ?? 'small-thick') === Spinner.TYPE_SMALL_THICK) {
+            dom = createSmallThick(args.size ?? 12, args.dom);
         }
 
         super(dom, args);

--- a/src/components/TextAreaInput/index.ts
+++ b/src/components/TextAreaInput/index.ts
@@ -23,12 +23,7 @@ export interface TextAreaInputArgs extends TextInputArgs {
  * The TextAreaInput wraps a textarea element. It has the same interface as {@link TextInput}.
  */
 class TextAreaInput extends TextInput {
-    static readonly defaultArgs: TextAreaInputArgs = {
-        ...TextInput.defaultArgs
-    };
-
-    constructor(args: TextAreaInputArgs = TextAreaInput.defaultArgs) {
-        args = { ...TextAreaInput.defaultArgs, ...args };
+    constructor(args: TextAreaInputArgs = {}) {
         args = Object.assign({
             input: document.createElement('textarea')
         }, args);

--- a/src/components/TextInput/component.tsx
+++ b/src/components/TextInput/component.tsx
@@ -7,7 +7,7 @@ import BaseComponent from '../Element/component';
 class TextInput extends BaseComponent <TextInputArgs, any> {
     onValidate: (value: string) => boolean;
 
-    constructor(props: TextInputArgs = Element.defaultArgs) {
+    constructor(props: TextInputArgs = {}) {
         super(props);
         this.elementClass = Element;
 

--- a/src/components/TextInput/index.ts
+++ b/src/components/TextInput/index.ts
@@ -56,7 +56,7 @@ class TextInput extends Input implements IFocusable, IPlaceholder {
     protected _onInputChangeEvt: (evt: Event) => void;
 
     constructor(args: TextInputArgs = {}) {
-        super(args.dom ?? 'div', args);
+        super(args.dom, args);
 
         this.class.add(CLASS_TEXT_INPUT);
 

--- a/src/components/TextInput/index.ts
+++ b/src/components/TextInput/index.ts
@@ -35,13 +35,6 @@ export interface TextInputArgs extends InputArgs, IBindableArgs, IPlaceholderArg
  * The TextInput is an input element of type text.
  */
 class TextInput extends Input implements IFocusable, IPlaceholder {
-    static readonly defaultArgs: TextInputArgs = {
-        ...Input.defaultArgs,
-        blurOnEnter: true,
-        blurOnEscape: true,
-        dom: 'div'
-    };
-
     protected _domInput: HTMLInputElement;
 
     protected _suspendInputChangeEvt: boolean;
@@ -62,9 +55,8 @@ class TextInput extends Input implements IFocusable, IPlaceholder {
 
     protected _onInputChangeEvt: (evt: Event) => void;
 
-    constructor(args: TextInputArgs = TextInput.defaultArgs) {
-        args = { ...TextInput.defaultArgs, ...args };
-        super(args.dom, args);
+    constructor(args: TextInputArgs = {}) {
+        super(args.dom ?? 'div', args);
 
         this.class.add(CLASS_TEXT_INPUT);
 
@@ -96,11 +88,11 @@ class TextInput extends Input implements IFocusable, IPlaceholder {
         if (args.value !== undefined) {
             this.value = args.value;
         }
-        this.placeholder = args.placeholder || null;
-        this.renderChanges = args.renderChanges || false;
-        this.blurOnEnter = (args.blurOnEnter !== undefined ? args.blurOnEnter : true);
-        this.blurOnEscape = (args.blurOnEscape !== undefined ? args.blurOnEscape : true);
-        this.keyChange = args.keyChange || false;
+        this.placeholder = args.placeholder ?? null;
+        this.renderChanges = args.renderChanges ?? false;
+        this.blurOnEnter = args.blurOnEnter ?? true;
+        this.blurOnEscape = args.blurOnEscape ?? true;
+        this.keyChange = args.keyChange ?? false;
         this._prevValue = null;
 
         if (args.onValidate) {

--- a/src/components/TreeView/index.ts
+++ b/src/components/TreeView/index.ts
@@ -142,12 +142,6 @@ class TreeView extends Container {
      */
     public static readonly EVENT_RENAME = 'rename';
 
-    static defaultArgs : TreeViewArgs = {
-        ...Container.defaultArgs,
-        allowDrag: true,
-        allowReordering: true
-    };
-
     protected _selectedItems: TreeViewItem[];
 
     protected _dragItems: TreeViewItem[];
@@ -191,17 +185,16 @@ class TreeView extends Container {
      *
      * @param args - The arguments.
      */
-    constructor(args: TreeViewArgs = TreeView.defaultArgs) {
-        args = { ...TreeView.defaultArgs, ...args };
+    constructor(args: TreeViewArgs = {}) {
         super(args);
 
         this.class.add(CLASS_ROOT);
 
         this._selectedItems = [];
         this._dragItems = [];
-        this._allowDrag = (args.allowDrag !== undefined ? args.allowDrag : true);
-        this._allowReordering = (args.allowReordering !== undefined ? args.allowReordering : true);
-        this._allowRenaming = (args.allowRenaming !== undefined ? args.allowRenaming : false);
+        this._allowDrag = args.allowDrag ?? true;
+        this._allowReordering = args.allowReordering ?? true;
+        this._allowRenaming = args.allowRenaming ?? false;
         this._dragging = false;
         this._dragOverItem = null;
         this._dragArea = DRAG_AREA_INSIDE;

--- a/src/components/TreeViewItem/index.ts
+++ b/src/components/TreeViewItem/index.ts
@@ -52,11 +52,7 @@ export interface TreeViewItemArgs extends ContainerArgs {
     /**
      * Method to be called when the {@link TreeViewItem} is deselected.
      */
-    onDeselect?: () => void,
-    /**
-     * Use the flex layout type. Defaults to true.
-     */
-    flex?: boolean
+    onDeselect?: () => void
 }
 
 /**
@@ -147,7 +143,7 @@ class TreeViewItem extends Container {
 
         this._containerContents = new Container({
             class: CLASS_CONTENTS,
-            flex: args.flex ?? true,
+            flex: true,
             flexDirection: 'row',
             tabIndex: 0
         });

--- a/src/components/TreeViewItem/index.ts
+++ b/src/components/TreeViewItem/index.ts
@@ -52,22 +52,17 @@ export interface TreeViewItemArgs extends ContainerArgs {
     /**
      * Method to be called when the {@link TreeViewItem} is deselected.
      */
-    onDeselect?: () => void
+    onDeselect?: () => void,
+    /**
+     * Use the flex layout type. Defaults to true.
+     */
+    flex?: boolean
 }
 
 /**
  * A TreeViewItem is a single node in a hierarchical {@link TreeView} control.
  */
 class TreeViewItem extends Container {
-    static readonly defaultArgs: TreeViewItemArgs = {
-        ...Container.defaultArgs,
-        flex: true,
-        icon: 'E360',
-        allowSelect: true,
-        allowDrop: true,
-        allowDrag: true
-    };
-
     /**
      * Fired when user selects the TreeViewItem.
      *
@@ -145,15 +140,14 @@ class TreeViewItem extends Container {
      *
      * @param args - The arguments.
      */
-    constructor(args: TreeViewItemArgs = TreeViewItem.defaultArgs) {
-        args = { ...TreeViewItem.defaultArgs, ...args };
+    constructor(args: TreeViewItemArgs = {}) {
         super(args);
 
         this.class.add(CLASS_ROOT, CLASS_EMPTY);
 
         this._containerContents = new Container({
             class: CLASS_CONTENTS,
-            flex: true,
+            flex: args.flex ?? true,
             flexDirection: 'row',
             tabIndex: 0
         });
@@ -166,16 +160,16 @@ class TreeViewItem extends Container {
         });
         this._containerContents.append(this._labelIcon);
 
-        this.icon = args.icon;
+        this.icon = args.icon ?? 'E360';
 
         this._labelText = new Label({
             class: CLASS_TEXT
         });
         this._containerContents.append(this._labelText);
 
-        this.allowSelect = args.allowSelect;
-        this.allowDrop = args.allowDrop;
-        this.allowDrag = args.allowDrag;
+        this.allowSelect = args.allowSelect ?? true;
+        this.allowDrop = args.allowDrop ?? true;
+        this.allowDrag = args.allowDrag ?? true;
 
         if (args.text) {
             this.text = args.text;

--- a/src/components/VectorInput/index.ts
+++ b/src/components/VectorInput/index.ts
@@ -26,7 +26,7 @@ export interface VectorInputArgs extends ElementArgs, IPlaceholderArgs, IBindabl
      */
     step?: number;
     /**
-     * The decimal precision of each vector element.
+     * The decimal precision of each vector element. Defaults to 7.
      */
     precision?: number;
     /**
@@ -39,18 +39,11 @@ export interface VectorInputArgs extends ElementArgs, IPlaceholderArgs, IBindabl
  * A vector input. The vector can have 2 to 4 dimensions with each dimension being a {@link NumericInput}.
  */
 class VectorInput extends Element implements IBindable, IFocusable, IPlaceholder {
-    static readonly defaultArgs: VectorInputArgs = {
-        ...Element.defaultArgs,
-        dimensions: 3,
-        precision: 7
-    };
-
     protected _inputs: NumericInput[] = [];
 
     protected _applyingChange = false;
 
-    constructor(args: VectorInputArgs = VectorInput.defaultArgs) {
-        args = { ...VectorInput.defaultArgs, ...args };
+    constructor(args: VectorInputArgs = {}) {
 
         // set binding after inputs have been created
         const binding = args.binding;
@@ -60,13 +53,13 @@ class VectorInput extends Element implements IBindable, IFocusable, IPlaceholder
 
         this.class.add(CLASS_VECTOR_INPUT);
 
-        const dimensions = Math.max(2, Math.min(4, args.dimensions));
+        const dimensions = Math.max(2, Math.min(4, args.dimensions ?? 3));
 
         for (let i = 0; i < dimensions; i++) {
             const input = new NumericInput({
                 min: args.min,
                 max: args.max,
-                precision: args.precision,
+                precision: args.precision ?? 7,
                 step: args.step,
                 stepPrecision: args.stepPrecision,
                 renderChanges: args.renderChanges,


### PR DESCRIPTION
The current defaultArgs implementation in components can be confusing to interpret, it requires the inheritance of default args from parent classes and requires combination with user supplied arguments in the constructor. This can be replaced by supplying the necessary class properties with fallback values.