### PR TITLE
NumericInput set value fix

### DIFF
--- a/src/components/NumericInput/index.ts
+++ b/src/components/NumericInput/index.ts
@@ -297,6 +297,7 @@ class NumericInput extends InputElement {
     }
 
     set value(value: number) {
+        value = this._normalizeValue(value);
         const forceUpdate = this.class.contains(pcuiClass.MULTIPLE_VALUES) && value === null && this._allowNull;
         const changed = this._updateValue(value, forceUpdate);
 


### PR DESCRIPTION
Updating the NumericInput value via its setter function is currently not normalising the passed in value. This means the values can sometimes be set with incorrect precision or with undefined values.