### PR TITLE
React LabelGroup linking fix

### DIFF
--- a/src/components/LabelGroup/component.tsx
+++ b/src/components/LabelGroup/component.tsx
@@ -26,7 +26,7 @@ class LabelGroup extends BaseComponent <LabelGroupArgs, any> {
         if (!((child.type as JSXElementConstructor<any>).prototype instanceof BaseComponent)) {
             throw new Error(childrenErrorMessage);
         }
-        // it's safe to cast the ReactElement child as a BaseComponent as we have confirmed it is a BaseComponent above
+        // it's safe to cast the ReactElement type as a BaseComponent as we have confirmed it is a BaseComponent above
         const fieldClass = (child.type as unknown as typeof BaseComponent).ctor;
         const labelField = new fieldClass({ ...fieldProps });
         if (child.props.link) {

--- a/src/components/LabelGroup/component.tsx
+++ b/src/components/LabelGroup/component.tsx
@@ -1,6 +1,6 @@
 import Element, { LabelGroupArgs } from './index';
 import BaseComponent from '../Element/component';
-import { ReactElement } from 'react';
+import { JSXElementConstructor, ReactElement } from 'react';
 
 /**
  * Represents a group of a Label and a Element. Useful for rows of labeled fields.
@@ -23,14 +23,14 @@ class LabelGroup extends BaseComponent <LabelGroupArgs, any> {
         const child = this.props.children as ReactElement;
         const fieldProps = child.props as Record<any, any>;
         // check if the ReactElement contains an instance of a BaseComponent as its type, confirming it is a PCUI react component
-        if (!(child.type instanceof BaseComponent)) {
+        if (!((child.type as JSXElementConstructor<any>).prototype instanceof BaseComponent)) {
             throw new Error(childrenErrorMessage);
         }
         // it's safe to cast the ReactElement child as a BaseComponent as we have confirmed it is a BaseComponent above
         const fieldClass = (child.type as unknown as typeof BaseComponent).ctor;
         const labelField = new fieldClass({ ...fieldProps });
         if (child.props.link) {
-            labelField.link(fieldProps.link.observer, fieldProps.props.link.path);
+            labelField.link(fieldProps.link.observer, fieldProps.link.path);
         }
         this.element = new this.elementClass({
             ...this.props,

--- a/src/components/LabelGroup/component.tsx
+++ b/src/components/LabelGroup/component.tsx
@@ -27,7 +27,7 @@ class LabelGroup extends BaseComponent <LabelGroupArgs, any> {
             throw new Error(childrenErrorMessage);
         }
         // it's safe to cast the ReactElement type as a BaseComponent as we have confirmed it is a BaseComponent above
-        const fieldClass = (child.type as unknown as typeof BaseComponent).ctor;
+        const fieldClass = (child.type as typeof BaseComponent).ctor;
         const labelField = new fieldClass({ ...fieldProps });
         if (child.props.link) {
             labelField.link(fieldProps.link.observer, fieldProps.link.path);

--- a/src/components/LabelGroup/component.tsx
+++ b/src/components/LabelGroup/component.tsx
@@ -1,5 +1,6 @@
 import Element, { LabelGroupArgs } from './index';
 import BaseComponent from '../Element/component';
+import { ReactElement } from 'react';
 
 /**
  * Represents a group of a Label and a Element. Useful for rows of labeled fields.
@@ -13,13 +14,23 @@ class LabelGroup extends BaseComponent <LabelGroupArgs, any> {
 
     attachElement = (nodeElement: HTMLElement, containerElement: any) => {
         if (!nodeElement) return;
+        const childrenErrorMessage = 'A LabelGroup must contain a single PCUI react component as a child';
+        // check that the LabelGroup has a single child
         if (Array.isArray(this.props.children) || !this.props.children) {
-            throw new Error('A LabelGroup must contain a single child react component');
+            throw new Error(childrenErrorMessage);
         }
-        const labelFieldChild = (this.props.children as { type: any, props: any });
-        const labelField = new labelFieldChild.type.ctor(labelFieldChild.props);
-        if (labelFieldChild.props.link) {
-            labelField.link(labelFieldChild.props.link.observer, labelFieldChild.props.link.path);
+        // casting child as a single ReactElement as we have confirmed it is above
+        const child = this.props.children as ReactElement;
+        const fieldProps = child.props as Record<any, any>;
+        // check if the ReactElement contains an instance of a BaseComponent as its type, confirming it is a PCUI react component
+        if (!(child.type instanceof BaseComponent)) {
+            throw new Error(childrenErrorMessage);
+        }
+        // it's safe to cast the ReactElement child as a BaseComponent as we have confirmed it is a BaseComponent above
+        const fieldClass = (child.type as unknown as typeof BaseComponent).ctor;
+        const labelField = new fieldClass({ ...fieldProps });
+        if (child.props.link) {
+            labelField.link(fieldProps.link.observer, fieldProps.props.link.path);
         }
         this.element = new this.elementClass({
             ...this.props,

--- a/src/components/LabelGroup/component.tsx
+++ b/src/components/LabelGroup/component.tsx
@@ -16,13 +16,17 @@ class LabelGroup extends BaseComponent <LabelGroupArgs, any> {
         if (Array.isArray(this.props.children) || !this.props.children) {
             throw new Error('A LabelGroup must contain a single child react component');
         }
+        const labelFieldChild = (this.props.children as { type: any, props: any });
+        const labelField = new labelFieldChild.type.ctor(labelFieldChild.props);
+        if (labelFieldChild.props.link) {
+            labelField.link(labelFieldChild.props.link.observer, labelFieldChild.props.link.path);
+        }
         this.element = new this.elementClass({
             ...this.props,
             dom: nodeElement,
             container: containerElement,
             parent: undefined,
-            // @ts-ignore
-            field: new this.props.children.type.ctor(this.props.children.props)
+            field: labelField
         });
     };
 


### PR DESCRIPTION
React LabelGroup fields were not being linked to an observer when a link property was passed in. Updates to PCUI components wrapped in a LabelGroup should now correctly update their bound observer.