### PR TITLE
Remove redundant left property for static element

### DIFF
--- a/src/components/Panel/style.scss
+++ b/src/components/Panel/style.scss
@@ -40,11 +40,9 @@
 
         // expanded icon
         &::before {
-            left: 0;
-            content: '\E179';
-
             @extend .font-icon;
 
+            content: '\E179';
             font-size: 14px;
             margin-right: 10px;
             text-align: center;


### PR DESCRIPTION
The `Panel` header icon CSS shows in Dev Tools as follows:

![image](https://github.com/playcanvas/pcui/assets/697563/8b791b84-fab2-43bf-ab65-094fbb5f44b2)

Therefore, this PR removes the redundant `left` property.