### PR TITLE
Migrate the ColorPicker to use Pointer Events

### DIFF
--- a/src/components/ColorPicker/index.ts
+++ b/src/components/ColorPicker/index.ts
@@ -489,12 +489,8 @@ class ColorPicker extends Element implements IBindable {
 
         // Get the pointer position relative to the element
         const rect = this._pickRect.getBoundingClientRect();
-        let x = event.clientX - rect.left;
-        let y = event.clientY - rect.top;
-
-        // Clamp x and y to the size of the element
-        x = Math.max(0, Math.min(this._size, x));
-        y = Math.max(0, Math.min(this._size, y));
+        const x = Math.max(0, Math.min(this._size, Math.floor(event.clientX - rect.left)));
+        const y = Math.max(0, Math.min(this._size, Math.floor(event.clientY - rect.top)));
 
         this._colorHSV[1] = x / this._size;
         this._colorHSV[2] = 1.0 - (y / this._size);

--- a/src/components/ColorPicker/style.scss
+++ b/src/components/ColorPicker/style.scss
@@ -110,6 +110,7 @@
             box-sizing: border-box;
             margin: 8px 0 8px 8px;
             background-color: #f00;
+            touch-action: none;
             cursor: crosshair;
 
             > .white {
@@ -153,6 +154,7 @@
             margin: 8px 0 8px 8px;
             border: 1px solid #000;
             box-sizing: border-box;
+            touch-action: none;
             cursor: crosshair;
             background: #000;
             background:
@@ -189,6 +191,7 @@
             height: 144px;
             margin: 8px 0 8px 8px;
             border: 1px solid #000;
+            touch-action: none;
             cursor: crosshair;
             background: #000;
             background: linear-gradient(to bottom, #fff 0%, #000 100%);


### PR DESCRIPTION
This PR migrates the `ColorPicker` control to use pointer events instead of mouse events. This means the ColorPicker now works perfectly on touch devices:

![colortouch](https://github.com/playcanvas/pcui/assets/697563/ab883fdf-f92d-4fc6-937b-d0dfb5d2d5ca)
