### PR TITLE
Panel component onClickRemove function

### DIFF
--- a/src/components/Panel/index.ts
+++ b/src/components/Panel/index.ts
@@ -226,7 +226,7 @@ class Panel extends Container {
         this.collapsed = !this.collapsed;
     };
 
-    protected _onClickRemove = (evt: MouseEvent) => {
+    protected _onClickRemove(evt: MouseEvent) {
         evt.preventDefault();
         evt.stopPropagation();
 
@@ -440,7 +440,7 @@ class Panel extends Container {
                 icon: 'E289',
                 class: CLASS_PANEL_REMOVE
             });
-            this._btnRemove.on('click', this._onClickRemove);
+            this._btnRemove.on('click', this._onClickRemove.bind(this));
             this.header.append(this._btnRemove);
         } else {
             this._btnRemove.destroy();


### PR DESCRIPTION
The onClickRemove function cannot be correctly overridden when set as an arrow function. This PR reverts that change for this specific function which has been overridden in multiple places in the PlayCanvas editor.

Resolves an issue reported on the PlayCanvas forum: https://forum.playcanvas.com/t/deleting-slot-does-not-work-in-audio-component-editor/29425/4