### PR TITLE
Remove `_treeOrder` member from `TreeViewItem`

### DIFF
--- a/src/components/TreeView/index.ts
+++ b/src/components/TreeView/index.ts
@@ -523,13 +523,15 @@ class TreeView extends Container {
      * is above the other. Performance wise this means it traverses
      * all tree items every time however seems to be pretty fast even with 15 - 20 K entities.
      */
-    protected _updateTreeOrder() {
+    protected _getTreeOrder(): Map<TreeViewItem, number> {
+        const treeOrder = new Map<TreeViewItem, number>();
         let order = 0;
 
         this._traverseDepthFirst((item: TreeViewItem) => {
-            // @ts-ignore
-            item._treeOrder = order++;
+            treeOrder.set(item, order++);
         });
+
+        return treeOrder;
     }
 
     protected _getChildIndex(item: TreeViewItem, parent: TreeViewItem) {
@@ -613,10 +615,9 @@ class TreeView extends Container {
         if (!isRootDragged && this._dragOverItem) {
             if (this._dragItems.length > 1) {
                 // sort items based on order in the hierarchy
-                this._updateTreeOrder();
+                const treeOrder = this._getTreeOrder();
                 this._dragItems.sort((a, b) => {
-                    // @ts-ignore
-                    return a._treeOrder - b._treeOrder;
+                    return treeOrder.get(a) - treeOrder.get(b);
                 });
             }
 

--- a/src/components/TreeViewItem/index.ts
+++ b/src/components/TreeViewItem/index.ts
@@ -120,8 +120,6 @@ class TreeViewItem extends Container {
 
     protected _numChildren = 0;
 
-    protected _treeOrder = -1;
-
     protected _treeView: any;
 
     protected _allowDrag: boolean;


### PR DESCRIPTION
At the moment, `TreeView` tags `TreeViewItem` instances with a number representing the depth first order of the item in the tree. This happens whenever a drag of a `TreeViewItem` ends. Since this member is protected, `@ts-ignore`s are needed to silence the TypeScript compiler errors.

This PR refactors the code to no longer have to tag `TreeViewItem`s with the order number. Instead, it creates a temporary `Map` of `TreeViewItem` to `number` (order).

This removes another 2 `@ts-ignore`s and makes the `TreeViewItem` set of member variables that little bit cleaner. There are only 34 `@ts-ignore`s left in the codebase.