### PR TITLE
Default tabIndex value fix

### DIFF
--- a/src/components/BooleanInput/index.ts
+++ b/src/components/BooleanInput/index.ts
@@ -27,8 +27,10 @@ class BooleanInput extends Input implements IBindable, IFocusable {
     protected _value: boolean;
 
     constructor(args: BooleanInputArgs = {}) {
-        args.tabIndex = args.tabIndex ?? 0;
-        super(args.dom, args);
+        // make copy of args
+        const booleanInputArgs = Object.assign({}, args);
+        booleanInputArgs.tabIndex = args.tabIndex ?? 0;
+        super(args.dom, booleanInputArgs);
 
         if (args.type === 'toggle') {
             this.class.add(CLASS_BOOLEAN_INPUT_TOGGLE);

--- a/src/components/GridViewItem/index.ts
+++ b/src/components/GridViewItem/index.ts
@@ -52,8 +52,10 @@ class GridViewItem extends Container implements IFocusable {
     protected _allowSelect: boolean;
 
     constructor(args: GridViewItemArgs = {}) {
-        args.tabIndex = args.tabIndex ?? 0;
-        super(args);
+        // make copy of args
+        const gridViewItemArgs = Object.assign({}, args);
+        gridViewItemArgs.tabIndex = args.tabIndex ?? 0;
+        super(gridViewItemArgs);
 
         this.allowSelect = args.allowSelect ?? true;
         this._type = args.type ?? null;

--- a/src/components/Menu/index.ts
+++ b/src/components/Menu/index.ts
@@ -33,8 +33,10 @@ class Menu extends Container implements IFocusable {
     protected _containerMenuItems: Container;
 
     constructor(args: MenuArgs = {}) {
-        args.tabIndex = args.tabIndex ?? 1;
-        super(args);
+        // make copy of args
+        const menuArgs = Object.assign({}, args);
+        menuArgs.tabIndex = args.tabIndex ?? 1;
+        super(menuArgs);
 
         this.hidden = args.hidden ?? true;
 

--- a/src/components/RadioButton/index.ts
+++ b/src/components/RadioButton/index.ts
@@ -18,8 +18,10 @@ class RadioButton extends Element implements IBindable, IFocusable {
     protected _renderChanges: boolean;
 
     constructor(args: RadioButtonArgs = {}) {
-        args.tabIndex = args.tabIndex ?? 0;
-        super(args.dom, args);
+        // make copy of args
+        const radioButtonArgs = Object.assign({}, args);
+        radioButtonArgs.tabIndex = args.tabIndex ?? 0;
+        super(args.dom, radioButtonArgs);
 
         this.class.add(CLASS_RADIO_BUTTON);
         this.class.add(pcuiClass.NOT_FLEXIBLE);


### PR DESCRIPTION
The args object should not be modified before it is copied otherwise the following error is thrown:
```
Uncaught TypeError: Cannot add property tabIndex, object is not extensible
    at new BooleanInput (index.js:37344:23)
```

This PR first copies the args object before updating this value., following the example in the Panel class.