### PR TITLE
[BREAKING] Remove `Element#classAdd` and `Element#classRemove`

### DIFF
--- a/src/components/Container/index.ts
+++ b/src/components/Container/index.ts
@@ -704,9 +704,9 @@ class Container extends Element {
         this._flex = value;
 
         if (value) {
-            this.classAdd(pcuiClass.FLEX);
+            this.class.add(pcuiClass.FLEX);
         } else {
-            this.classRemove(pcuiClass.FLEX);
+            this.class.remove(pcuiClass.FLEX);
         }
     }
 
@@ -723,9 +723,9 @@ class Container extends Element {
         this._grid = value;
 
         if (value) {
-            this.classAdd(pcuiClass.GRID);
+            this.class.add(pcuiClass.GRID);
         } else {
-            this.classRemove(pcuiClass.GRID);
+            this.class.remove(pcuiClass.GRID);
         }
     }
 
@@ -742,9 +742,9 @@ class Container extends Element {
         this._scrollable = value;
 
         if (value) {
-            this.classAdd(pcuiClass.SCROLLABLE);
+            this.class.add(pcuiClass.SCROLLABLE);
         } else {
-            this.classRemove(pcuiClass.SCROLLABLE);
+            this.class.remove(pcuiClass.SCROLLABLE);
         }
 
     }
@@ -767,7 +767,7 @@ class Container extends Element {
 
         // remove old class
         if (this._resizable) {
-            this.classRemove(`${pcuiClass.RESIZABLE}-${this._resizable}`);
+            this.class.remove(`${pcuiClass.RESIZABLE}-${this._resizable}`);
         }
 
         this._resizable = value;
@@ -775,8 +775,8 @@ class Container extends Element {
 
         if (value) {
             // add resize class and create / append resize handle
-            this.classAdd(pcuiClass.RESIZABLE);
-            this.classAdd(`${pcuiClass.RESIZABLE}-${value}`);
+            this.class.add(pcuiClass.RESIZABLE);
+            this.class.add(`${pcuiClass.RESIZABLE}-${value}`);
 
             if (!this._domResizeHandle) {
                 this._createResizeHandle();
@@ -784,7 +784,7 @@ class Container extends Element {
             this._dom.appendChild(this._domResizeHandle);
         } else {
             // remove resize class and resize handle
-            this.classRemove(pcuiClass.RESIZABLE);
+            this.class.remove(pcuiClass.RESIZABLE);
             if (this._domResizeHandle) {
                 this._dom.removeChild(this._domResizeHandle);
             }

--- a/src/components/Element/index.ts
+++ b/src/components/Element/index.ts
@@ -586,10 +586,10 @@ class Element extends Events {
     flash() {
         if (this._flashTimeout) return;
 
-        this.classAdd(pcuiClass.FLASH);
+        this.class.add(pcuiClass.FLASH);
         this._flashTimeout = window.setTimeout(() => {
             this._flashTimeout = null;
-            this.classRemove(pcuiClass.FLASH);
+            this.class.remove(pcuiClass.FLASH);
         }, 200);
     }
 
@@ -617,9 +617,9 @@ class Element extends Events {
 
     protected _onEnabledChange(enabled: boolean) {
         if (enabled) {
-            this.classRemove(pcuiClass.DISABLED);
+            this.class.remove(pcuiClass.DISABLED);
         } else {
-            this.classAdd(pcuiClass.DISABLED);
+            this.class.add(pcuiClass.DISABLED);
         }
 
         this.emit(enabled ? 'enable' : 'disable');
@@ -661,9 +661,9 @@ class Element extends Events {
 
     protected _onReadOnlyChange(readOnly: boolean) {
         if (readOnly) {
-            this.classAdd(pcuiClass.READONLY);
+            this.class.add(pcuiClass.READONLY);
         } else {
-            this.classRemove(pcuiClass.READONLY);
+            this.class.remove(pcuiClass.READONLY);
         }
 
         this.emit('readOnly', readOnly);
@@ -679,31 +679,6 @@ class Element extends Events {
             if (!this._readOnly) {
                 this._onReadOnlyChange(false);
             }
-        }
-
-    }
-
-    /**
-     * Adds the specified class to the DOM element but checks if the classList contains it first.
-     *
-     * @param cls - The class to add.
-     */
-    classAdd(cls: string) {
-        const classList = this._dom.classList;
-        if (!classList.contains(cls)) {
-            classList.add(cls);
-        }
-    }
-
-    /**
-     * Removes the specified class from the DOM element but checks if the classList contains it first.
-     *
-     * @param cls - The class to remove.
-     */
-    classRemove(cls: string) {
-        const classList = this._dom.classList;
-        if (classList.contains(cls)) {
-            classList.remove(cls);
         }
     }
 
@@ -861,9 +836,9 @@ class Element extends Events {
         this._hidden = value;
 
         if (value) {
-            this.classAdd(pcuiClass.HIDDEN);
+            this.class.add(pcuiClass.HIDDEN);
         } else {
-            this.classRemove(pcuiClass.HIDDEN);
+            this.class.remove(pcuiClass.HIDDEN);
         }
 
         this.emit(value ? 'hide' : 'show');
@@ -909,9 +884,9 @@ class Element extends Events {
         if (this._hasError === value) return;
         this._hasError = value;
         if (value) {
-            this.classAdd(pcuiClass.ERROR);
+            this.class.add(pcuiClass.ERROR);
         } else {
-            this.classRemove(pcuiClass.ERROR);
+            this.class.remove(pcuiClass.ERROR);
         }
     }
 
@@ -934,11 +909,11 @@ class Element extends Events {
             value = [value];
         }
         value.forEach((cls: string) => {
-            this.classAdd(cls);
+            this.class.add(cls);
         });
         this._class.forEach((cls) => {
             if (!value.includes(cls)) {
-                this.classRemove(cls);
+                this.class.remove(cls);
             }
         });
         this._class = value;

--- a/src/components/GridViewItem/index.ts
+++ b/src/components/GridViewItem/index.ts
@@ -153,7 +153,7 @@ class GridViewItem extends Container implements IFocusable {
             if (this._radioButton)
                 this._radioButton.value = value;
             else
-                this.classAdd(CLASS_SELECTED);
+                this.class.add(CLASS_SELECTED);
 
             this.emit('select', this);
         } else {
@@ -161,7 +161,7 @@ class GridViewItem extends Container implements IFocusable {
             if (this._radioButton)
                 this._radioButton.value = false;
             else
-                this.classRemove(CLASS_SELECTED);
+                this.class.remove(CLASS_SELECTED);
 
             this.emit('deselect', this);
         }

--- a/src/components/Panel/index.ts
+++ b/src/components/Panel/index.ts
@@ -367,9 +367,9 @@ class Panel extends Container {
         this._collapsible = value;
 
         if (value) {
-            this.classAdd(pcuiClass.COLLAPSIBLE);
+            this.class.add(pcuiClass.COLLAPSIBLE);
         } else {
-            this.classRemove(pcuiClass.COLLAPSIBLE);
+            this.class.remove(pcuiClass.COLLAPSIBLE);
         }
 
         this._reflow();
@@ -460,9 +460,9 @@ class Panel extends Container {
 
         this._collapseHorizontally = value;
         if (value) {
-            this.classAdd(CLASS_PANEL_HORIZONTAL);
+            this.class.add(CLASS_PANEL_HORIZONTAL);
         } else {
-            this.classRemove(CLASS_PANEL_HORIZONTAL);
+            this.class.remove(CLASS_PANEL_HORIZONTAL);
         }
 
         this._reflow();

--- a/src/components/TreeViewItem/index.ts
+++ b/src/components/TreeViewItem/index.ts
@@ -217,7 +217,7 @@ class TreeViewItem extends Container {
         if (!(element instanceof TreeViewItem)) return;
 
         this._numChildren++;
-        if (this._parent !== this._treeView) this.classRemove(CLASS_EMPTY);
+        if (this._parent !== this._treeView) this.class.remove(CLASS_EMPTY);
 
         if (this._treeView) {
             this._treeView._onAppendTreeViewItem(element);
@@ -228,7 +228,7 @@ class TreeViewItem extends Container {
         if (element instanceof TreeViewItem) {
             this._numChildren--;
             if (this._numChildren === 0) {
-                this.classAdd(CLASS_EMPTY);
+                this.class.add(CLASS_EMPTY);
             }
 
             if (this._treeView) {
@@ -357,7 +357,7 @@ class TreeViewItem extends Container {
     };
 
     rename() {
-        this.classAdd(CLASS_RENAME);
+        this.class.add(CLASS_RENAME);
 
         // show text input to enter new text
         const textInput = new TextInput({
@@ -371,7 +371,7 @@ class TreeViewItem extends Container {
         });
 
         textInput.on('destroy', () => {
-            this.classRemove(CLASS_RENAME);
+            this.class.remove(CLASS_RENAME);
             this.focus();
         });
 
@@ -415,7 +415,7 @@ class TreeViewItem extends Container {
         }
 
         if (value) {
-            this._containerContents.classAdd(CLASS_SELECTED);
+            this._containerContents.class.add(CLASS_SELECTED);
             this.emit('select', this);
             if (this._treeView) {
                 this._treeView._onChildSelected(this);
@@ -423,7 +423,7 @@ class TreeViewItem extends Container {
 
             this.focus();
         } else {
-            this._containerContents.classRemove(CLASS_SELECTED);
+            this._containerContents.class.remove(CLASS_SELECTED);
             this.blur();
             this.emit('deselect', this);
             if (this._treeView) {
@@ -474,10 +474,10 @@ class TreeViewItem extends Container {
         if (value) {
             if (!this.numChildren) return;
 
-            this.classAdd(CLASS_OPEN);
+            this.class.add(CLASS_OPEN);
             this.emit('open', this);
         } else {
-            this.classRemove(CLASS_OPEN);
+            this.class.remove(CLASS_OPEN);
             this.emit('close', this);
         }
     }


### PR DESCRIPTION
This PR removes `Element#classAdd` and `Element#classRemove` from the API. Let's examine the docs for `Element#classAdd`:

> Adds the specified class to the DOM element but checks if the classList contains it first.

It performs this check using the [`DOMTokenList#contains`](https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList/contains) function.

Now let's examine the docs for [`DOMTokenList#add`](https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList/add):

> The add() method of the DOMTokenList interface adds the given tokens to the list, omitting any that are already present.

So `Element#classAdd` is entirely redundant because `DOMTokenList#add` _already_ checks if a supplied class name is already present and does not add it twice.

The same applies to `Element#classRemove`.

Most of the PCUI codebase (plus apps built on PCUI) already do `element.class.add/remove` instead of `element.classAdd/Remove`. This PR migrates the remaining occurrences to simply use the `DOMTokenList` API.