### PR TITLE
Minor binding refactor

### DIFF
--- a/src/binding/BindingBase/index.ts
+++ b/src/binding/BindingBase/index.ts
@@ -33,11 +33,11 @@ export interface BindingBaseArgs {
  * Base class for data binding between {@link IBindable} {@link Element}s and Observers.
  */
 class BindingBase extends Events {
-    protected _observers: Observer[];
+    protected _observers: Observer[] = [];
 
-    protected _paths: string[];
+    protected _paths: string[] = [];
 
-    protected _applyingChange: boolean;
+    protected _applyingChange = false;
 
     protected _element?: IBindable;
 
@@ -51,22 +51,16 @@ class BindingBase extends Events {
 
     protected _historyCombine: boolean;
 
-    protected _linked: boolean;
+    protected _linked = false;
 
     /**
      * Creates a new binding.
      *
      * @param args - The arguments.
      */
-    constructor(args: BindingBaseArgs) {
+    constructor(args: Readonly<BindingBaseArgs>) {
         super();
 
-        // the observers we are binding to
-        this._observers = [];
-        // the paths to use for the observers
-        this._paths = [];
-
-        this._applyingChange = false;
         this._element = args.element;
 
         this._history = args.history;
@@ -74,8 +68,6 @@ class BindingBase extends Events {
         this._historyPostfix = args.historyPostfix;
         this._historyName = args.historyName;
         this._historyCombine = args.historyCombine || false;
-
-        this._linked = false;
     }
 
     // Returns the path at the specified index

--- a/src/binding/BindingElementToObservers/index.ts
+++ b/src/binding/BindingElementToObservers/index.ts
@@ -1,13 +1,6 @@
 import { Observer } from '@playcanvas/observer';
 import BindingBase from '../BindingBase';
 
-type BindingRecord = {
-    observer: Observer,
-    path: string,
-    value: any,
-    index?: number
-}
-
 /**
  * Provides one way binding between an {@link IBindable} element and Observers. Any changes from
  * the element will be propagated to the observers.

--- a/src/binding/BindingElementToObservers/index.ts
+++ b/src/binding/BindingElementToObservers/index.ts
@@ -1,6 +1,13 @@
 import { Observer } from '@playcanvas/observer';
 import BindingBase from '../BindingBase';
 
+type BindingRecord = {
+    observer: Observer,
+    path: string,
+    value: any,
+    index?: number
+}
+
 /**
  * Provides one way binding between an {@link IBindable} element and Observers. Any changes from
  * the element will be propagated to the observers.
@@ -176,11 +183,11 @@ class BindingElementToObservers extends BindingBase {
         }
 
         const execute = () => {
-            for (let i = 0; i < records.length; i++) {
-                const latest = records[i].observer.latest();
+            for (const record of records) {
+                const latest = record.observer.latest();
                 if (!latest) continue;
 
-                const path = records[i].path;
+                const path = record.path;
 
                 let history = false;
                 if (latest.history) {
@@ -188,7 +195,7 @@ class BindingElementToObservers extends BindingBase {
                     latest.history.enabled = false;
                 }
 
-                latest.insert(path, records[i].value);
+                latest.insert(path, record.value);
 
                 if (history) {
                     latest.history.enabled = true;
@@ -202,11 +209,11 @@ class BindingElementToObservers extends BindingBase {
                 redo: execute,
                 combine: this._historyCombine,
                 undo: () => {
-                    for (let i = 0; i < records.length; i++) {
-                        const latest = records[i].observer.latest();
+                    for (const record of records) {
+                        const latest = record.observer.latest();
                         if (!latest) continue;
 
-                        const path = records[i].path;
+                        const path = record.path;
 
                         let history = false;
                         if (latest.history) {
@@ -214,7 +221,7 @@ class BindingElementToObservers extends BindingBase {
                             latest.history.enabled = false;
                         }
 
-                        latest.removeValue(path, records[i].value);
+                        latest.removeValue(path, record.value);
 
                         if (history) {
                             latest.history.enabled = true;
@@ -259,11 +266,11 @@ class BindingElementToObservers extends BindingBase {
         }
 
         const execute = () => {
-            for (let i = 0; i < records.length; i++) {
-                const latest = records[i].observer.latest();
+            for (const record of records) {
+                const latest = record.observer.latest();
                 if (!latest) continue;
 
-                const path = records[i].path;
+                const path = record.path;
 
                 let history = false;
                 if (latest.history) {
@@ -271,7 +278,7 @@ class BindingElementToObservers extends BindingBase {
                     latest.history.enabled = false;
                 }
 
-                latest.removeValue(path, records[i].value);
+                latest.removeValue(path, record.value);
 
                 if (history) {
                     latest.history.enabled = true;
@@ -285,11 +292,11 @@ class BindingElementToObservers extends BindingBase {
                 redo: execute,
                 combine: this._historyCombine,
                 undo: () => {
-                    for (let i = 0; i < records.length; i++) {
-                        const latest = records[i].observer.latest();
+                    for (const record of records) {
+                        const latest = record.observer.latest();
                         if (!latest) continue;
 
-                        const path = records[i].path;
+                        const path = record.path;
 
                         let history = false;
                         if (latest.history) {
@@ -297,8 +304,8 @@ class BindingElementToObservers extends BindingBase {
                             latest.history.enabled = false;
                         }
 
-                        if (latest.get(path).indexOf(records[i].value) === -1) {
-                            latest.insert(path, records[i].value, records[i].index);
+                        if (latest.get(path).indexOf(record.value) === -1) {
+                            latest.insert(path, record.value, record.index);
                         }
 
                         if (history) {

--- a/src/binding/BindingElementToObservers/index.ts
+++ b/src/binding/BindingElementToObservers/index.ts
@@ -76,7 +76,6 @@ class BindingElementToObservers extends BindingBase {
                     this.emit('history:undo', context);
                 }
             });
-
         }
 
         execute();

--- a/src/binding/BindingObserversToElement/index.ts
+++ b/src/binding/BindingObserversToElement/index.ts
@@ -16,21 +16,19 @@ export interface BindingObserversToElementArgs extends BindingBaseArgs {
 class BindingObserversToElement extends BindingBase {
     _customUpdate: (element: IBindable, observers: Observer[], paths: string[]) => void;
 
-    _events: EventHandle[];
+    _events: EventHandle[] = [];
 
-    _updateTimeout: number;
+    _updateTimeout: number = null;
 
     /**
      * Creates a new BindingObserversToElement instance.
      *
      * @param args - The arguments.
      */
-    constructor(args: BindingObserversToElementArgs = {}) {
+    constructor(args: Readonly<BindingObserversToElementArgs> = {}) {
         super(args);
 
         this._customUpdate = args.customUpdate;
-        this._events = [];
-        this._updateTimeout = null;
     }
 
     private _linkObserver(observer: Observer, path: string) {

--- a/src/binding/BindingTwoWay/index.ts
+++ b/src/binding/BindingTwoWay/index.ts
@@ -30,13 +30,12 @@ class BindingTwoWay extends BindingBase {
      *
      * @param args - The arguments.
      */
-    constructor(args: BindingTwoWayArgs = {}) {
+    constructor(args: Readonly<BindingTwoWayArgs> = {}) {
         super(args);
 
         this._bindingElementToObservers = args.bindingElementToObservers || new BindingElementToObservers(args);
         this._bindingObserversToElement = args.bindingObserversToElement || new BindingObserversToElement(args);
 
-        this._applyingChange = false;
         this._bindingElementToObservers.on('applyingChange', (value: any) => {
             this.applyingChange = value;
         });

--- a/src/components/Canvas/index.ts
+++ b/src/components/Canvas/index.ts
@@ -1,5 +1,7 @@
 import Element, { ElementArgs } from '../Element';
 
+const CLASS_ROOT = 'pcui-canvas';
+
 /**
  * The arguments for the {@link Canvas} constructor.
  */
@@ -24,14 +26,13 @@ class Canvas extends Element {
     constructor(args: Readonly<CanvasArgs> = {}) {
         super({ dom: 'canvas', ...args });
 
-        const canvas = this._dom as HTMLCanvasElement;
-        canvas.classList.add('pcui-canvas');
+        this.class.add(CLASS_ROOT);
 
         const { useDevicePixelRatio = false } = args;
         this._ratio = useDevicePixelRatio ? window.devicePixelRatio : 1;
 
         // Disable I-bar cursor on click+drag
-        canvas.onselectstart = (evt: Event) => {
+        this.dom.onselectstart = (evt: Event) => {
             return false;
         };
     }

--- a/src/components/GridView/index.ts
+++ b/src/components/GridView/index.ts
@@ -40,25 +40,21 @@ class GridView extends Container {
 
     protected _filterFn: (item: GridViewItem) => boolean;
 
-    protected _filterAnimationFrame: number;
+    protected _filterAnimationFrame: number = null;
 
-    protected _filterCanceled: boolean;
+    protected _filterCanceled = false;
 
     protected _multiSelect: boolean;
 
     protected _allowDeselect: boolean;
 
-    protected _selected: GridViewItem[];
+    protected _selected: GridViewItem[] = [];
 
     constructor(args: Readonly<GridViewArgs> = {}) {
         super(args);
 
         this._vertical = !!args.vertical;
-        if (this._vertical) {
-            this.class.add(CLASS_VERTICAL);
-        } else {
-            this.class.add(CLASS_ROOT);
-        }
+        this.class.add(this._vertical ? CLASS_VERTICAL : CLASS_ROOT);
 
         this.on('append', (element: Element) => {
             this._onAppendGridViewItem(element as GridViewItem);
@@ -68,14 +64,10 @@ class GridView extends Container {
         });
 
         this._filterFn = args.filterFn;
-        this._filterAnimationFrame = null;
-        this._filterCanceled = false;
 
         // Default options for GridView layout
         this._multiSelect = args.multiSelect ?? true;
         this._allowDeselect = args.allowDeselect ?? true;
-
-        this._selected = [];
     }
 
     protected _onAppendGridViewItem(item: GridViewItem) {


### PR DESCRIPTION
Mainly affects the binding source:

* Move constructor member variable initialization to the top of the class.
* Make binding class argument objects read-only.
* Change some `for` loops into `for...of` loops.