### PR TITLE
SelectInput: disable options

### DIFF
--- a/src/components/SelectInput/component.tsx
+++ b/src/components/SelectInput/component.tsx
@@ -5,9 +5,22 @@ import BaseComponent from '../Element/component';
  * An input that allows selecting from a dropdown or entering tags.
  */
 class Component extends BaseComponent <SelectInputArgs, any> {
+    onSelect?: () => void;
+
     constructor(props: SelectInputArgs) {
         super(props);
         this.elementClass = Element;
+
+        this.onSelect = props.onSelect;
+
+        this.onAttach = this.onAttachFn.bind(this);
+
+    }
+
+    onAttachFn() {
+        if (this.props.onSelect) {
+            this.element.on('select', this.onSelect);
+        }
     }
 
     render() {

--- a/src/components/SelectInput/component.tsx
+++ b/src/components/SelectInput/component.tsx
@@ -5,7 +5,7 @@ import BaseComponent from '../Element/component';
  * An input that allows selecting from a dropdown or entering tags.
  */
 class Component extends BaseComponent <SelectInputArgs, any> {
-    onSelect?: () => void;
+    onSelect?: (value: string) => void;
 
     constructor(props: SelectInputArgs) {
         super(props);

--- a/src/components/SelectInput/index.stories.tsx
+++ b/src/components/SelectInput/index.stories.tsx
@@ -8,10 +8,4 @@ export default {
     component: Component
 };
 
-export const Main = args => <Component onChange={action('value-change')} {...args}
-    options={[
-        { v: 'webgl1', t: 'WebGL 1' },
-        { v: 'webgl2', t: 'WebGL 2' },
-        { v: 'webgpu', t: 'WebGPU' }
-    ]}
-/>;
+export const Main = args => <Component onChange={action('value-change')} {...args} />;

--- a/src/components/SelectInput/index.stories.tsx
+++ b/src/components/SelectInput/index.stories.tsx
@@ -8,4 +8,10 @@ export default {
     component: Component
 };
 
-export const Main = args => <Component onChange={action('value-change')} {...args} />;
+export const Main = args => <Component onChange={action('value-change')} {...args}
+    options={[
+        { v: 'webgl1', t: 'WebGL 1' },
+        { v: 'webgl2', t: 'WebGL 2' },
+        { v: 'webgpu', t: 'WebGPU' }
+    ]}
+/>;

--- a/src/components/SelectInput/index.ts
+++ b/src/components/SelectInput/index.ts
@@ -164,7 +164,7 @@ class SelectInput extends Element implements IBindable, IFocusable {
 
     protected _onSelect: (value: string) => void;
 
-    protected _prefix: string;
+    protected _prefix = '';
 
     constructor(args: Readonly<SelectInputArgs> = {}) {
         // main container

--- a/src/components/SelectInput/index.ts
+++ b/src/components/SelectInput/index.ts
@@ -80,7 +80,7 @@ export interface SelectInputArgs extends ElementArgs, IBindableArgs, IPlaceholde
     /**
      * The order that the options should be checked in to find a valid fallback option that isn't included in the disabledOptions object.
      */
-    fallbackOrder?: any;
+    fallbackOrder?: Array<string>;
     /**
      * All the option values that should be disabled. The keys of the object are the values of the options and the values are the text to show when the option is disabled.
      */
@@ -92,7 +92,7 @@ export interface SelectInputArgs extends ElementArgs, IBindableArgs, IPlaceholde
     /**
      * Text to display in the SelectInput before the selected option.
      */
-    pretext?: string;
+    prefix?: string;
 }
 
 
@@ -164,7 +164,7 @@ class SelectInput extends Element implements IBindable, IFocusable {
 
     protected _onSelect: (value: string) => void;
 
-    protected _pretext: string;
+    protected _prefix: string;
 
     constructor(args: Readonly<SelectInputArgs> = {}) {
         // main container
@@ -305,7 +305,7 @@ class SelectInput extends Element implements IBindable, IFocusable {
         this._onSelect = args.onSelect;
         this.fallbackOrder = args.fallbackOrder;
         this.disabledOptions = args.disabledOptions;
-        this._pretext = args.pretext ?? '';
+        this._prefix = args.prefix ?? '';
     }
 
     destroy() {
@@ -501,7 +501,7 @@ class SelectInput extends Element implements IBindable, IFocusable {
     // when the value is changed show the correct title
     protected _onValueChange(value: any) {
         if (!this.multiSelect) {
-            this._labelValue.value = this._pretext + (this._valueToText[value] || '');
+            this._labelValue.value = this._prefix + (this._valueToText[value] || '');
 
             value = '' + value;
             for (const key in this._valueToLabel) {

--- a/src/components/SelectInput/style.scss
+++ b/src/components/SelectInput/style.scss
@@ -84,6 +84,26 @@
     }
 }
 
+.pcui-select-input-has-disabled-value .pcui-container.pcui-select-input-list .pcui-label.pcui-selected {
+    &::after {
+        font-family: inherit;
+        content: 'fallback';
+        color: $text-primary;
+        font-size: 10px;
+        position: absolute;
+        right: 6px;
+    }
+}
+
+.pcui-label.pcui-select-input-disabled-value {
+    &::after {
+        @extend .font-icon;
+        content: '\e133' !important;
+        position: absolute;
+        right: 6px;
+    }
+}
+
 .pcui-select-input.pcui-open {
     .pcui-select-input-shadow {
         box-shadow: $element-shadow-hover;
@@ -262,6 +282,12 @@
 
 .pcui-select-input.pcui-disabled {
     opacity: $element-opacity-disabled;
+}
+
+.pcui-select-input {
+    .pcui-label.pcui-disabled {
+        opacity: $element-opacity-disabled;
+    }
 }
 
 .pcui-select-input.pcui-readonly {


### PR DESCRIPTION
The PR adds support for disabling certain options in the SelectInput and allowing the SelectInput to fall back to another option if the currently selected value is set as disabled. Upon removing the previously selected value from the disabled options, it should be restored as the SelectInput's current value.

Also includes support for a `pretext` argument that can be passed into the SelectInput class. This adds text to the beginning of the selected value, as shown here:
<img width="208" alt="image" src="https://user-images.githubusercontent.com/1721533/222218485-da0eba4d-fe81-4c20-95b3-e0b034434e06.png">

Each disabled option can be given new text to display when disabled. The SelectInput also now visually indicates both the user selected (but now disabled) option and the fallback option when displaying its list of options:
<img width="208" alt="image" src="https://user-images.githubusercontent.com/1721533/222218973-1df9b23e-1478-4348-89c8-e587a70da609.png">
