### PR TITLE
Remove: flag allowSyntheticDefaultImports from ts config

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ document.body.appendChild(label.dom);
 If you'd like to include PCUI in your React project, you can import the individual components as follows:
 
 ```javascript
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import { TextInput } from '@playcanvas/pcui/react';
 import '@playcanvas/pcui/styles';

--- a/docs/pages/2-react.markdown
+++ b/docs/pages/2-react.markdown
@@ -8,7 +8,7 @@ nav_order: 3
 If you are more familiar with React, you can import React elements into your own `.jsx` files and use them as follows:
 
 ```jsx
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import { TextInput } from '@playcanvas/pcui/react';
 import '@playcanvas/pcui/styles';

--- a/react/tsconfig.json
+++ b/react/tsconfig.json
@@ -8,7 +8,6 @@
             "es2019",
             "dom"
         ],
-        "allowSyntheticDefaultImports" : true,
         "esModuleInterop" : true,
         "sourceMap": true,
         "moduleResolution": "node"

--- a/src/components/ArrayInput/index.stories.tsx
+++ b/src/components/ArrayInput/index.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import Component from './component';
 import '../../scss/index.js';

--- a/src/components/BooleanInput/index.stories.tsx
+++ b/src/components/BooleanInput/index.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import Component from './component';
 import '../../scss/index.js';

--- a/src/components/Button/component.tsx
+++ b/src/components/Button/component.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Element, { ButtonArgs } from './index';
 import BaseComponent from '../Element/component';
 

--- a/src/components/Button/index.stories.tsx
+++ b/src/components/Button/index.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Component from './component';
 import '../../scss/index.js';
 import { action } from '@storybook/addon-actions';

--- a/src/components/Canvas/component.tsx
+++ b/src/components/Canvas/component.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Element, { CanvasArgs } from './index';
 import BaseComponent from '../Element/component';
 

--- a/src/components/Canvas/index.stories.tsx
+++ b/src/components/Canvas/index.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import CanvasComponent from './component';
 

--- a/src/components/Code/index.stories.tsx
+++ b/src/components/Code/index.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import Component from './component';
 import '../../scss/index.js';

--- a/src/components/ColorPicker/component.tsx
+++ b/src/components/ColorPicker/component.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Element, { ColorPickerArgs } from './index';
 import BaseComponent from '../Element/component';
 

--- a/src/components/ColorPicker/index.stories.tsx
+++ b/src/components/ColorPicker/index.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import ColorPickerComponent from './component';
 

--- a/src/components/Container/component.tsx
+++ b/src/components/Container/component.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Element, { ContainerArgs } from './index';
 import BaseComponent from '../Element/component';
 

--- a/src/components/Container/index.stories.tsx
+++ b/src/components/Container/index.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import Container from './component';
 import Label from '../Label/component';

--- a/src/components/Divider/index.stories.tsx
+++ b/src/components/Divider/index.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import Component from './component';
 import '../../scss/index.js';

--- a/src/components/Element/component.tsx
+++ b/src/components/Element/component.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Element, { ElementArgs } from './index';
 
 /**

--- a/src/components/Element/index.ts
+++ b/src/components/Element/index.ts
@@ -1,5 +1,5 @@
 import { EventHandle, Events, Observer } from '@playcanvas/observer';
-import React from 'react';
+import * as React from 'react';
 import * as pcuiClass from '../../class';
 
 import { BindingBase } from '../../binding';

--- a/src/components/GradientPicker/component.tsx
+++ b/src/components/GradientPicker/component.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Element, { GradientPickerArgs } from './index';
 import BaseComponent from '../Element/component';
 

--- a/src/components/GradientPicker/index.stories.tsx
+++ b/src/components/GradientPicker/index.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import GradientPickerComponent from './component';
 

--- a/src/components/GridView/component.tsx
+++ b/src/components/GridView/component.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import GridViewElement, { GridViewArgs } from './index';
 import GridViewItemElement from '../GridViewItem/index';
 import BaseComponent from '../Element/component';

--- a/src/components/GridView/index.stories.tsx
+++ b/src/components/GridView/index.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import GridView from './component';
 import GridViewItem from '../GridViewItem/component';

--- a/src/components/InfoBox/component.tsx
+++ b/src/components/InfoBox/component.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Element, { InfoBoxArgs } from './index';
 import BaseComponent from '../Element/component';
 

--- a/src/components/InfoBox/index.stories.tsx
+++ b/src/components/InfoBox/index.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import Component from './component';
 import '../../scss/index.js';

--- a/src/components/Label/component.tsx
+++ b/src/components/Label/component.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Element, { LabelArgs } from './index';
 import BaseComponent from '../Element/component';
 

--- a/src/components/Label/index.stories.tsx
+++ b/src/components/Label/index.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import Component from './component';
 import '../../scss/index.js';

--- a/src/components/LabelGroup/index.stories.tsx
+++ b/src/components/LabelGroup/index.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import Component from './component';
 import '../../scss/index.js';

--- a/src/components/Menu/component.tsx
+++ b/src/components/Menu/component.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Element, { MenuArgs } from './index';
 import BaseComponent from '../Element/component';
 

--- a/src/components/Menu/index.stories.tsx
+++ b/src/components/Menu/index.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import Component from './component';
 import '../../scss/index.js';

--- a/src/components/NumericInput/index.stories.tsx
+++ b/src/components/NumericInput/index.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import Component from './component';
 import '../../scss/index.js';

--- a/src/components/Overlay/index.stories.tsx
+++ b/src/components/Overlay/index.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Component from './component';
 import '../../scss/index.js';
 

--- a/src/components/Panel/component.tsx
+++ b/src/components/Panel/component.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Element, { PanelArgs } from './index';
 import BaseComponent from '../Element/component';
 

--- a/src/components/Panel/index.stories.tsx
+++ b/src/components/Panel/index.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import Component from './component';
 import '../../scss/index.js';

--- a/src/components/Progress/index.stories.tsx
+++ b/src/components/Progress/index.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import Component from './component';
 import '../../scss/index.js';

--- a/src/components/RadioButton/index.stories.tsx
+++ b/src/components/RadioButton/index.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import Component from './component';
 import '../../scss/index.js';

--- a/src/components/SelectInput/index.stories.tsx
+++ b/src/components/SelectInput/index.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import Component from './component';
 import '../../scss/index.js';

--- a/src/components/SliderInput/index.stories.tsx
+++ b/src/components/SliderInput/index.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import Component from './component';
 import '../../scss/index.js';

--- a/src/components/Spinner/component.tsx
+++ b/src/components/Spinner/component.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Element, { SpinnerArgs } from './index';
 import BaseComponent from '../Element/component';
 

--- a/src/components/Spinner/index.stories.tsx
+++ b/src/components/Spinner/index.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import SpinnerComponent from './component';
 export default {

--- a/src/components/TextAreaInput/index.stories.tsx
+++ b/src/components/TextAreaInput/index.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import Component from './component';
 import '../../scss/index.js';

--- a/src/components/TextInput/index.stories.tsx
+++ b/src/components/TextInput/index.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import Component from './component';
 import '../../scss/index.js';

--- a/src/components/TreeView/component.tsx
+++ b/src/components/TreeView/component.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import TreeViewElement, { TreeViewArgs } from './index';
 import TreeViewItemElement from '../TreeViewItem/index';
 import BaseComponent from '../Element/component';

--- a/src/components/TreeView/index.stories.tsx
+++ b/src/components/TreeView/index.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import TreeView from './component';
 import TreeViewItem from '../TreeViewItem/component';

--- a/src/components/VectorInput/index.stories.tsx
+++ b/src/components/VectorInput/index.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import Component from './component';
 import '../../scss/index.js';

--- a/src/examples/BidirectionalBinding/index.stories.tsx
+++ b/src/examples/BidirectionalBinding/index.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import { Observer } from '@playcanvas/observer';
 import Container from '../../components/Container/component';

--- a/src/examples/Observer/index.stories.tsx
+++ b/src/examples/Observer/index.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import { Observer } from '@playcanvas/observer';
 import Container from '../../components/Container/component';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,6 @@
             "es2019",
             "dom"
         ],
-        "allowSyntheticDefaultImports" : true,
         "esModuleInterop" : true,
         "sourceMap": true,
         "moduleResolution": "node"


### PR DESCRIPTION
### Problem: by default TS dosen't allow ["synthetic default imports"](https://www.typescriptlang.org/tsconfig#allowSyntheticDefaultImports)


https://user-images.githubusercontent.com/17799857/213328964-e21c475a-671f-4cc0-9c95-663b6205b23c.mp4

### Local solution: 
Add the line allowsynthgeticsdefaultports: true to the tsconfig.json

### Global solution
Change `import React from 'react'; => import * as React from 'react';` in pcui repo. This change will allow use **pcui** without set "allowSyntheticDefaultImports: true" flag in _tsconfig.json_.

( if you not appruve that pr please add some message about this flag in documentation, for people who want to use pcui with typescript )