### PR TITLE
Protect navigator access from causing a ReferenceError

### DIFF
--- a/src/components/SliderInput/index.ts
+++ b/src/components/SliderInput/index.ts
@@ -8,7 +8,7 @@ const CLASS_SLIDER_BAR = CLASS_SLIDER + '-bar';
 const CLASS_SLIDER_HANDLE = CLASS_SLIDER + '-handle';
 const CLASS_SLIDER_ACTIVE = CLASS_SLIDER + '-active';
 
-const IS_CHROME = /Chrome\//.test(navigator.userAgent);
+const IS_CHROME = /Chrome\//.test(globalThis.navigator?.userAgent);
 
 /**
  * The arguments for the {@link SliderInput} constructor.


### PR DESCRIPTION
Fixes: https://github.com/playcanvas/pcui/issues/322

Now we can properly import it in `node` via `await import('./dist/module/src/index.mjs')` aswell:

![image](https://github.com/playcanvas/pcui/assets/5236548/a9983192-10cb-4f3e-9309-53a08488d2d2)
