### PR TITLE
Fix blurring of `NumericInput`

### DIFF
--- a/src/components/NumericInput/index.ts
+++ b/src/components/NumericInput/index.ts
@@ -193,13 +193,15 @@ class NumericInput extends InputElement {
     }
 
     protected _onInputKeyDown(evt: KeyboardEvent) {
-        if (!this.enabled || this.readOnly) return super._onInputKeyDown(evt);
+        if (!this.enabled || this.readOnly) return;
 
         // increase / decrease value with arrow keys
         if (evt.key === 'ArrowUp' || evt.key === 'ArrowDown') {
             const inc = evt.key === 'ArrowDown' ? -1 : 1;
             this.value += (evt.shiftKey ? this._stepPrecision : this._step) * inc;
         }
+
+        super._onInputKeyDown(evt);
     }
 
     protected _isScrolling() {


### PR DESCRIPTION
I believe this probably broke in this PR: https://github.com/playcanvas/pcui/pull/281

If the `NumericInput` is read-only or disabled, I think the function should just immediately return. Otherwise, the super should always be called.

Fixes https://github.com/playcanvas/editor/issues/1008
