### PR TITLE
NumericInput: Focus on slider click

### DIFF
--- a/src/components/NumericInput/index.ts
+++ b/src/components/NumericInput/index.ts
@@ -184,6 +184,7 @@ class NumericInput extends InputElement {
             this._historyCombine = false;
             this._historyPostfix = null;
         }
+        this.focus();
     };
 
     protected _onInputChange(evt: any) {


### PR DESCRIPTION
This PR ensures the NumericInput component focusses on its input field when the draggable slider is clicked. 

Fixes #99 