### PR TITLE
Export binding classes in the react build

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,7 @@ Observers can also be bound bi-directionally, in which case an element can both 
 
 ```jsx
 import { Observer } from '@playcanvas/observer';
-import { BindingTwoWay } from '@playcanvas/pcui';
-import { TextInput } from '@playcanvas/pcui/react';
+import { BindingTwoWay, TextInput } from '@playcanvas/pcui/react';
 import '@playcanvas/pcui/styles';
 
 // create a new observer for a simple object which contains a text string

--- a/docs/pages/5-examples/5-examples-history.markdown
+++ b/docs/pages/5-examples/5-examples-history.markdown
@@ -21,7 +21,7 @@ import React, { useState } from 'react';
 import ReactDOM from 'react-dom';
 
 import { Observer, History } from '@playcanvas/observer';
-import { Container, Button, SliderInput, Progress, Label, BindingTwoWay } from '@playcanvas/pcui';
+import { Container, Button, SliderInput, Progress, Label, BindingTwoWay } from '@playcanvas/pcui/react';
 
 const observer = new Observer({ progress: 0 });
 const history = new History();

--- a/docs/pages/5-examples/5-examples-todo.markdown
+++ b/docs/pages/5-examples/5-examples-todo.markdown
@@ -22,7 +22,7 @@ import React, { useState } from 'react';
 import ReactDOM from 'react-dom';
 import { Observer } from '@playcanvas/observer';
 
-import { Container, TextInput, BooleanInput, Label, SelectInput, Button, BindingTwoWay } from '@playcanvas/pcui';
+import { Container, TextInput, BooleanInput, Label, SelectInput, Button, BindingTwoWay } from '@playcanvas/pcui/react';
 
 const observer = new Observer({ input: '', items: {} });
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,1 +1,2 @@
+export * from './binding';
 export * from './components/components';


### PR DESCRIPTION
The react build currently references a different version of the BindingBase class from the one a user imports from `@playcanvas/pcui`. When importing components from `@playcanvas/pcui/react`, users should also import the binding classes from this build so both the binding classes and react components reference the same version of BindingBase.