### PR TITLE
SelectInput options/disabledOptions setter fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@playcanvas/pcui",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@playcanvas/pcui",
-      "version": "4.0.4",
+      "version": "4.0.5",
       "license": "MIT",
       "dependencies": {
         "@playcanvas/observer": "^1.3.6"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playcanvas/pcui",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "author": "PlayCanvas <support@playcanvas.com>",
   "homepage": "https://playcanvas.github.io/pcui",
   "description": "User interface component library for the web",

--- a/src/components/SelectInput/index.ts
+++ b/src/components/SelectInput/index.ts
@@ -1041,7 +1041,7 @@ class SelectInput extends Element implements IBindable, IFocusable {
     }
 
     set options(value) {
-        if (this._options && this._options === value) return;
+        if (this._options && JSON.stringify(this._options) === JSON.stringify(value)) return;
 
         this._containerOptions.clear();
         this._labelHighlighted = null;
@@ -1115,7 +1115,7 @@ class SelectInput extends Element implements IBindable, IFocusable {
     }
 
     set disabledOptions(value: any) {
-        if (this._disabledOptions === value) return;
+        if (JSON.stringify(this._disabledOptions) === JSON.stringify(value)) return;
         this._disabledOptions = value || {};
         const newValue = this._updateDisabledValue(this._value);
         this._updateValue(newValue);


### PR DESCRIPTION
The setters for the options and disabledOptions properties contain and early exit if the SelectInput already has the same value. However these checks are not deep comparing the values so the early exit condition never passed.