### PR TITLE
[BREAKING] Remove first parameter of `Element` constructor

### DIFF
--- a/src/components/ArrayInput/index.ts
+++ b/src/components/ArrayInput/index.ts
@@ -117,19 +117,17 @@ class ArrayInput extends Element implements IFocusable, IBindable {
 
     protected _renderChanges: boolean;
 
-    constructor(args: ArrayInputArgs = {}) {
-        // remove binding because we want to set it later
-        const binding = args.binding;
-        delete args.binding;
-
+    constructor(args: Readonly<ArrayInputArgs> = {}) {
         const container = new Container({
             dom: args.dom,
             flex: true
         });
 
-        args = { ...args, dom: container.dom };
+        const elementArgs = { ...args, dom: container.dom };
+        // remove binding because we want to set it later
+        delete elementArgs.binding;
 
-        super(args);
+        super(elementArgs);
 
         this._container = container;
         this._container.parent = this;
@@ -184,16 +182,19 @@ class ArrayInput extends Element implements IFocusable, IBindable {
             valueType = 'string';
         }
 
-        delete args.dom;
-
         this._valueType = valueType;
         this._elementType = args.type ?? 'string';
-        this._elementArgs = args.elementArgs || args;
+        if (args.elementArgs) {
+            this._elementArgs = args.elementArgs;
+        } else {
+            this._elementArgs = { ...args };
+            delete this._elementArgs.dom;
+        }
 
         this._arrayElements = [];
 
         // set binding now
-        this.binding = binding;
+        this.binding = args.binding;
 
         this._values = [];
 

--- a/src/components/ArrayInput/index.ts
+++ b/src/components/ArrayInput/index.ts
@@ -189,6 +189,7 @@ class ArrayInput extends Element implements IFocusable, IBindable {
         } else {
             this._elementArgs = { ...args };
             delete this._elementArgs.dom;
+            delete this._elementArgs.binding;
         }
 
         this._arrayElements = [];

--- a/src/components/ArrayInput/index.ts
+++ b/src/components/ArrayInput/index.ts
@@ -127,7 +127,9 @@ class ArrayInput extends Element implements IFocusable, IBindable {
             flex: true
         });
 
-        super(container.dom, args);
+        args.dom = container.dom;
+
+        super(args);
 
         this._container = container;
         this._container.parent = this;

--- a/src/components/ArrayInput/index.ts
+++ b/src/components/ArrayInput/index.ts
@@ -187,9 +187,8 @@ class ArrayInput extends Element implements IFocusable, IBindable {
         if (args.elementArgs) {
             this._elementArgs = args.elementArgs;
         } else {
-            this._elementArgs = { ...args };
-            delete this._elementArgs.dom;
-            delete this._elementArgs.binding;
+            delete elementArgs.dom;
+            this._elementArgs = elementArgs;
         }
 
         this._arrayElements = [];

--- a/src/components/ArrayInput/index.ts
+++ b/src/components/ArrayInput/index.ts
@@ -127,7 +127,7 @@ class ArrayInput extends Element implements IFocusable, IBindable {
             flex: true
         });
 
-        args.dom = container.dom;
+        args = { ...args, dom: container.dom };
 
         super(args);
 

--- a/src/components/BooleanInput/index.ts
+++ b/src/components/BooleanInput/index.ts
@@ -27,8 +27,9 @@ class BooleanInput extends Input implements IBindable, IFocusable {
     protected _value: boolean;
 
     constructor(args: BooleanInputArgs = {}) {
-        args.tabIndex = args.tabIndex ?? 0;
-        super(args.dom, args);
+        args.tabIndex ??= 0;
+
+        super(args);
 
         if (args.type === 'toggle') {
             this.class.add(CLASS_BOOLEAN_INPUT_TOGGLE);

--- a/src/components/BooleanInput/index.ts
+++ b/src/components/BooleanInput/index.ts
@@ -27,9 +27,10 @@ class BooleanInput extends Input implements IBindable, IFocusable {
     protected _value: boolean;
 
     constructor(args: Readonly<BooleanInputArgs> = {}) {
-        args = args.tabIndex === undefined ? { ...args, tabIndex: 0 } : args;
+        const elementArgs = { ...args };
+        elementArgs.tabIndex ??= 0;
 
-        super(args);
+        super(elementArgs);
 
         if (args.type === 'toggle') {
             this.class.add(CLASS_BOOLEAN_INPUT_TOGGLE);

--- a/src/components/BooleanInput/index.ts
+++ b/src/components/BooleanInput/index.ts
@@ -27,7 +27,7 @@ class BooleanInput extends Input implements IBindable, IFocusable {
     protected _value: boolean;
 
     constructor(args: BooleanInputArgs = {}) {
-        args.tabIndex ??= 0;
+        args = args.tabIndex === undefined ? { ...args, tabIndex: 0 } : args;
 
         super(args);
 

--- a/src/components/BooleanInput/index.ts
+++ b/src/components/BooleanInput/index.ts
@@ -27,9 +27,7 @@ class BooleanInput extends Input implements IBindable, IFocusable {
     protected _value: boolean;
 
     constructor(args: Readonly<BooleanInputArgs> = {}) {
-        const elementArgs = { tabIndex: 0, ...args };
-
-        super(elementArgs);
+        super({ tabIndex: 0, ...args });
 
         if (args.type === 'toggle') {
             this.class.add(CLASS_BOOLEAN_INPUT_TOGGLE);

--- a/src/components/BooleanInput/index.ts
+++ b/src/components/BooleanInput/index.ts
@@ -27,8 +27,7 @@ class BooleanInput extends Input implements IBindable, IFocusable {
     protected _value: boolean;
 
     constructor(args: Readonly<BooleanInputArgs> = {}) {
-        const elementArgs = { ...args };
-        elementArgs.tabIndex ??= 0;
+        const elementArgs = { tabIndex: 0, ...args };
 
         super(elementArgs);
 

--- a/src/components/BooleanInput/index.ts
+++ b/src/components/BooleanInput/index.ts
@@ -26,7 +26,7 @@ export interface BooleanInputArgs extends ElementArgs, IBindableArgs {
 class BooleanInput extends Input implements IBindable, IFocusable {
     protected _value: boolean;
 
-    constructor(args: BooleanInputArgs = {}) {
+    constructor(args: Readonly<BooleanInputArgs> = {}) {
         args = args.tabIndex === undefined ? { ...args, tabIndex: 0 } : args;
 
         super(args);

--- a/src/components/Button/index.ts
+++ b/src/components/Button/index.ts
@@ -38,7 +38,7 @@ class Button extends Element {
 
     protected _size: string | null;
 
-    constructor(args: ButtonArgs = {}) {
+    constructor(args: Readonly<ButtonArgs> = {}) {
         args = args.dom === undefined ? { ...args, dom: 'button' } : args;
 
         super(args);

--- a/src/components/Button/index.ts
+++ b/src/components/Button/index.ts
@@ -39,7 +39,7 @@ class Button extends Element {
     protected _size: string | null;
 
     constructor(args: ButtonArgs = {}) {
-        args.dom ??= 'button';
+        args = args.dom === undefined ? { ...args, dom: 'button' } : args;
 
         super(args);
 

--- a/src/components/Button/index.ts
+++ b/src/components/Button/index.ts
@@ -39,8 +39,7 @@ class Button extends Element {
     protected _size: string | null;
 
     constructor(args: Readonly<ButtonArgs> = {}) {
-        const elementArgs = { ...args };
-        elementArgs.dom ??= 'button';
+        const elementArgs = { dom: 'button', ...args };
 
         super(elementArgs);
 

--- a/src/components/Button/index.ts
+++ b/src/components/Button/index.ts
@@ -39,7 +39,8 @@ class Button extends Element {
     protected _size: string | null;
 
     constructor(args: Readonly<ButtonArgs> = {}) {
-        args = args.dom === undefined ? { ...args, dom: 'button' } : args;
+        const elementArgs = { ...args };
+        elementArgs.dom ??= 'button';
 
         super(args);
 

--- a/src/components/Button/index.ts
+++ b/src/components/Button/index.ts
@@ -42,7 +42,7 @@ class Button extends Element {
         const elementArgs = { ...args };
         elementArgs.dom ??= 'button';
 
-        super(args);
+        super(elementArgs);
 
         this.class.add(CLASS_BUTTON);
 

--- a/src/components/Button/index.ts
+++ b/src/components/Button/index.ts
@@ -39,9 +39,7 @@ class Button extends Element {
     protected _size: string | null;
 
     constructor(args: Readonly<ButtonArgs> = {}) {
-        const elementArgs = { dom: 'button', ...args };
-
-        super(elementArgs);
+        super({ dom: 'button', ...args });
 
         this.class.add(CLASS_BUTTON);
 

--- a/src/components/Button/index.ts
+++ b/src/components/Button/index.ts
@@ -39,7 +39,9 @@ class Button extends Element {
     protected _size: string | null;
 
     constructor(args: ButtonArgs = {}) {
-        super(args.dom ?? 'button', args);
+        args.dom ??= 'button';
+
+        super(args);
 
         this.class.add(CLASS_BUTTON);
 

--- a/src/components/Canvas/index.ts
+++ b/src/components/Canvas/index.ts
@@ -22,9 +22,10 @@ class Canvas extends Element {
     protected _ratio: number;
 
     constructor(args: Readonly<CanvasArgs> = {}) {
-        args = args.dom === undefined ? { ...args, dom: 'canvas' } : args;
+        const elementArgs = { ...args };
+        elementArgs.dom ??= 'canvas';
 
-        super(args);
+        super(elementArgs);
 
         const canvas = this._dom as HTMLCanvasElement;
         canvas.classList.add('pcui-canvas');

--- a/src/components/Canvas/index.ts
+++ b/src/components/Canvas/index.ts
@@ -22,8 +22,7 @@ class Canvas extends Element {
     protected _ratio: number;
 
     constructor(args: Readonly<CanvasArgs> = {}) {
-        const elementArgs = { ...args };
-        elementArgs.dom ??= 'canvas';
+        const elementArgs = { dom: 'canvas', ...args };
 
         super(elementArgs);
 

--- a/src/components/Canvas/index.ts
+++ b/src/components/Canvas/index.ts
@@ -21,7 +21,7 @@ class Canvas extends Element {
 
     protected _ratio: number;
 
-    constructor(args: CanvasArgs = {}) {
+    constructor(args: Readonly<CanvasArgs> = {}) {
         args = args.dom === undefined ? { ...args, dom: 'canvas' } : args;
 
         super(args);

--- a/src/components/Canvas/index.ts
+++ b/src/components/Canvas/index.ts
@@ -22,9 +22,7 @@ class Canvas extends Element {
     protected _ratio: number;
 
     constructor(args: Readonly<CanvasArgs> = {}) {
-        const elementArgs = { dom: 'canvas', ...args };
-
-        super(elementArgs);
+        super({ dom: 'canvas', ...args });
 
         const canvas = this._dom as HTMLCanvasElement;
         canvas.classList.add('pcui-canvas');

--- a/src/components/Canvas/index.ts
+++ b/src/components/Canvas/index.ts
@@ -22,7 +22,9 @@ class Canvas extends Element {
     protected _ratio: number;
 
     constructor(args: CanvasArgs = {}) {
-        super(args.dom ?? 'canvas', args);
+        args.dom ??= 'canvas';
+
+        super(args);
 
         const canvas = this._dom as HTMLCanvasElement;
         canvas.classList.add('pcui-canvas');

--- a/src/components/Canvas/index.ts
+++ b/src/components/Canvas/index.ts
@@ -22,7 +22,7 @@ class Canvas extends Element {
     protected _ratio: number;
 
     constructor(args: CanvasArgs = {}) {
-        args.dom ??= 'canvas';
+        args = args.dom === undefined ? { ...args, dom: 'canvas' } : args;
 
         super(args);
 

--- a/src/components/Code/index.ts
+++ b/src/components/Code/index.ts
@@ -23,8 +23,9 @@ class Code extends Container {
 
     protected _text: string;
 
-    constructor(args: CodeArgs = {}) {
+    constructor(args: Readonly<CodeArgs> = {}) {
         super(args);
+
         this.class.add(CLASS_ROOT);
 
         this._inner = new Label();

--- a/src/components/ColorPicker/index.ts
+++ b/src/components/ColorPicker/index.ts
@@ -87,7 +87,7 @@ class ColorPicker extends Element implements IBindable {
     protected _renderChanges: boolean;
 
     constructor(args: ColorPickerArgs = {}) {
-        super(args.dom, args);
+        super(args);
 
         this._size = 144;
         this._directInput = true;

--- a/src/components/ColorPicker/index.ts
+++ b/src/components/ColorPicker/index.ts
@@ -86,7 +86,7 @@ class ColorPicker extends Element implements IBindable {
 
     protected _renderChanges: boolean;
 
-    constructor(args: ColorPickerArgs = {}) {
+    constructor(args: Readonly<ColorPickerArgs> = {}) {
         super(args);
 
         this._size = 144;

--- a/src/components/Container/index.ts
+++ b/src/components/Container/index.ts
@@ -141,7 +141,7 @@ class Container extends Element {
     protected _draggedHeight: number;
 
     constructor(args: ContainerArgs = {}) {
-        super(args.dom, args);
+        super(args);
 
         this.class.add(CLASS_CONTAINER);
 

--- a/src/components/Container/index.ts
+++ b/src/components/Container/index.ts
@@ -140,7 +140,7 @@ class Container extends Element {
 
     protected _draggedHeight: number;
 
-    constructor(args: ContainerArgs = {}) {
+    constructor(args: Readonly<ContainerArgs> = {}) {
         super(args);
 
         this.class.add(CLASS_CONTAINER);

--- a/src/components/Divider/index.ts
+++ b/src/components/Divider/index.ts
@@ -11,7 +11,7 @@ export interface DividerArgs extends ElementArgs {}
  * Represents a vertical division between two elements.
  */
 class Divider extends Element {
-    constructor(args: DividerArgs = {}) {
+    constructor(args: Readonly<DividerArgs> = {}) {
         super(args);
 
         this.class.add(CLASS_ROOT);

--- a/src/components/Divider/index.ts
+++ b/src/components/Divider/index.ts
@@ -12,7 +12,7 @@ export interface DividerArgs extends ElementArgs {}
  */
 class Divider extends Element {
     constructor(args: DividerArgs = {}) {
-        super(args.dom, args);
+        super(args);
 
         this.class.add(CLASS_ROOT);
     }

--- a/src/components/Element/index.ts
+++ b/src/components/Element/index.ts
@@ -400,7 +400,7 @@ class Element extends Events {
 
     protected _onClickEvt: () => void;
 
-    constructor(dom: HTMLElement | string, args: ElementArgs = {}) {
+    constructor(args: ElementArgs = {}) {
         super();
 
         this._destroyed = false;
@@ -408,13 +408,9 @@ class Element extends Events {
 
         this._eventsParent = [];
 
-        if (typeof dom === 'string') {
-            this._dom = document.createElement(dom);
-        } else if (dom instanceof Node) {
-            this._dom = dom;
-        } else if (typeof args.dom === 'string') {
+        if (typeof args.dom === 'string') {
             this._dom = document.createElement(args.dom);
-        } else if (args.dom instanceof HTMLElement) {
+        } else if (args.dom instanceof Node) {
             this._dom = args.dom;
         } else {
             this._dom = document.createElement('div');

--- a/src/components/Element/index.ts
+++ b/src/components/Element/index.ts
@@ -400,7 +400,7 @@ class Element extends Events {
 
     protected _onClickEvt: () => void;
 
-    constructor(args: ElementArgs = {}) {
+    constructor(args: Readonly<ElementArgs> = {}) {
         super();
 
         this._destroyed = false;

--- a/src/components/GradientPicker/index.ts
+++ b/src/components/GradientPicker/index.ts
@@ -118,7 +118,7 @@ class GradientPicker extends Element {
      * @param args - The arguments. Extends the Element arguments. Any settable property can also
      * be set through the constructor.
      */
-    constructor(args: GradientPickerArgs = {}) {
+    constructor(args: Readonly<GradientPickerArgs> = {}) {
         super(args);
 
         this.class.add(CLASS_GRADIENT);

--- a/src/components/GradientPicker/index.ts
+++ b/src/components/GradientPicker/index.ts
@@ -119,7 +119,7 @@ class GradientPicker extends Element {
      * be set through the constructor.
      */
     constructor(args: GradientPickerArgs = {}) {
-        super(args.dom, args);
+        super(args);
 
         this.class.add(CLASS_GRADIENT);
 

--- a/src/components/GridView/index.ts
+++ b/src/components/GridView/index.ts
@@ -50,7 +50,7 @@ class GridView extends Container {
 
     protected _clickFn: any;
 
-    constructor(args: GridViewArgs = {}) {
+    constructor(args: Readonly<GridViewArgs> = {}) {
         super(args);
 
         this._vertical = !!args.vertical;

--- a/src/components/GridViewItem/index.ts
+++ b/src/components/GridViewItem/index.ts
@@ -52,7 +52,8 @@ class GridViewItem extends Container implements IFocusable {
     protected _allowSelect: boolean;
 
     constructor(args: GridViewItemArgs = {}) {
-        args.tabIndex = args.tabIndex ?? 0;
+        args.tabIndex ??= 0;
+
         super(args);
 
         this.allowSelect = args.allowSelect ?? true;

--- a/src/components/GridViewItem/index.ts
+++ b/src/components/GridViewItem/index.ts
@@ -52,9 +52,7 @@ class GridViewItem extends Container implements IFocusable {
     protected _allowSelect: boolean;
 
     constructor(args: Readonly<GridViewItemArgs> = {}) {
-        const containerArgs = { tabIndex: 0, ...args };
-
-        super(containerArgs);
+        super({ tabIndex: 0, ...args });
 
         this.allowSelect = args.allowSelect ?? true;
         this._type = args.type ?? null;

--- a/src/components/GridViewItem/index.ts
+++ b/src/components/GridViewItem/index.ts
@@ -52,7 +52,7 @@ class GridViewItem extends Container implements IFocusable {
     protected _allowSelect: boolean;
 
     constructor(args: GridViewItemArgs = {}) {
-        args.tabIndex ??= 0;
+        args = args.tabIndex === undefined ? { ...args, tabIndex: 0 } : args;
 
         super(args);
 

--- a/src/components/GridViewItem/index.ts
+++ b/src/components/GridViewItem/index.ts
@@ -51,7 +51,7 @@ class GridViewItem extends Container implements IFocusable {
 
     protected _allowSelect: boolean;
 
-    constructor(args: GridViewItemArgs = {}) {
+    constructor(args: Readonly<GridViewItemArgs> = {}) {
         args = args.tabIndex === undefined ? { ...args, tabIndex: 0 } : args;
 
         super(args);

--- a/src/components/GridViewItem/index.ts
+++ b/src/components/GridViewItem/index.ts
@@ -52,8 +52,7 @@ class GridViewItem extends Container implements IFocusable {
     protected _allowSelect: boolean;
 
     constructor(args: Readonly<GridViewItemArgs> = {}) {
-        const containerArgs = { ...args };
-        containerArgs.tabIndex ??= 0;
+        const containerArgs = { tabIndex: 0, ...args };
 
         super(containerArgs);
 

--- a/src/components/GridViewItem/index.ts
+++ b/src/components/GridViewItem/index.ts
@@ -52,9 +52,10 @@ class GridViewItem extends Container implements IFocusable {
     protected _allowSelect: boolean;
 
     constructor(args: Readonly<GridViewItemArgs> = {}) {
-        args = args.tabIndex === undefined ? { ...args, tabIndex: 0 } : args;
+        const containerArgs = { ...args };
+        containerArgs.tabIndex ??= 0;
 
-        super(args);
+        super(containerArgs);
 
         this.allowSelect = args.allowSelect ?? true;
         this._type = args.type ?? null;

--- a/src/components/InfoBox/index.ts
+++ b/src/components/InfoBox/index.ts
@@ -47,7 +47,7 @@ class InfoBox extends Container {
 
     protected _text: string;
 
-    constructor(args: InfoBoxArgs = {}) {
+    constructor(args: Readonly<InfoBoxArgs> = {}) {
         super(args);
 
         this.class.add(CLASS_INFOBOX);

--- a/src/components/InfoBox/index.ts
+++ b/src/components/InfoBox/index.ts
@@ -35,9 +35,9 @@ export interface InfoBoxArgs extends ContainerArgs {
  * Represents an information box.
  */
 class InfoBox extends Container {
-    protected _titleElement: Element;
+    protected _titleElement = new Element();
 
-    protected _textElement: Element;
+    protected _textElement = new Element();
 
     protected _unsafe: boolean;
 
@@ -51,8 +51,7 @@ class InfoBox extends Container {
         super(args);
 
         this.class.add(CLASS_INFOBOX);
-        this._titleElement = new Element(document.createElement('div'));
-        this._textElement = new Element(document.createElement('div'));
+
         this.append(this._titleElement);
         this.append(this._textElement);
 

--- a/src/components/Label/index.ts
+++ b/src/components/Label/index.ts
@@ -45,7 +45,7 @@ class Label extends Input implements IPlaceholder {
     protected _text: string;
 
     constructor(args: LabelArgs = {}) {
-        args.dom ??= 'span';
+        args = args.dom === undefined ? { ...args, dom: 'span' } : args;
 
         super(args);
 

--- a/src/components/Label/index.ts
+++ b/src/components/Label/index.ts
@@ -45,9 +45,7 @@ class Label extends Input implements IPlaceholder {
     protected _text: string;
 
     constructor(args: Readonly<LabelArgs> = {}) {
-        const elementArgs = { dom: 'span', ...args };
-
-        super(elementArgs);
+        super({ dom: 'span', ...args });
 
         this.class.add(CLASS_LABEL);
 

--- a/src/components/Label/index.ts
+++ b/src/components/Label/index.ts
@@ -45,7 +45,9 @@ class Label extends Input implements IPlaceholder {
     protected _text: string;
 
     constructor(args: LabelArgs = {}) {
-        super(args.dom ?? 'span', args);
+        args.dom ??= 'span';
+
+        super(args);
 
         this.class.add(CLASS_LABEL);
 

--- a/src/components/Label/index.ts
+++ b/src/components/Label/index.ts
@@ -45,8 +45,7 @@ class Label extends Input implements IPlaceholder {
     protected _text: string;
 
     constructor(args: Readonly<LabelArgs> = {}) {
-        const elementArgs = { ...args };
-        elementArgs.dom ??= 'span';
+        const elementArgs = { dom: 'span', ...args };
 
         super(elementArgs);
 

--- a/src/components/Label/index.ts
+++ b/src/components/Label/index.ts
@@ -45,9 +45,10 @@ class Label extends Input implements IPlaceholder {
     protected _text: string;
 
     constructor(args: Readonly<LabelArgs> = {}) {
-        args = args.dom === undefined ? { ...args, dom: 'span' } : args;
+        const elementArgs = { ...args };
+        elementArgs.dom ??= 'span';
 
-        super(args);
+        super(elementArgs);
 
         this.class.add(CLASS_LABEL);
 

--- a/src/components/Label/index.ts
+++ b/src/components/Label/index.ts
@@ -44,7 +44,7 @@ class Label extends Input implements IPlaceholder {
 
     protected _text: string;
 
-    constructor(args: LabelArgs = {}) {
+    constructor(args: Readonly<LabelArgs> = {}) {
         args = args.dom === undefined ? { ...args, dom: 'span' } : args;
 
         super(args);

--- a/src/components/LabelGroup/index.ts
+++ b/src/components/LabelGroup/index.ts
@@ -35,7 +35,7 @@ class LabelGroup extends Container {
 
     protected _field: Element;
 
-    constructor(args: LabelGroupArgs = {}) {
+    constructor(args: Readonly<LabelGroupArgs> = {}) {
         super(args);
 
         this.class.add(CLASS_LABEL_GROUP);

--- a/src/components/Menu/index.ts
+++ b/src/components/Menu/index.ts
@@ -33,9 +33,10 @@ class Menu extends Container implements IFocusable {
     protected _containerMenuItems: Container;
 
     constructor(args: Readonly<MenuArgs> = {}) {
-        args = args.tabIndex === undefined ? { ...args, tabIndex: 1 } : args;
+        const containerArgs = { ...args };
+        containerArgs.tabIndex ??= 1;
 
-        super(args);
+        super(containerArgs);
 
         this.hidden = args.hidden ?? true;
 

--- a/src/components/Menu/index.ts
+++ b/src/components/Menu/index.ts
@@ -33,8 +33,7 @@ class Menu extends Container implements IFocusable {
     protected _containerMenuItems: Container;
 
     constructor(args: Readonly<MenuArgs> = {}) {
-        const containerArgs = { ...args };
-        containerArgs.tabIndex ??= 1;
+        const containerArgs = { tabIndex: 1, ...args };
 
         super(containerArgs);
 

--- a/src/components/Menu/index.ts
+++ b/src/components/Menu/index.ts
@@ -32,7 +32,7 @@ export interface MenuArgs extends ContainerArgs {
 class Menu extends Container implements IFocusable {
     protected _containerMenuItems: Container;
 
-    constructor(args: MenuArgs = {}) {
+    constructor(args: Readonly<MenuArgs> = {}) {
         args = args.tabIndex === undefined ? { ...args, tabIndex: 1 } : args;
 
         super(args);

--- a/src/components/Menu/index.ts
+++ b/src/components/Menu/index.ts
@@ -33,7 +33,8 @@ class Menu extends Container implements IFocusable {
     protected _containerMenuItems: Container;
 
     constructor(args: MenuArgs = {}) {
-        args.tabIndex = args.tabIndex ?? 1;
+        args.tabIndex ??= 1;
+
         super(args);
 
         this.hidden = args.hidden ?? true;

--- a/src/components/Menu/index.ts
+++ b/src/components/Menu/index.ts
@@ -33,9 +33,7 @@ class Menu extends Container implements IFocusable {
     protected _containerMenuItems: Container;
 
     constructor(args: Readonly<MenuArgs> = {}) {
-        const containerArgs = { tabIndex: 1, ...args };
-
-        super(containerArgs);
+        super({ tabIndex: 1, ...args });
 
         this.hidden = args.hidden ?? true;
 

--- a/src/components/Menu/index.ts
+++ b/src/components/Menu/index.ts
@@ -33,7 +33,7 @@ class Menu extends Container implements IFocusable {
     protected _containerMenuItems: Container;
 
     constructor(args: MenuArgs = {}) {
-        args.tabIndex ??= 1;
+        args = args.tabIndex === undefined ? { ...args, tabIndex: 1 } : args;
 
         super(args);
 

--- a/src/components/MenuItem/index.ts
+++ b/src/components/MenuItem/index.ts
@@ -73,7 +73,7 @@ class MenuItem extends Container implements IBindable {
 
     protected _renderChanges: boolean;
 
-    constructor(args: MenuItemArgs = {}) {
+    constructor(args: Readonly<MenuItemArgs> = {}) {
         super(args);
 
         this.class.add(CLASS_MENU_ITEM);

--- a/src/components/NumericInput/index.ts
+++ b/src/components/NumericInput/index.ts
@@ -73,17 +73,13 @@ class NumericInput extends TextInput {
 
     protected _sliderUsed = false;
 
-    constructor(args: NumericInputArgs = {}) {
-        // make copy of args
-        args = Object.assign({}, args);
-        const value = args.value;
-        // delete value because we want to set it after
-        // the other arguments
-        delete args.value;
-        const renderChanges = args.renderChanges;
-        delete args.renderChanges;
+    constructor(args: Readonly<NumericInputArgs> = {}) {
+        const textInputArgs = { ...args };
+        // delete value because we want to set it after the other arguments
+        delete textInputArgs.value;
+        delete textInputArgs.renderChanges;
 
-        super(args);
+        super(textInputArgs);
 
         this.class.add(CLASS_NUMERIC_INPUT);
 
@@ -105,13 +101,13 @@ class NumericInput extends TextInput {
         }
 
         this._oldValue = undefined;
-        this.value = value;
+        this.value = args.value;
 
         this._historyCombine = false;
         this._historyPostfix = null;
         this._sliderPrevValue = 0;
 
-        this.renderChanges = renderChanges;
+        this.renderChanges = args.renderChanges;
 
         if (!args.hideSlider) {
             this._sliderControl = new Element();

--- a/src/components/NumericInput/index.ts
+++ b/src/components/NumericInput/index.ts
@@ -114,7 +114,7 @@ class NumericInput extends TextInput {
         this.renderChanges = renderChanges;
 
         if (!args.hideSlider) {
-            this._sliderControl = new Element(document.createElement('div'));
+            this._sliderControl = new Element();
             this._sliderControl.class.add(CLASS_NUMERIC_INPUT_SLIDER_CONTROL);
             this.dom.append(this._sliderControl.dom);
 

--- a/src/components/Overlay/index.ts
+++ b/src/components/Overlay/index.ts
@@ -27,7 +27,7 @@ export interface OverlayArgs extends ElementArgs {
 class Overlay extends Container {
     protected _domClickableOverlay: HTMLDivElement;
 
-    constructor(args: OverlayArgs = {}) {
+    constructor(args: Readonly<OverlayArgs> = {}) {
         super(args);
 
         this.class.add(CLASS_OVERLAY);

--- a/src/components/Panel/index.ts
+++ b/src/components/Panel/index.ts
@@ -128,15 +128,13 @@ class Panel extends Container {
      * @param args - The arguments. Extends the Container constructor arguments. All settable
      * properties can also be set through the constructor.
      */
-    constructor(args: PanelArgs = {}) {
+    constructor(args: Readonly<PanelArgs> = {}) {
+        const containerArgs = { ...args, flex: true };
+        delete containerArgs.grid;
+        delete containerArgs.flexDirection;
+        delete containerArgs.scrollable;
 
-        const panelArgs = Object.assign({}, args);
-        panelArgs.flex = true;
-        delete panelArgs.grid;
-        delete panelArgs.flexDirection;
-        delete panelArgs.scrollable;
-
-        super(panelArgs);
+        super(containerArgs);
 
         this.class.add(CLASS_PANEL);
 

--- a/src/components/Progress/index.ts
+++ b/src/components/Progress/index.ts
@@ -24,7 +24,7 @@ class Progress extends Container {
 
     protected _value: number;
 
-    constructor(args: ProgressArgs = {}) {
+    constructor(args: Readonly<ProgressArgs> = {}) {
         super(args);
         this.class.add(CLASS_ROOT);
 

--- a/src/components/Progress/index.ts
+++ b/src/components/Progress/index.ts
@@ -18,7 +18,9 @@ export interface ProgressArgs extends ContainerArgs {
  * Represents a bar that can highlight progress of an activity.
  */
 class Progress extends Container {
-    protected _inner: Element;
+    protected _inner = new Element({
+        class: CLASS_INNER
+    });
 
     protected _value: number;
 
@@ -26,9 +28,7 @@ class Progress extends Container {
         super(args);
         this.class.add(CLASS_ROOT);
 
-        this._inner = new Element(document.createElement('div'));
         this.append(this._inner);
-        this._inner.class.add(CLASS_INNER);
 
         if (args.value !== undefined) {
             this.value = args.value;

--- a/src/components/RadioButton/index.ts
+++ b/src/components/RadioButton/index.ts
@@ -18,9 +18,7 @@ class RadioButton extends Element implements IBindable, IFocusable {
     protected _renderChanges: boolean;
 
     constructor(args: Readonly<RadioButtonArgs> = {}) {
-        const elementArgs = { tabIndex: 0, ...args };
-
-        super(elementArgs);
+        super({ tabIndex: 0, ...args });
 
         this.class.add(CLASS_RADIO_BUTTON);
         this.class.add(pcuiClass.NOT_FLEXIBLE);

--- a/src/components/RadioButton/index.ts
+++ b/src/components/RadioButton/index.ts
@@ -18,9 +18,10 @@ class RadioButton extends Element implements IBindable, IFocusable {
     protected _renderChanges: boolean;
 
     constructor(args: Readonly<RadioButtonArgs> = {}) {
-        args = args.tabIndex === undefined ? { ...args, tabIndex: 0 } : args;
+        const elementArgs = { ...args };
+        elementArgs.tabIndex ??= 0;
 
-        super(args);
+        super(elementArgs);
 
         this.class.add(CLASS_RADIO_BUTTON);
         this.class.add(pcuiClass.NOT_FLEXIBLE);

--- a/src/components/RadioButton/index.ts
+++ b/src/components/RadioButton/index.ts
@@ -18,7 +18,7 @@ class RadioButton extends Element implements IBindable, IFocusable {
     protected _renderChanges: boolean;
 
     constructor(args: RadioButtonArgs = {}) {
-        args.tabIndex ??= 0;
+        args = args.tabIndex === undefined ? { ...args, tabIndex: 0 } : args;
 
         super(args);
 

--- a/src/components/RadioButton/index.ts
+++ b/src/components/RadioButton/index.ts
@@ -17,7 +17,7 @@ class RadioButton extends Element implements IBindable, IFocusable {
 
     protected _renderChanges: boolean;
 
-    constructor(args: RadioButtonArgs = {}) {
+    constructor(args: Readonly<RadioButtonArgs> = {}) {
         args = args.tabIndex === undefined ? { ...args, tabIndex: 0 } : args;
 
         super(args);

--- a/src/components/RadioButton/index.ts
+++ b/src/components/RadioButton/index.ts
@@ -18,8 +18,7 @@ class RadioButton extends Element implements IBindable, IFocusable {
     protected _renderChanges: boolean;
 
     constructor(args: Readonly<RadioButtonArgs> = {}) {
-        const elementArgs = { ...args };
-        elementArgs.tabIndex ??= 0;
+        const elementArgs = { tabIndex: 0, ...args };
 
         super(elementArgs);
 

--- a/src/components/RadioButton/index.ts
+++ b/src/components/RadioButton/index.ts
@@ -18,8 +18,9 @@ class RadioButton extends Element implements IBindable, IFocusable {
     protected _renderChanges: boolean;
 
     constructor(args: RadioButtonArgs = {}) {
-        args.tabIndex = args.tabIndex ?? 0;
-        super(args.dom, args);
+        args.tabIndex ??= 0;
+
+        super(args);
 
         this.class.add(CLASS_RADIO_BUTTON);
         this.class.add(pcuiClass.NOT_FLEXIBLE);

--- a/src/components/SelectInput/index.ts
+++ b/src/components/SelectInput/index.ts
@@ -138,7 +138,7 @@ class SelectInput extends Element implements IBindable, IFocusable {
 
     protected _renderChanges: boolean;
 
-    constructor(args: SelectInputArgs = {}) {
+    constructor(args: Readonly<SelectInputArgs> = {}) {
         // main container
         const container = new Container({
             dom: args.dom

--- a/src/components/SelectInput/index.ts
+++ b/src/components/SelectInput/index.ts
@@ -144,9 +144,9 @@ class SelectInput extends Element implements IBindable, IFocusable {
             dom: args.dom
         });
 
-        args = { ...args, dom: container.dom };
+        const elementArgs = { ...args, dom: container.dom };
 
-        super(args);
+        super(elementArgs);
 
         this._container = container;
         this._container.parent = this;

--- a/src/components/SelectInput/index.ts
+++ b/src/components/SelectInput/index.ts
@@ -143,6 +143,7 @@ class SelectInput extends Element implements IBindable, IFocusable {
         const container = new Container({
             dom: args.dom
         });
+
         args = { ...args, dom: container.dom };
 
         super(args);

--- a/src/components/SelectInput/index.ts
+++ b/src/components/SelectInput/index.ts
@@ -143,7 +143,7 @@ class SelectInput extends Element implements IBindable, IFocusable {
         const container = new Container({
             dom: args.dom
         });
-        args.dom = container.dom;
+        args = { ...args, dom: container.dom };
 
         super(args);
 

--- a/src/components/SelectInput/index.ts
+++ b/src/components/SelectInput/index.ts
@@ -140,8 +140,13 @@ class SelectInput extends Element implements IBindable, IFocusable {
 
     constructor(args: SelectInputArgs = {}) {
         // main container
-        const container = new Container({ dom: args.dom });
-        super(container.dom, args);
+        const container = new Container({
+            dom: args.dom
+        });
+        args.dom = container.dom;
+
+        super(args);
+
         this._container = container;
         this._container.parent = this;
 

--- a/src/components/SliderInput/index.ts
+++ b/src/components/SliderInput/index.ts
@@ -75,7 +75,7 @@ class SliderInput extends Element implements IBindable, IFocusable {
      *
      * @param args - The arguments.
      */
-    constructor(args: SliderInputArgs = {}) {
+    constructor(args: Readonly<SliderInputArgs> = {}) {
         super(args);
 
         this.class.add(CLASS_SLIDER);

--- a/src/components/SliderInput/index.ts
+++ b/src/components/SliderInput/index.ts
@@ -52,7 +52,7 @@ export interface SliderInputArgs extends ElementArgs, IBindableArgs, IFlexArgs {
 class SliderInput extends Element implements IBindable, IFocusable {
     protected _historyCombine = false;
 
-    protected _historyPostfix: any = null;
+    protected _historyPostfix: string = null;
 
     protected _numericInput: NumericInput;
 

--- a/src/components/SliderInput/index.ts
+++ b/src/components/SliderInput/index.ts
@@ -76,7 +76,7 @@ class SliderInput extends Element implements IBindable, IFocusable {
      * @param args - The arguments.
      */
     constructor(args: SliderInputArgs = {}) {
-        super(args.dom, args);
+        super(args);
 
         this.class.add(CLASS_SLIDER);
 

--- a/src/components/Spinner/index.ts
+++ b/src/components/Spinner/index.ts
@@ -39,12 +39,11 @@ class Spinner extends Element {
      * @param args - The arguments.
      */
     constructor(args: SpinnerArgs = {}) {
-        let dom = null;
         if ((args.type ?? 'small-thick') === Spinner.TYPE_SMALL_THICK) {
-            dom = createSmallThick(args.size ?? 12, args.dom);
+            args.dom = createSmallThick(args.size ?? 12, args.dom);
         }
 
-        super(dom, args);
+        super(args);
 
         this.class.add(CLASS_ROOT);
     }

--- a/src/components/Spinner/index.ts
+++ b/src/components/Spinner/index.ts
@@ -40,7 +40,8 @@ class Spinner extends Element {
      */
     constructor(args: SpinnerArgs = {}) {
         if ((args.type ?? 'small-thick') === Spinner.TYPE_SMALL_THICK) {
-            args.dom = createSmallThick(args.size ?? 12, args.dom);
+            const dom = createSmallThick(args.size ?? 12, args.dom);
+            args = { ...args, dom };
         }
 
         super(args);

--- a/src/components/Spinner/index.ts
+++ b/src/components/Spinner/index.ts
@@ -38,7 +38,7 @@ class Spinner extends Element {
      *
      * @param args - The arguments.
      */
-    constructor(args: SpinnerArgs = {}) {
+    constructor(args: Readonly<SpinnerArgs> = {}) {
         if ((args.type ?? 'small-thick') === Spinner.TYPE_SMALL_THICK) {
             const dom = createSmallThick(args.size ?? 12, args.dom);
             args = { ...args, dom };

--- a/src/components/TextAreaInput/index.ts
+++ b/src/components/TextAreaInput/index.ts
@@ -23,7 +23,7 @@ export interface TextAreaInputArgs extends TextInputArgs {
  * The TextAreaInput wraps a textarea element. It has the same interface as {@link TextInput}.
  */
 class TextAreaInput extends TextInput {
-    constructor(args: TextAreaInputArgs = {}) {
+    constructor(args: Readonly<TextAreaInputArgs> = {}) {
         args = Object.assign({
             input: document.createElement('textarea')
         }, args);

--- a/src/components/TextInput/index.ts
+++ b/src/components/TextInput/index.ts
@@ -55,7 +55,7 @@ class TextInput extends Input implements IFocusable, IPlaceholder {
 
     protected _onInputChangeEvt: (evt: Event) => void;
 
-    constructor(args: TextInputArgs = {}) {
+    constructor(args: Readonly<TextInputArgs> = {}) {
         super(args);
 
         this.class.add(CLASS_TEXT_INPUT);

--- a/src/components/TextInput/index.ts
+++ b/src/components/TextInput/index.ts
@@ -56,7 +56,7 @@ class TextInput extends Input implements IFocusable, IPlaceholder {
     protected _onInputChangeEvt: (evt: Event) => void;
 
     constructor(args: TextInputArgs = {}) {
-        super(args.dom, args);
+        super(args);
 
         this.class.add(CLASS_TEXT_INPUT);
 

--- a/src/components/TreeView/index.ts
+++ b/src/components/TreeView/index.ts
@@ -200,7 +200,7 @@ class TreeView extends Container {
         this._dragArea = DRAG_AREA_INSIDE;
         this._dragScroll = 0;
         this._dragScrollInterval = null;
-        this._dragHandle = new Element(document.createElement('div'), {
+        this._dragHandle = new Element({
             class: CLASS_DRAGGED_HANDLE
         });
         this._dragScrollElement = args.dragScrollElement || this;

--- a/src/components/TreeView/index.ts
+++ b/src/components/TreeView/index.ts
@@ -185,7 +185,7 @@ class TreeView extends Container {
      *
      * @param args - The arguments.
      */
-    constructor(args: TreeViewArgs = {}) {
+    constructor(args: Readonly<TreeViewArgs> = {}) {
         super(args);
 
         this.class.add(CLASS_ROOT);

--- a/src/components/TreeViewItem/index.ts
+++ b/src/components/TreeViewItem/index.ts
@@ -136,7 +136,7 @@ class TreeViewItem extends Container {
      *
      * @param args - The arguments.
      */
-    constructor(args: TreeViewItemArgs = {}) {
+    constructor(args: Readonly<TreeViewItemArgs> = {}) {
         super(args);
 
         this.class.add(CLASS_ROOT, CLASS_EMPTY);

--- a/src/components/VectorInput/index.ts
+++ b/src/components/VectorInput/index.ts
@@ -49,7 +49,7 @@ class VectorInput extends Element implements IBindable, IFocusable, IPlaceholder
         const binding = args.binding;
         delete args.binding;
 
-        super(args.dom ? args.dom : document.createElement('div'), args);
+        super(args);
 
         this.class.add(CLASS_VECTOR_INPUT);
 

--- a/src/components/VectorInput/index.ts
+++ b/src/components/VectorInput/index.ts
@@ -43,13 +43,12 @@ class VectorInput extends Element implements IBindable, IFocusable, IPlaceholder
 
     protected _applyingChange = false;
 
-    constructor(args: VectorInputArgs = {}) {
-
+    constructor(args: Readonly<VectorInputArgs> = {}) {
+        const elementArgs = { ...args };
         // set binding after inputs have been created
-        const binding = args.binding;
-        delete args.binding;
+        delete elementArgs.binding;
 
-        super(args);
+        super(elementArgs);
 
         this.class.add(CLASS_VECTOR_INPUT);
 
@@ -82,8 +81,8 @@ class VectorInput extends Element implements IBindable, IFocusable, IPlaceholder
 
         // set the binding after the inputs have been created
         // because we rely on them in the overridden setter
-        if (binding) {
-            this.binding = binding;
+        if (args.binding) {
+            this.binding = args.binding;
         }
 
         if (args.value !== undefined) {


### PR DESCRIPTION
At the moment, you can set the DOM element when creating a PCUI Element by setting the first parameter of the `Element` constructor or by setting the `dom` property of the `ElementArgs` options object. The code gives precedence to the first parameter of the constructor, but otherwise, there appears to be little reason why the parameter is needed at all. It makes the constructor signature of `Element` needlessly different to every other PCUI element class. Therefore, this PR removes it.

As an aside, this PR makes all constructor options objects read-only. The utility type `Readonly<...>` has been applied to the options object parameter types. For instances where an options objects must to be written to, it is shallow copied to a new object using object destructuring.

Fixes #260