### PR TITLE
Binding observer fix

### DIFF
--- a/src/binding/BindingElementToObservers/index.ts
+++ b/src/binding/BindingElementToObservers/index.ts
@@ -27,7 +27,7 @@ class BindingElementToObservers extends BindingBase {
     // to the observers
     private _setValue(value: any, isArrayOfValues: boolean) {
         if (this.applyingChange) return;
-        if (!this._observers) return;
+        if (!this._observers.length) return;
 
         this.applyingChange = true;
 


### PR DESCRIPTION
The `BindingBase#_observers` property is now always set to an array, so the `BindingObserversToElement#_updateValue` function can no longer test against the property being set. The `BindingBase#link` function also no longer needs to call `BindingBase#unlink` as it sets all of the unlinked properties itself.