### PR TITLE
Refactor accessing of childNodes array

### DIFF
--- a/react/tsconfig.json
+++ b/react/tsconfig.json
@@ -6,7 +6,8 @@
         "jsx": "react",
         "lib": [
             "es2019",
-            "dom"
+            "dom",
+            "dom.iterable"
         ],
         "esModuleInterop" : true,
         "sourceMap": true,

--- a/src/components/Menu/index.ts
+++ b/src/components/Menu/index.ts
@@ -111,18 +111,18 @@ class Menu extends Container implements IFocusable {
         }
 
         // @ts-ignore
-        item._containerItems.dom.childNodes.forEach((child) => {
+        for (const child of item._containerItems.dom.childNodes) {
             this._filterMenuItems(child.ui as MenuItem);
-        });
+        }
     }
 
     protected _onShowMenu() {
         this.focus();
 
         // filter child menu items
-        this._containerMenuItems.dom.childNodes.forEach((child) => {
+        for (const child of this._containerMenuItems.dom.childNodes) {
             this._filterMenuItems(child.ui as MenuItem);
-        });
+        }
     }
 
     protected _onKeyDown = (evt: KeyboardEvent) => {
@@ -153,9 +153,9 @@ class Menu extends Container implements IFocusable {
             containerItems.style.right = '100%';
         }
 
-        containerItems.dom.childNodes.forEach((child) => {
+        for (const child of containerItems.dom.childNodes) {
             this._limitSubmenuAtScreenEdges(child.ui as MenuItem);
-        });
+        }
     }
 
     focus() {
@@ -204,9 +204,9 @@ class Menu extends Container implements IFocusable {
         this._containerMenuItems.style.left = left + 'px';
         this._containerMenuItems.style.top = top + 'px';
 
-        this._containerMenuItems.dom.childNodes.forEach((child) => {
+        for (const child of this._containerMenuItems.dom.childNodes) {
             this._limitSubmenuAtScreenEdges(child.ui as MenuItem);
-        });
+        }
     }
 
     /**

--- a/src/components/MenuItem/index.ts
+++ b/src/components/MenuItem/index.ts
@@ -250,11 +250,11 @@ class MenuItem extends Container implements IBindable {
 
         // set menu on child menu items
         if (!this._containerItems.destroyed) {
-            this._containerItems.dom.childNodes.forEach((child) => {
+            for (const child of this._containerItems.dom.childNodes) {
                 if (child.ui instanceof MenuItem) {
                     child.ui.menu = value;
                 }
-            });
+            }
         }
     }
 

--- a/src/components/TreeView/index.ts
+++ b/src/components/TreeView/index.ts
@@ -506,14 +506,14 @@ class TreeView extends Container {
             fn(item);
 
             if (item.numChildren) {
-                for (let i = 0; i < item.dom.childNodes.length; i++) {
-                    traverse(item.dom.childNodes[i].ui);
+                for (const child of item.dom.childNodes) {
+                    traverse(child.ui);
                 }
             }
         }
 
-        for (let i = 0; i < this.dom.childNodes.length; i++) {
-            traverse(this.dom.childNodes[i].ui);
+        for (const child of this.dom.childNodes) {
+            traverse(child.ui);
         }
     }
 
@@ -665,9 +665,9 @@ class TreeView extends Container {
                     // but will instead calculate the new indexes and pass that data to the reparent function
                     // to perform the reparenting
 
-                    const fakeDom: { parent: any; children: any; }[] = [];
+                    const fakeDom: { parent: TreeViewItem; children: ChildNode[]; }[] = [];
 
-                    const getChildren = (treeviewItem: { dom: { childNodes: any; }; }) => {
+                    const getChildren = (treeviewItem: TreeViewItem) => {
                         let idx = fakeDom.findIndex(entry => entry.parent === treeviewItem);
                         if (idx === -1) {
                             fakeDom.push({ parent: treeviewItem, children: [...treeviewItem.dom.childNodes] });
@@ -686,7 +686,7 @@ class TreeView extends Container {
                         });
 
                         // add array of parent's child nodes to fakeDom array
-                        const parentChildren = getChildren(item.parent);
+                        const parentChildren = getChildren(item.parent as TreeViewItem);
 
                         // remove this item from the children array in fakeDom
                         const childIdx = parentChildren.indexOf(item.dom);
@@ -698,7 +698,7 @@ class TreeView extends Container {
                         if (this._dragArea === DRAG_AREA_BEFORE) {
                             // If dragged before a TreeViewItem...
                             r.newParent = this._dragOverItem.parent;
-                            const parentChildren = getChildren(this._dragOverItem.parent);
+                            const parentChildren = getChildren(this._dragOverItem.parent as TreeViewItem);
                             const index = parentChildren.indexOf(this._dragOverItem.dom);
                             parentChildren.splice(index, 0, r.item.dom);
                             r.newChildIndex = index;
@@ -711,7 +711,7 @@ class TreeView extends Container {
                         } else if (this._dragArea === DRAG_AREA_AFTER) {
                             // If dragged after a TreeViewItem...
                             r.newParent = this._dragOverItem.parent;
-                            const parentChildren = getChildren(this._dragOverItem.parent);
+                            const parentChildren = getChildren(this._dragOverItem.parent as TreeViewItem);
                             const after = i > 0 ? reparented[i - 1].item : this._dragOverItem;
                             const index = parentChildren.indexOf(after.dom);
                             parentChildren.splice(index + 1, 0, r.item.dom);

--- a/src/components/TreeViewItem/index.ts
+++ b/src/components/TreeViewItem/index.ts
@@ -559,9 +559,9 @@ class TreeViewItem extends Container {
      */
     get firstChild() {
         if (this._numChildren) {
-            for (let i = 0; i < this.dom.childNodes.length; i++) {
-                if (this.dom.childNodes[i].ui instanceof TreeViewItem) {
-                    return this.dom.childNodes[i].ui as TreeViewItem;
+            for (const child of this.dom.childNodes) {
+                if (child.ui instanceof TreeViewItem) {
+                    return child.ui as TreeViewItem;
                 }
             }
         }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
         "jsx": "react",
         "lib": [
             "es2019",
-            "dom"
+            "dom",
+            "dom.iterable"
         ],
         "esModuleInterop" : true,
         "sourceMap": true,


### PR DESCRIPTION
This PR:

* Uses `for...of` loops to iterate the `childNodes` array where possible (easier to step than `forEach` and terser than a `for` loop).
* Eliminates some `any` types from `TreeView.ts`.
* Updates the `tsconfig.json` files to allow `dom.iterable` related code (which permits use of `for...of` for iterating `childNodes`. See [this](https://stackoverflow.com/questions/71510368/why-is-dom-and-dom-iterable-seperate) for more info on `dom.iterable`.