### PR TITLE
[BREAKING] Remove `Element#class` setter

### DIFF
--- a/src/components/Element/index.ts
+++ b/src/components/Element/index.ts
@@ -376,8 +376,6 @@ class Element extends Events {
 
     protected _dom: HTMLElement;
 
-    protected _class: string[];
-
     protected _hiddenParents: boolean;
 
     protected _flashTimeout: number;
@@ -440,17 +438,11 @@ class Element extends Events {
         // add font regular class
         this._dom.classList.add(pcuiClass.FONT_REGULAR);
 
-        this._class = [];
         // add user classes
         if (args.class) {
-            if (Array.isArray(args.class)) {
-                for (let i = 0; i < args.class.length; i++) {
-                    this._dom.classList.add(args.class[i]);
-                    this._class.push(args.class[i]);
-                }
-            } else {
-                this._dom.classList.add(args.class);
-                this._class.push(args.class);
+            const classes = Array.isArray(args.class) ? args.class : [args.class];
+            for (const cls of classes) {
+                this._dom.classList.add(cls);
             }
         }
 
@@ -929,21 +921,6 @@ class Element extends Events {
     /**
      * Shortcut to Element.dom.classList.
      */
-    set class(value: any) {
-        if (!Array.isArray(value)) {
-            value = [value];
-        }
-        value.forEach((cls: string) => {
-            this.classAdd(cls);
-        });
-        this._class.forEach((cls) => {
-            if (!value.includes(cls)) {
-                this.classRemove(cls);
-            }
-        });
-        this._class = value;
-    }
-
     get class(): DOMTokenList {
         return this._dom.classList;
     }

--- a/src/components/Element/index.ts
+++ b/src/components/Element/index.ts
@@ -919,7 +919,8 @@ class Element extends Events {
     }
 
     /**
-     * Shortcut to Element.dom.classList.
+     * Get the `DOMTokenList` of the underlying DOM element. This is essentially a shortcut to
+     * `element.dom.classList`.
      */
     get class(): DOMTokenList {
         return this._dom.classList;


### PR DESCRIPTION
The signature for the `Element#class` setter is:

```
set class(value: string | string[])
```

However, the getter has the signature:

```
get class(): DOMTokenList
```

This is problematic for TypeScript though:

![image](https://user-images.githubusercontent.com/697563/212440767-25d036da-b840-4e88-9d68-b9794d46fb6b.png)

So in the current codebase, the setter leaves the supplied value as an `any` type.

If the developer wants to set the class(es) on an Element, they should get the `class` (via the getter) and then simply call the `DOMTokenList#add` function. As it happens, this is exactly what all (PlayCanvas) PCUI apps do! I can find no instance anywhere where the `class` setter is called. Therefore, I am taking the opportunity to remove it from the API.