### PR TITLE
NumericInput keydown / change events fix

### DIFF
--- a/src/components/NumericInput/index.ts
+++ b/src/components/NumericInput/index.ts
@@ -83,7 +83,7 @@ class NumericInput extends TextInput {
         const renderChanges = args.renderChanges;
         delete args.renderChanges;
 
-        super(args);
+        super(args, true);
 
         this.class.add(CLASS_NUMERIC_INPUT);
 
@@ -123,6 +123,11 @@ class NumericInput extends TextInput {
 
             document.addEventListener('pointerlockchange', this._onPointerLockChange, false);
         }
+
+        this._onInputKeyDownEvt = this._onInputKeyDown.bind(this);
+        this._onInputChangeEvt = this._onInputChange.bind(this);
+        this._domInput.addEventListener('keydown', this._onInputKeyDownEvt);
+        this._domInput.addEventListener('change', this._onInputChangeEvt);
     }
 
     destroy() {

--- a/src/components/TextInput/index.ts
+++ b/src/components/TextInput/index.ts
@@ -55,7 +55,7 @@ class TextInput extends Input implements IFocusable, IPlaceholder {
 
     protected _onInputChangeEvt: (evt: Event) => void;
 
-    constructor(args: TextInputArgs = {}) {
+    constructor(args: TextInputArgs = {}, numericInput = false) {
         super(args.dom, args);
 
         this.class.add(CLASS_TEXT_INPUT);
@@ -70,13 +70,15 @@ class TextInput extends Input implements IFocusable, IPlaceholder {
         input.tabIndex = 0;
         input.autocomplete = "off";
 
-        this._onInputKeyDownEvt = this._onInputKeyDown.bind(this);
-        this._onInputChangeEvt = this._onInputChange.bind(this);
+        if (!numericInput) {
+            this._onInputKeyDownEvt = this._onInputKeyDown.bind(this);
+            this._onInputChangeEvt = this._onInputChange.bind(this);
+            input.addEventListener('keydown', this._onInputKeyDownEvt);
+            input.addEventListener('change', this._onInputChangeEvt);
+        }
 
-        input.addEventListener('change', this._onInputChangeEvt);
         input.addEventListener('focus', this._onInputFocus);
         input.addEventListener('blur', this._onInputBlur);
-        input.addEventListener('keydown', this._onInputKeyDownEvt);
         input.addEventListener('contextmenu', this._onInputCtxMenu, false);
 
         this.dom.appendChild(input);


### PR DESCRIPTION
It's not possible to access overridden functions in a super class' constructor. This PR instead leaves the adding of the overridden event listeners to the NumericInput's constructor when the TextInput is being extended.

Note that this is a temporary fix until [this issue](https://github.com/playcanvas/pcui/issues/248) is fixed in 4.0.0.