### PR TITLE
ArrayInput linking fix

### DIFF
--- a/src/components/ArrayInput/index.ts
+++ b/src/components/ArrayInput/index.ts
@@ -1,6 +1,7 @@
 import * as utils from '../../helpers/utils';
 
 import Element, { ElementArgs, IBindable, IBindableArgs, IFocusable } from '../Element';
+import { Observer } from '@playcanvas/observer';
 import Container from '../Container';
 import Panel from '../Panel';
 import NumericInput from '../NumericInput';
@@ -512,6 +513,20 @@ class ArrayInput extends Element implements IFocusable, IBindable {
 
     blur() {
         this._inputSize.blur();
+    }
+
+    unlink() {
+        super.unlink();
+        this._arrayElements.forEach((entry: { element: Element; }) => {
+            entry.element.unlink();
+        });
+    }
+
+    link(observers: Observer|Observer[], paths: string|string[]) {
+        super.link(observers, paths);
+        this._arrayElements.forEach((entry: { element: Element; }, index: number) => {
+            this._linkArrayElement(entry.element, index);
+        });
     }
 
     /**

--- a/src/components/ArrayInput/index.ts
+++ b/src/components/ArrayInput/index.ts
@@ -1,7 +1,6 @@
-import * as utils from '../../helpers/utils';
-
-import Element, { ElementArgs, IBindable, IBindableArgs, IFocusable } from '../Element';
 import { Observer } from '@playcanvas/observer';
+import * as utils from '../../helpers/utils';
+import Element, { ElementArgs, IBindable, IBindableArgs, IFocusable } from '../Element';
 import Container from '../Container';
 import Panel from '../Panel';
 import NumericInput from '../NumericInput';


### PR DESCRIPTION
The ArrayInput does not currently link and unlink the elements it contains. The linking of elements is currently left until the ArrayInput value is set, however this linking is skipped when the value hasn't changed. It should not be required to update the input value in order to link to another set of observers. This PR addresses this by explicitly linking all ArrayInput elements when it has been linked itself.

Fixes https://github.com/playcanvas/editor/issues/1002