### PR TITLE
Remove some occurrences of ts-ignore

### DIFF
--- a/src/components/GridView/component.tsx
+++ b/src/components/GridView/component.tsx
@@ -10,7 +10,6 @@ import BaseComponent from '../Element/component';
 class GridView extends BaseComponent <GridViewArgs, any> {
     constructor(props: GridViewArgs) {
         super(props);
-        // @ts-ignore
         this.element = new GridViewElement({ ...props });
         this.loadChildren(this.props.children, this.element);
     }
@@ -21,8 +20,7 @@ class GridView extends BaseComponent <GridViewArgs, any> {
             children = [children];
         }
         children.forEach((child: any) => {
-            // @ts-ignore
-            const childElement = new GridViewItemElement({ text: child.props.text, open: false });
+            const childElement = new GridViewItemElement({ text: child.props.text });
             element.append(childElement);
             this.loadChildren(child.props.children, childElement);
         });

--- a/src/components/LabelGroup/component.tsx
+++ b/src/components/LabelGroup/component.tsx
@@ -8,7 +8,6 @@ import { JSXElementConstructor, ReactElement } from 'react';
 class LabelGroup extends BaseComponent <LabelGroupArgs, any> {
     constructor(props: LabelGroupArgs) {
         super(props);
-        // @ts-ignore
         this.elementClass = Element;
     }
 

--- a/src/components/Menu/component.stories.tsx
+++ b/src/components/Menu/component.stories.tsx
@@ -19,8 +19,8 @@ export default meta;
 type Story = StoryObj<typeof Menu>;
 
 window.addEventListener('contextmenu', (evt: MouseEvent) => {
-    // @ts-ignore
-    if (evt.target.ui instanceof LabelElement) {
+    const target = evt.target as HTMLElement;
+    if (target.ui instanceof LabelElement) {
         const element = document.querySelector('.pcui-menu');
         if (element) {
             const menu = element.ui as MenuElement;

--- a/src/components/Menu/component.tsx
+++ b/src/components/Menu/component.tsx
@@ -14,7 +14,6 @@ class Menu extends BaseComponent <MenuArgs, any> {
     }
 
     onDivLoaded = (element: any) => {
-        // @ts-ignore
         this.element = new Element({ ...this.props, dom: element });
     };
 


### PR DESCRIPTION
Removes 4 occurrences of `@ts-ignore`. The `GridViewItem` one was needed because of a copy+paste error from `TreeViewItem` (which has an `open` property).