### PR TITLE
Type `searchItems` function

### DIFF
--- a/src/components/TreeView/index.ts
+++ b/src/components/TreeView/index.ts
@@ -418,11 +418,11 @@ class TreeView extends Container {
         });
     }
 
-    protected _onRemoveTreeViewItem(element: TreeViewItem) {
-        element.selected = false;
+    protected _onRemoveTreeViewItem(item: TreeViewItem) {
+        item.selected = false;
 
         // do the same for all children of the element
-        element.forEachChild((child) => {
+        item.forEachChild((child) => {
             if (child instanceof TreeViewItem) {
                 this._onRemoveTreeViewItem(child);
             }

--- a/src/components/TreeView/index.ts
+++ b/src/components/TreeView/index.ts
@@ -401,17 +401,17 @@ class TreeView extends Container {
         super._onRemoveChild(element);
     }
 
-    protected _onAppendTreeViewItem(element: TreeViewItem) {
-        element.treeView = this;
+    protected _onAppendTreeViewItem(item: TreeViewItem) {
+        item.treeView = this;
 
         if (this._filter) {
             // add new item to filtered results if it
             // satisfies the current filter
-            this._searchItems([[element.text, element]], this._filter);
+            this._searchItems([[item.text, item]], this._filter);
         }
 
         // do the same for all children of the element
-        element.forEachChild((child) => {
+        item.forEachChild((child) => {
             if (child instanceof TreeViewItem) {
                 this._onAppendTreeViewItem(child);
             }

--- a/src/components/TreeView/index.ts
+++ b/src/components/TreeView/index.ts
@@ -984,7 +984,7 @@ class TreeView extends Container {
         this.emit('rename', item, newName);
     }
 
-    protected _searchItems(searchArr: any, filter: string) {
+    protected _searchItems(searchArr: [string, TreeViewItem][], filter: string) {
         const results = searchItems(searchArr, filter);
         if (!results.length) return;
 
@@ -1007,7 +1007,7 @@ class TreeView extends Container {
 
         this.class.add(CLASS_FILTERING);
 
-        const search: any[][] = [];
+        const search: [string, TreeViewItem][] = [];
         this._traverseDepthFirst((item) => {
             search.push([item.text, item]);
         });

--- a/src/components/TreeViewItem/index.ts
+++ b/src/components/TreeViewItem/index.ts
@@ -1,3 +1,4 @@
+import Element from '../Element';
 import Label from '../Label';
 import Container, { ContainerArgs } from '../Container';
 import TextInput from '../TextInput';
@@ -211,20 +212,22 @@ class TreeViewItem extends Container {
         super.destroy();
     }
 
-    protected _onAppendChild(element: any) {
+    protected _onAppendChild(element: Element) {
         super._onAppendChild(element);
 
-        if (!(element instanceof TreeViewItem)) return;
+        if (element instanceof TreeViewItem) {
+            this._numChildren++;
+            if (this._parent !== this._treeView) {
+                this.classRemove(CLASS_EMPTY);
+            }
 
-        this._numChildren++;
-        if (this._parent !== this._treeView) this.classRemove(CLASS_EMPTY);
-
-        if (this._treeView) {
-            this._treeView._onAppendTreeViewItem(element);
+            if (this._treeView) {
+                this._treeView._onAppendTreeViewItem(element);
+            }
         }
     }
 
-    protected _onRemoveChild(element: any) {
+    protected _onRemoveChild(element: Element) {
         if (element instanceof TreeViewItem) {
             this._numChildren--;
             if (this._numChildren === 0) {

--- a/src/helpers/search.ts
+++ b/src/helpers/search.ts
@@ -83,12 +83,21 @@ type SearchRecord<Type> = {
 };
 
 type SearchArgs = {
+    /**
+     * Tolerance for how many characters of the search string must be contained in the item name. Default is 0.5.
+     */
     containsCharsTolerance?: number;
+    /**
+     * Tolerance for how many edits are allowed between the search string and the item name. Default is 0.5.
+     */
     editsDistanceTolerance?: number;
+    /**
+     * Limit the number of results. If not set, all results will be returned.
+     */
     limitResults?: number;
 };
 
-const _searchItems = <Type>(items: SearchRecord<Type>[], search: string, args: Readonly<SearchArgs>) => {
+const _searchItems = <Type>(items: SearchRecord<Type>[], search: string, args: Readonly<SearchArgs>): SearchRecord<Type>[] => {
     const results: SearchRecord<Type>[] = [];
 
     for (const item of items) {
@@ -168,11 +177,6 @@ const _searchItems = <Type>(items: SearchRecord<Type>[], search: string, args: R
  * second value is an object to be found.
  * @param search - String to search for.
  * @param args - Search arguments.
- * @param args.containsCharsTolerance - Tolerance for how many characters of the search string
- * must be contained in the item name. Default is 0.5.
- * @param args.editsDistanceTolerance - Tolerance for how many edits are allowed between the
- * search string and the item name. Default is 0.5.
- * @param args.limitResults - Limit the number of results. Default is 0 (no limit).
  * @returns Array of found items.
  * @example
  * const items = [

--- a/src/helpers/search.ts
+++ b/src/helpers/search.ts
@@ -73,13 +73,25 @@ const searchStringTokenize = (name: string): string[] => {
     return tokens;
 };
 
+type SearchRecord<Type> = {
+    name: string;
+    item: Type;
+    tokens: string[];
+    edits: number;
+    subFull: number;
+    sub: number;
+};
 
-const _searchItems = (items: any, search: string, args: any) => {
-    const results: any = [];
+type SearchArgs = {
+    containsCharsTolerance?: number;
+    editsDistanceTolerance?: number;
+    limitResults?: number;
+};
 
-    for (let i = 0; i < items.length; i++) {
-        const item = items[i];
+const _searchItems = <Type>(items: SearchRecord<Type>[], search: string, args: Readonly<SearchArgs>) => {
+    const results: SearchRecord<Type>[] = [];
 
+    for (const item of items) {
         // direct hit
         if (item.subFull !== Infinity) {
             results.push(item);
@@ -149,21 +161,30 @@ const _searchItems = (items: any, search: string, args: any) => {
     return results;
 };
 
-// perform search through items
-// items is an array with arrays of two values
-// where first value is a string to be searched by
-// and second value is an object to be found
-//
-// [
-//     [ 'camera', {object} ],
-//     [ 'New Entity', {object} ],
-//     [ 'Sun', {object} ]
-// ]
-//
-export const searchItems = (items: any, search: string, args?: any) => {
-    let i;
-
-    search = (search || '').toLowerCase().trim();
+/**
+ * Perform search through items.
+ *
+ * @param items - Array of tuples where the first value is a string to be searched by and the
+ * second value is an object to be found.
+ * @param search - String to search for.
+ * @param args - Search arguments.
+ * @param args.containsCharsTolerance - Tolerance for how many characters of the search string
+ * must be contained in the item name. Default is 0.5.
+ * @param args.editsDistanceTolerance - Tolerance for how many edits are allowed between the
+ * search string and the item name. Default is 0.5.
+ * @param args.limitResults - Limit the number of results. Default is 0 (no limit).
+ * @returns Array of found items.
+ * @example
+ * const items = [
+ *     ['Item 1', { id: 1 }],
+ *     ['Item 2', { id: 2 }],
+ *     ['Item 3', { id: 3 }],
+ * ];
+ * const results = searchItems(items, 'item');
+ * // results = [{ id: 1 }, { id: 2 }, { id: 3 }]
+ */
+export const searchItems = <Type>(items: [string, Type][], search = '', args: SearchArgs = {}): Type[] => {
+    search = search.toLowerCase().trim();
 
     if (!search)
         return [];
@@ -172,19 +193,18 @@ export const searchItems = (items: any, search: string, args?: any) => {
     if (!searchTokens.length)
         return [];
 
-    args = args || { };
     args.containsCharsTolerance = args.containsCharsTolerance || 0.5;
     args.editsDistanceTolerance = args.editsDistanceTolerance || 0.5;
 
-    let records: any = [];
+    let records: SearchRecord<Type>[] = [];
 
-    for (i = 0; i < items.length; i++) {
-        const subInd = items[i][0].toLowerCase().trim().indexOf(search);
+    for (const item of items) {
+        const subInd = item[0].toLowerCase().trim().indexOf(search);
 
         records.push({
-            name: items[i][0],
-            item: items[i][1],
-            tokens: searchStringTokenize(items[i][0]),
+            name: item[0],
+            item: item[1],
+            tokens: searchStringTokenize(item[0]),
             edits: Infinity,
             subFull: (subInd !== -1) ? subInd : Infinity,
             sub: Infinity
@@ -192,11 +212,11 @@ export const searchItems = (items: any, search: string, args?: any) => {
     }
 
     // search each token
-    for (i = 0; i < searchTokens.length; i++)
+    for (let i = 0; i < searchTokens.length; i++)
         records = _searchItems(records, searchTokens[i], args);
 
     // sort result first by substring? then by edits number
-    records.sort((a: any, b: any) => {
+    records.sort((a: SearchRecord<Type>, b: SearchRecord<Type>) => {
         if (a.subFull !== b.subFull) {
             return a.subFull - b.subFull;
         } else if (a.sub !== b.sub) {
@@ -208,13 +228,12 @@ export const searchItems = (items: any, search: string, args?: any) => {
     });
 
     // return only items without match information
-    for (i = 0; i < records.length; i++)
-        records[i] = records[i].item;
+    let recordItems = records.map((record: SearchRecord<Type>) => record.item);
 
     // limit number of results
-    if (args.hasOwnProperty('limitResults') && records.length > args.limitResults) {
-        records = records.slice(0, args.limitResults);
+    if (args.hasOwnProperty('limitResults') && recordItems.length > args.limitResults) {
+        recordItems = recordItems.slice(0, args.limitResults);
     }
 
-    return records;
+    return recordItems;
 };


### PR DESCRIPTION
Add types (and docs) for the `searchItems` function. I've used [TypeScript Generics](https://www.typescriptlang.org/docs/handbook/2/generics.html) to achieve this. This eliminates 12 `any` types in the codebase.

Also refactors `TreeView` and `TreeViewItem` a little.