### PR TITLE
Panel class drag event fix

### DIFF
--- a/src/components/Panel/index.ts
+++ b/src/components/Panel/index.ts
@@ -122,6 +122,8 @@ class Panel extends Container {
 
     protected _headerSize: number;
 
+    protected _onDragEndEvt: (event: MouseEvent) => void;
+
     /**
      * Creates a new Panel.
      *
@@ -170,6 +172,8 @@ class Panel extends Container {
         // execute reflow now after all fields have been initialized
         this._suspendReflow = false;
         this._reflow();
+
+        this._onDragEndEvt = this._onDragEnd.bind(this);
     }
 
     destroy() {
@@ -180,8 +184,8 @@ class Panel extends Container {
             this._reflowTimeout = null;
         }
 
-        window.removeEventListener('mouseup', this._onDragEnd);
-        window.removeEventListener('mouseleave', this._onDragEnd);
+        window.removeEventListener('mouseup', this._onDragEndEvt);
+        window.removeEventListener('mouseleave', this._onDragEndEvt);
         window.removeEventListener('mousemove', this._onDragMove);
 
         super.destroy();
@@ -311,8 +315,8 @@ class Panel extends Container {
         evt.stopPropagation();
         evt.preventDefault();
 
-        window.addEventListener('mouseup', this._onDragEnd);
-        window.addEventListener('mouseleave', this._onDragEnd);
+        window.addEventListener('mouseup', this._onDragEndEvt);
+        window.addEventListener('mouseleave', this._onDragEndEvt);
         window.addEventListener('mousemove', this._onDragMove);
 
         this.emit('dragstart');
@@ -332,9 +336,9 @@ class Panel extends Container {
         }
     };
 
-    protected _onDragEnd = (evt: MouseEvent) => {
-        window.removeEventListener('mouseup', this._onDragEnd);
-        window.removeEventListener('mouseleave', this._onDragEnd);
+    protected _onDragEnd(evt: MouseEvent) {
+        window.removeEventListener('mouseup', this._onDragEndEvt);
+        window.removeEventListener('mouseleave', this._onDragEndEvt);
         window.removeEventListener('mousemove', this._onDragMove);
 
         if (this._draggedChild === this) {
@@ -347,7 +351,7 @@ class Panel extends Container {
             // @ts-ignore accessing protected methods
             this.parent._onChildDragEnd(evt, this);
         }
-    };
+    }
 
     /**
      * Gets / sets whether the Element is collapsible.


### PR DESCRIPTION
Currently classes that extend the Panel class cannot correctly extend the onDragEnd function due to it being an anonymous function.