### PR TITLE
Prohibit empty interfaces in the codebase

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "rules": {
       "@typescript-eslint/ban-ts-comment": "off",
       "@typescript-eslint/no-empty-function": "off",
-      "@typescript-eslint/no-empty-interface": "off",
       "@typescript-eslint/no-explicit-any": "off",
       "@typescript-eslint/no-unused-vars": "off",
       "jsdoc/require-returns": "off",

--- a/src/components/Divider/component.tsx
+++ b/src/components/Divider/component.tsx
@@ -1,11 +1,12 @@
-import Element, { DividerArgs } from './index';
+import Element from './index';
+import { ElementArgs } from '../Element/index';
 import BaseComponent from '../Element/component';
 
 /**
  * Represents a vertical division between two elements
  */
-class Component extends BaseComponent <DividerArgs, any> {
-    constructor(props: DividerArgs) {
+class Component extends BaseComponent <ElementArgs, any> {
+    constructor(props: ElementArgs) {
         super(props);
         this.elementClass = Element;
     }

--- a/src/components/Divider/index.ts
+++ b/src/components/Divider/index.ts
@@ -3,15 +3,10 @@ import Element, { ElementArgs } from '../Element';
 const CLASS_ROOT = 'pcui-divider';
 
 /**
- * The arguments for the {@link Divider} constructor.
- */
-export interface DividerArgs extends ElementArgs {}
-
-/**
  * Represents a vertical division between two elements.
  */
 class Divider extends Element {
-    constructor(args: Readonly<DividerArgs> = {}) {
+    constructor(args: Readonly<ElementArgs> = {}) {
         super(args);
 
         this.class.add(CLASS_ROOT);

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -5,7 +5,7 @@ import Canvas, { CanvasArgs } from './Canvas';
 import Code, { CodeArgs } from './Code';
 import ColorPicker, { ColorPickerArgs } from './ColorPicker';
 import Container, { ContainerArgs } from './Container';
-import Divider, { DividerArgs } from './Divider';
+import Divider from './Divider';
 import Element, { ElementArgs, IBindable, IBindableArgs, IFlexArgs, IFocusable, IParentArgs, IPlaceholder, IPlaceholderArgs } from './Element';
 import GradientPicker, { GradientPickerArgs } from './GradientPicker';
 import GridView, { GridViewArgs } from './GridView';
@@ -46,7 +46,6 @@ export {
     Container,
     ContainerArgs,
     Divider,
-    DividerArgs,
     Element,
     ElementArgs,
     GradientPicker,


### PR DESCRIPTION
The `Divider` element needlessly extends the `ElementArgs` interface when the constructor could just accept `ElementArgs`. Enabled the ESLint rule [`@typescript-eslint/no-empty-interface`](https://typescript-eslint.io/rules/no-empty-interface/) to prevent this in future.