### PR TITLE
Document all getters

### DIFF
--- a/src/binding/BindingBase/index.ts
+++ b/src/binding/BindingBase/index.ts
@@ -161,18 +161,21 @@ class BindingBase extends Events {
     }
 
     /**
-     * The element
+     * Sets the element.
      */
     set element(value: IBindable | undefined) {
         this._element = value;
     }
 
+    /**
+     * Gets the element.
+     */
     get element(): IBindable | undefined {
         return this._element;
     }
 
     /**
-     * Whether the binding is currently applying a change either to the observers or the element.
+     * Sets whether the binding is currently applying a change, either to the observers or the element.
      */
     set applyingChange(value) {
         if (this._applyingChange === value) return;
@@ -181,63 +184,79 @@ class BindingBase extends Events {
         this.emit('applyingChange', value);
     }
 
+    /**
+     * Gets whether the binding is currently applying a change, either to the observers or the element.
+     */
     get applyingChange() {
         return this._applyingChange;
     }
 
     /**
-     * Whether the binding is linked to observers.
+     * Gets whether the binding is linked to observers.
      */
     get linked() {
         return this._linked;
     }
 
     /**
-     * If a history module is used whether to combine history actions when applying changes to observers.
+     * Sets whether to combine history actions when applying changes to observers. This is assuming
+     * a history module is being used.
      */
     set historyCombine(value) {
         this._historyCombine = value;
     }
 
+    /**
+     * Gets whether to combine history actions when applying changes to observers.
+     */
     get historyCombine() {
         return this._historyCombine;
     }
 
     /**
-     * The name of the history action when applying changes to observers.
+     * Sets the name of the history action when applying changes to observers.
      */
     set historyName(value) {
         this._historyName = value;
     }
 
+    /**
+     * Gets the name of the history action when applying changes to observers.
+     */
     get historyName() {
         return this._historyName;
     }
 
     /**
-     * A string to prefix the historyName with.
+     * Sets the string to prefix {@link historyName} with.
      */
     set historyPrefix(value) {
         this._historyPrefix = value;
     }
 
+    /**
+     * Gets the string to prefix {@link historyName} with.
+     */
     get historyPrefix() {
         return this._historyPrefix;
     }
 
     /**
-     * A string to postfix the historyName with.
+     * Sets the string to postfix {@link historyName} with.
      */
     set historyPostfix(value) {
         this._historyPostfix = value;
     }
 
+    /**
+     * Gets the string to postfix {@link historyName} with.
+     */
     get historyPostfix() {
         return this._historyPostfix;
     }
 
     /**
-     * Whether history is enabled for the binding. A valid history object must have been provided first.
+     * Sets whether history is enabled for the binding. A valid history object must have been provided first.
      */
     set historyEnabled(value) {
         if (this._history) {
@@ -246,20 +265,23 @@ class BindingBase extends Events {
         }
     }
 
+    /**
+     * Gets whether history is enabled for the binding.
+     */
     get historyEnabled() {
         // @ts-ignore
         return this._history && this._history.enabled;
     }
 
     /**
-     * The linked observers.
+     * Gets the linked observers.
      */
     get observers() {
         return this._observers;
     }
 
     /**
-     * The linked paths.
+     * Gets the linked paths.
      */
     get paths() {
         return this._paths;

--- a/src/components/Button/index.ts
+++ b/src/components/Button/index.ts
@@ -89,7 +89,7 @@ class Button extends Element {
     }
 
     /**
-     * Gets / sets the text of the button.
+     * Sets the text of the button.
      */
     set text(value: string) {
         if (this._text === value) return;
@@ -101,12 +101,15 @@ class Button extends Element {
         }
     }
 
+    /**
+     * Gets the text of the button.
+     */
     get text(): string {
         return this._text;
     }
 
     /**
-     * The CSS code for an icon for the button. e.g. 'E401' (notice we omit the '\\' character).
+     * Sets the CSS code for an icon for the button. e.g. 'E401' (notice we omit the '\\' character).
      */
     set icon(value: string) {
         if (this._icon === value || !value.match(/^E[0-9]{0,4}$/)) return;
@@ -119,12 +122,15 @@ class Button extends Element {
         }
     }
 
+    /**
+     * Gets the CSS code for an icon for the button.
+     */
     get icon(): string {
         return this._icon;
     }
 
     /**
-     * Gets / sets the 'size' type of the button. Can be null or 'small'.
+     * Sets the 'size' type of the button. Can be null or 'small'.
      */
     set size(value: string) {
         if (this._size === value) return;
@@ -140,6 +146,9 @@ class Button extends Element {
         }
     }
 
+    /**
+     * Gets the 'size' type of the button.
+     */
     get size(): string {
         return this._size;
     }

--- a/src/components/Canvas/index.ts
+++ b/src/components/Canvas/index.ts
@@ -65,7 +65,7 @@ class Canvas extends Element {
     }
 
     /**
-     * Gets / sets the width of the canvas.
+     * Sets the width of the canvas.
      */
     set width(value: number) {
         if (this._width === value)
@@ -80,13 +80,16 @@ class Canvas extends Element {
         this.emit('resize', this._width, this._height);
     }
 
+    /**
+     * Gets the width of the canvas.
+     */
     get width(): number {
         return this._width;
     }
 
 
     /**
-     * Gets / sets the height of the canvas.
+     * Sets the height of the canvas.
      */
     set height(value: number) {
         if (this._height === value)
@@ -101,6 +104,9 @@ class Canvas extends Element {
         this.emit('resize', this._width, this._height);
     }
 
+    /**
+     * Gets the height of the canvas.
+     */
     get height(): number {
         return this._height;
     }

--- a/src/components/Code/index.ts
+++ b/src/components/Code/index.ts
@@ -44,13 +44,16 @@ class Code extends Container {
     }
 
     /**
-     * Gets / sets the text to display in the code block.
+     * Sets the text to display in the code block.
      */
     set text(value) {
         this._text = value;
         this._inner.text = value;
     }
 
+    /**
+     * Gets the text to display in the code block.
+     */
     get text() {
         return this._text;
     }

--- a/src/components/Container/index.ts
+++ b/src/components/Container/index.ts
@@ -628,7 +628,7 @@ class Container extends Element {
     }
 
     /**
-     * Gets / sets whether the Element supports flex layout.
+     * Sets whether the Element supports flex layout.
      */
     set flex(value: boolean) {
         if (value === this._flex) return;
@@ -642,12 +642,15 @@ class Container extends Element {
         }
     }
 
+    /**
+     * Gets whether the Element supports flex layout.
+     */
     get flex(): boolean {
         return this._flex;
     }
 
     /**
-     * Gets / sets whether the Element supports the grid layout.
+     * Sets whether the Element supports the grid layout.
      */
     set grid(value: boolean) {
         if (value === this._grid) return;
@@ -661,12 +664,15 @@ class Container extends Element {
         }
     }
 
+    /**
+     * Gets whether the Element supports the grid layout.
+     */
     get grid(): boolean {
         return this._grid;
     }
 
     /**
-     * Gets /sets whether the Element should be scrollable.
+     * Sets whether the Element should be scrollable.
      */
     set scrollable(value: boolean) {
         if (this._scrollable === value) return;
@@ -681,13 +687,16 @@ class Container extends Element {
 
     }
 
+    /**
+     * Gets whether the Element should be scrollable.
+     */
     get scrollable(): boolean {
         return this._scrollable;
     }
 
     /**
-     * Gets / sets whether the Element is resizable and where the resize handle is located. Can
-     * be one of 'top', 'bottom', 'right', 'left'. Set to null to disable resizing.
+     * Sets whether the Element is resizable and where the resize handle is located. Can be one of
+     * 'top', 'bottom', 'right', 'left'. Set to null to disable resizing.
      */
     set resizable(value: string) {
         if (value === this._resizable) return;
@@ -723,35 +732,44 @@ class Container extends Element {
         }
     }
 
+    /**
+     * Gets whether the Element is resizable and where the resize handle is located.
+     */
     get resizable(): string {
         return this._resizable;
     }
 
     /**
-     * Gets / sets the minimum size the Element can take when resized in pixels.
+     * Sets the minimum size the Element can take when resized in pixels.
      */
     set resizeMin(value: number) {
         this._resizeMin = Math.max(0, Math.min(value, this._resizeMax));
     }
 
+    /**
+     * Gets the minimum size the Element can take when resized in pixels.
+     */
     get resizeMin(): number {
         return this._resizeMin;
     }
 
     /**
-     * Gets / sets the maximum size the Element can take when resized in pixels.
+     * Sets the maximum size the Element can take when resized in pixels.
      */
     set resizeMax(value: number) {
         this._resizeMax = Math.max(this._resizeMin, value);
     }
 
+    /**
+     * Gets the maximum size the Element can take when resized in pixels.
+     */
     get resizeMax(): number {
         return this._resizeMax;
     }
 
     /**
-     * The internal DOM element used as a the container of all children.
-     * Can be overridden by derived classes.
+     * Sets the internal DOM element used as a the container of all children. Can be overridden by
+     * derived classes.
      */
     set domContent(value: HTMLElement) {
         if (this._domContent === value) return;
@@ -767,6 +785,9 @@ class Container extends Element {
         }
     }
 
+    /**
+     * Gets the internal DOM element used as a the container of all children.
+     */
     get domContent(): HTMLElement {
         return this._domContent;
     }

--- a/src/components/Element/index.ts
+++ b/src/components/Element/index.ts
@@ -26,19 +26,28 @@ const elementRegistry: Map<string, any> = new Map();
 
 export interface IBindable {
     /**
-     * Gets / sets the value of the Element.
+     * Sets the value of the Element.
      */
     set value(values: any),
+    /**
+     * Gets the value of the Element.
+     */
     get value(): any,
     /**
-     * Gets / sets multiple values to the Element. It is up to the Element to determine how to display them.
+     * Sets multiple values on the Element. It is up to the Element to determine how to display them.
      */
     set values(values: Array<any>),
+    /**
+     * Gets multiple values on the Element.
+     */
     get values(): Array<any>,
     /**
-     * Gets / sets whether the input should flash on changes.
+     * Sets whether the input should flash on changes.
      */
     set renderChanges(value: boolean),
+    /**
+     * Gets whether the input should flash on changes.
+     */
     get renderChanges(): boolean,
 }
 
@@ -59,9 +68,12 @@ export interface IBindableArgs {
 
 export interface IPlaceholder {
     /**
-     * Gets / sets the placeholder text of the input.
+     * Sets the placeholder text of the input.
      */
     set placeholder(value: string),
+    /**
+     * Gets the placeholder text of the input.
+     */
     get placeholder(): string
 }
 
@@ -709,7 +721,7 @@ class Element extends Events {
 
 
     /**
-     * Gets / sets whether the Element or its parent chain is enabled or not. Defaults to `true`.
+     * Sets whether the Element or its parent chain is enabled or not. Defaults to `true`.
      */
     set enabled(value: boolean) {
         if (this._enabled === value) return;
@@ -725,13 +737,16 @@ class Element extends Events {
         }
     }
 
+    /**
+     * Gets whether the Element or its parent chain is enabled or not.
+     */
     get enabled(): boolean {
         if (this._ignoreParent) return this._enabled;
         return this._enabled && (!this._parent || this._parent.enabled);
     }
 
     /**
-     * Gets / sets whether the Element will ignore parent events & variable states.
+     * Sets whether the Element will ignore parent events & variable states.
      */
     set ignoreParent(value) {
         this._ignoreParent = value;
@@ -739,6 +754,9 @@ class Element extends Events {
         this._onReadOnlyChange(this.readOnly);
     }
 
+    /**
+     * Gets whether the Element will ignore parent events & variable states.
+     */
     get ignoreParent() {
         return this._ignoreParent;
     }
@@ -751,7 +769,7 @@ class Element extends Events {
     }
 
     /**
-     * Gets / sets the parent Element.
+     * Sets the parent Element.
      */
     set parent(value: Element) {
         if (value === this._parent) return;
@@ -800,12 +818,15 @@ class Element extends Events {
         }
     }
 
+    /**
+     * Gets the parent Element.
+     */
     get parent(): Element {
         return this._parent;
     }
 
     /**
-     * Gets / sets whether the Element is hidden.
+     * Sets whether the Element is hidden.
      */
     set hidden(value: boolean) {
         if (value === this._hidden) return;
@@ -827,6 +848,9 @@ class Element extends Events {
         }
     }
 
+    /**
+     * Gets whether the Element is hidden.
+     */
     get hidden(): boolean {
         return this._hidden;
     }
@@ -841,7 +865,7 @@ class Element extends Events {
 
 
     /**
-     * Gets / sets whether the Element is read only.
+     * Sets whether the Element is read only.
      */
     set readOnly(value: boolean) {
         if (this._readOnly === value) return;
@@ -850,6 +874,9 @@ class Element extends Events {
         this._onReadOnlyChange(value);
     }
 
+    /**
+     * Gets whether the Element is read only.
+     */
     get readOnly(): boolean {
         if (this._ignoreParent) return this._readOnly;
         return this._readOnly || !!(this._parent && this._parent.readOnly);
@@ -857,7 +884,7 @@ class Element extends Events {
 
 
     /**
-     * Gets / sets whether the Element is in an error state.
+     * Sets whether the Element is in an error state.
      */
     set error(value: boolean) {
         if (this._hasError === value) return;
@@ -869,6 +896,9 @@ class Element extends Events {
         }
     }
 
+    /**
+     * Gets whether the Element is in an error state.
+     */
     get error(): boolean {
         return this._hasError;
     }
@@ -889,41 +919,50 @@ class Element extends Events {
     }
 
     /**
-     * Gets / sets the width of the Element in pixels. Can also be an empty string to remove it.
+     * Sets the width of the Element in pixels. Can also be an empty string to remove it.
      */
     set width(value: number | string) {
         this.style.width = typeof value === 'number' ? `${value}px` : value;
     }
 
+    /**
+     * Gets the width of the Element in pixels.
+     */
     get width(): number {
         return this._dom.clientWidth;
     }
 
     /**
-     * Gets / sets the height of the Element in pixels. Can also be an empty string to remove it.
+     * Sets the height of the Element in pixels. Can also be an empty string to remove it.
      */
     set height(value: number | string) {
         this.style.height = typeof value === 'number' ? `${value}px` : value;
     }
 
+    /**
+     * Gets the height of the Element in pixels.
+     */
     get height(): number {
         return this._dom.clientHeight;
     }
 
 
     /**
-     * Gets / sets the tabIndex of the Element.
+     * Sets the tabIndex of the Element.
      */
     set tabIndex(value: number) {
         this._dom.tabIndex = value;
     }
 
+    /**
+     * Gets the tabIndex of the Element.
+     */
     get tabIndex(): number {
         return this._dom.tabIndex;
     }
 
     /**
-     * Gets / sets the Binding object for the element.
+     * Sets the Binding object for the element.
      */
     set binding(value: BindingBase) {
         if (this._binding === value) return;
@@ -951,6 +990,9 @@ class Element extends Events {
         }
     }
 
+    /**
+     * Gets the Binding object for the element.
+     */
     get binding(): BindingBase {
         return this._binding;
     }
@@ -962,100 +1004,127 @@ class Element extends Events {
     // CSS proxy accessors
 
     /**
-     * Gets / sets the flex-direction CSS property.
+     * Sets the flex-direction CSS property.
      */
     set flexDirection(value) {
         this.style.flexDirection = value;
     }
 
+    /**
+     * Gets the flex-direction CSS property.
+     */
     get flexDirection() {
         return this.style.flexDirection;
     }
 
     /**
-     * Gets / sets the flex-grow CSS property.
+     * Sets the flex-grow CSS property.
      */
     set flexGrow(value) {
         this.style.flexGrow = value;
     }
 
+    /**
+     * Gets the flex-grow CSS property.
+     */
     get flexGrow() {
         return this.style.flexGrow;
     }
 
     /**
-     * Gets / sets the flex-basis CSS property.
+     * Sets the flex-basis CSS property.
      */
     set flexBasis(value) {
         this.style.flexBasis = value;
     }
 
+    /**
+     * Gets the flex-basis CSS property.
+     */
     get flexBasis() {
         return this.style.flexBasis;
     }
 
     /**
-     * Gets / sets the flex-shrink CSS property.
+     * Sets the flex-shrink CSS property.
      */
     set flexShrink(value) {
         this.style.flexShrink = value;
     }
 
+    /**
+     * Gets the flex-shrink CSS property.
+     */
     get flexShrink() {
         return this.style.flexShrink;
     }
 
     /**
-     * Gets / sets the flex-wrap CSS property.
+     * Sets the flex-wrap CSS property.
      */
     set flexWrap(value) {
         this.style.flexWrap = value;
     }
 
+    /**
+     * Gets the flex-wrap CSS property.
+     */
     get flexWrap() {
         return this.style.flexWrap;
     }
 
     /**
-     * Gets / sets the align-items CSS property.
+     * Sets the align-items CSS property.
      */
     set alignItems(value) {
         this.style.alignItems = value;
     }
 
+    /**
+     * Gets the align-items CSS property.
+     */
     get alignItems() {
         return this.style.alignItems;
     }
 
     /**
-     * Gets / sets the align-self CSS property.
+     * Sets the align-self CSS property.
      */
     set alignSelf(value) {
         this.style.alignSelf = value;
     }
 
+    /**
+     * Gets the align-self CSS property.
+     */
     get alignSelf() {
         return this.style.alignSelf;
     }
 
     /**
-     * Gets / sets the justify-content CSS property.
+     * Sets the justify-content CSS property.
      */
     set justifyContent(value) {
         this.style.justifyContent = value;
     }
 
+    /**
+     * Gets the justify-content CSS property.
+     */
     get justifyContent() {
         return this.style.justifyContent;
     }
 
     /**
-     * Gets / sets the justify-self CSS property.
+     * Sets the justify-self CSS property.
      */
     set justifySelf(value) {
         this.style.justifySelf = value;
     }
 
+    /**
+     * Gets the justify-self CSS property.
+     */
     get justifySelf() {
         return this.style.justifySelf;
     }

--- a/src/components/GridViewItem/index.ts
+++ b/src/components/GridViewItem/index.ts
@@ -130,18 +130,21 @@ class GridViewItem extends Container implements IFocusable {
     }
 
     /**
-     * If `true` allow selecting the item. Defaults to `true`.
+     * Sets whether the item can be selected. Defaults to `true`.
      */
     set allowSelect(value) {
         this._allowSelect = value;
     }
 
+    /**
+     * Gets whether the item can be selected. Defaults to `true`.
+     */
     get allowSelect() {
         return this._allowSelect;
     }
 
     /**
-     * Whether the item is selected.
+     * Sets whether the item is selected.
      */
     set selected(value) {
         if (value) {
@@ -171,23 +174,29 @@ class GridViewItem extends Container implements IFocusable {
         }
     }
 
+    /**
+     * Gets whether the item is selected.
+     */
     get selected() {
         return this._selected;
     }
 
     /**
-     * The text of the item.
+     * Sets the text of the item.
      */
     set text(value) {
         this._labelText.text = value;
     }
 
+    /**
+     * Gets the text of the item.
+     */
     get text() {
         return this._labelText.text;
     }
 
     /**
-     * Returns the next visible sibling grid view item.
+     * Gets the next visible sibling grid view item.
      */
     get nextSibling() {
         let sibling = this.dom.nextSibling;
@@ -203,7 +212,7 @@ class GridViewItem extends Container implements IFocusable {
     }
 
     /**
-     * Returns the previous visible sibling grid view item.
+     * Gets the previous visible sibling grid view item.
      */
     get previousSibling() {
         let sibling = this.dom.previousSibling;

--- a/src/components/InfoBox/index.ts
+++ b/src/components/InfoBox/index.ts
@@ -80,6 +80,9 @@ class InfoBox extends Container {
         }
     }
 
+    /**
+     * Gets the icon of the info box.
+     */
     get icon() {
         return this._icon;
     }
@@ -97,6 +100,9 @@ class InfoBox extends Container {
         }
     }
 
+    /**
+     * Gets the title of the info box.
+     */
     get title() {
         return this._title;
     }
@@ -114,6 +120,9 @@ class InfoBox extends Container {
         }
     }
 
+    /**
+     * Gets the text of the info box.
+     */
     get text() {
         return this._text;
     }

--- a/src/components/InputElement/index.ts
+++ b/src/components/InputElement/index.ts
@@ -202,7 +202,7 @@ abstract class InputElement extends Element implements IBindable, IFocusable, IP
 
 
     /**
-     * Gets / sets the method to call when keyup is called on the input DOM element.
+     * Sets the method to call when keyup is called on the input DOM element.
      */
     set keyChange(value) {
         if (this._keyChange === value) return;
@@ -215,6 +215,9 @@ abstract class InputElement extends Element implements IBindable, IFocusable, IP
         }
     }
 
+    /**
+     * Gets the method to call when keyup is called on the input DOM element.
+     */
     get keyChange() {
         return this._keyChange;
     }
@@ -227,23 +230,29 @@ abstract class InputElement extends Element implements IBindable, IFocusable, IP
     }
 
     /**
-     * Gets / sets whether the input should blur when the enter key is pressed.
+     * Sets whether the input should blur when the enter key is pressed.
      */
     set blurOnEnter(value: boolean) {
         this._blurOnEnter = value;
     }
 
+    /**
+     * Gets whether the input should blur when the enter key is pressed.
+     */
     get blurOnEnter(): boolean {
         return this._blurOnEnter;
     }
 
     /**
-     * Gets / sets whether the input should blur when the escape key is pressed.
+     * Sets whether the input should blur when the escape key is pressed.
      */
     set blurOnEscape(value: boolean) {
         this._blurOnEscape = value;
     }
 
+    /**
+     * Gets whether the input should blur when the escape key is pressed.
+     */
     get blurOnEscape(): boolean {
         return this._blurOnEscape;
     }

--- a/src/components/Label/index.ts
+++ b/src/components/Label/index.ts
@@ -95,7 +95,7 @@ class Label extends Element implements IPlaceholder, IBindable {
     }
 
     /**
-     * Gets / sets the text of the Label.
+     * Sets the text of the Label.
      */
     set text(value: string) {
         if (value === undefined || value === null) {
@@ -109,6 +109,9 @@ class Label extends Element implements IPlaceholder, IBindable {
         }
     }
 
+    /**
+     * Gets the text of the Label.
+     */
     get text(): string {
         return this._text;
     }

--- a/src/components/LabelGroup/index.ts
+++ b/src/components/LabelGroup/index.ts
@@ -74,18 +74,21 @@ class LabelGroup extends Container {
     }
 
     /**
-     * Sets / Gets the text of the label.
+     * Sets the text of the label.
      */
     set text(value) {
         this._label.text = value;
     }
 
+    /**
+     * Gets the text of the label.
+     */
     get text() {
         return this._label.text;
     }
 
     /**
-     * Sets / Gets whether to align the label at the top of the group. Defaults to `false` which aligns it at the center.
+     * Sets whether to align the label at the top of the group. Defaults to `false` which aligns it at the center.
      */
     set labelAlignTop(value) {
         if (value) {
@@ -95,6 +98,9 @@ class LabelGroup extends Container {
         }
     }
 
+    /**
+     * Gets whether to align the label at the top of the group.
+     */
     get labelAlignTop() {
         return this.class.contains(CLASS_LABEL_TOP);
     }

--- a/src/components/MenuItem/index.ts
+++ b/src/components/MenuItem/index.ts
@@ -194,12 +194,15 @@ class MenuItem extends Container implements IBindable {
     }
 
     /**
-     * Gets / sets the text shown on the MenuItem.
+     * Sets the text shown on the MenuItem.
      */
     set text(value) {
         this._labelText.text = value;
     }
 
+    /**
+     * Gets the text shown on the MenuItem.
+     */
     get text() {
         return this._labelText.text;
     }
@@ -218,7 +221,7 @@ class MenuItem extends Container implements IBindable {
     }
 
     /**
-     * Gets / sets the CSS code for an icon for the MenuItem. e.g. 'E401' (notice we omit the '\\' character).
+     * Sets the CSS code for an icon for the MenuItem. e.g. 'E401' (notice we omit the '\\' character).
      */
     set icon(value) {
         if (this._icon === value || !value.match(/^E[0-9]{0,4}$/)) return;
@@ -231,23 +234,29 @@ class MenuItem extends Container implements IBindable {
         }
     }
 
+    /**
+     * Gets the CSS code for an icon for the MenuItem.
+     */
     get icon() {
         return this._icon;
     }
 
     /**
-     * Gets / sets the binding for the MenuItem label.
+     * Sets the binding for the MenuItem label.
      */
     set binding(value) {
         this._labelText.binding = value;
     }
 
+    /**
+     * Gets the binding for the MenuItem label.
+     */
     get binding() {
         return this._labelText.binding;
     }
 
     /**
-     * Gets / sets the menu.
+     * Sets the menu.
      */
     set menu(value) {
         this._menu = value;
@@ -262,39 +271,51 @@ class MenuItem extends Container implements IBindable {
         }
     }
 
+    /**
+     * Gets the menu.
+     */
     get menu() {
         return this._menu;
     }
 
     /**
-     * Gets / sets the function that is called when the MenuItem is selected.
+     * Sets the function that is called when the MenuItem is selected.
      */
     set onSelect(value) {
         this._onSelect = value;
     }
 
+    /**
+     * Gets the function that is called when the MenuItem is selected.
+     */
     get onSelect() {
         return this._onSelect;
     }
 
     /**
-     * Gets / sets the function that is called when the MenuItem is enabled or disabled.
+     * Sets the function that is called when the MenuItem is enabled or disabled.
      */
     set onIsEnabled(value) {
         this._onIsEnabled = value;
     }
 
+    /**
+     * Gets the function that is called when the MenuItem is enabled or disabled.
+     */
     get onIsEnabled() {
         return this._onIsEnabled;
     }
 
     /**
-     * Gets / sets the function that is called when the MenuItem is visible or hidden.
+     * Sets the function that is called when the MenuItem is visible or hidden.
      */
     set onIsVisible(value) {
         this._onIsVisible = value;
     }
 
+    /**
+     * Gets the function that is called when the MenuItem is visible or hidden.
+     */
     get onIsVisible() {
         return this._onIsVisible;
     }

--- a/src/components/NumericInput/index.ts
+++ b/src/components/NumericInput/index.ts
@@ -345,7 +345,7 @@ class NumericInput extends InputElement {
     }
 
     /**
-     * Gets / sets the minimum value this field can take.
+     * Sets the minimum value this field can take.
      */
     set min(value) {
         if (this._min === value) return;
@@ -357,12 +357,15 @@ class NumericInput extends InputElement {
         }
     }
 
+    /**
+     * Gets the minimum value this field can take.
+     */
     get min() {
         return this._min;
     }
 
     /**
-     * Gets / sets the maximum value this field can take.
+     * Sets the maximum value this field can take.
      */
     set max(value) {
         if (this._max === value) return;
@@ -374,12 +377,15 @@ class NumericInput extends InputElement {
         }
     }
 
+    /**
+     * Gets the maximum value this field can take.
+     */
     get max() {
         return this._max;
     }
 
     /**
-     * Gets / sets the precision of the input.
+     * Sets the precision of the input.
      */
     set precision(value) {
         if (this._precision === value) return;
@@ -391,17 +397,23 @@ class NumericInput extends InputElement {
         }
     }
 
+    /**
+     * Gets the precision of the input.
+     */
     get precision() {
         return this._precision;
     }
 
     /**
-     * Gets / sets the amount that the value will be increased or decreased when using the arrow keys and the slider input.
+     * Sets the amount that the value will be increased or decreased when using the arrow keys and the slider input.
      */
     set step(value) {
         this._step = value;
     }
 
+    /**
+     * Gets the amount that the value will be increased or decreased when using the arrow keys and the slider input.
+     */
     get step() {
         return this._step;
     }

--- a/src/components/Overlay/index.ts
+++ b/src/components/Overlay/index.ts
@@ -94,7 +94,7 @@ class Overlay extends Container {
     }
 
     /**
-     * Whether the overlay can be hidden by clicking on it.
+     * Sets whether the overlay can be hidden by clicking on it.
      */
     set clickable(value) {
         if (value) {
@@ -104,12 +104,15 @@ class Overlay extends Container {
         }
     }
 
+    /**
+     * Gets whether the overlay can be hidden by clicking on it.
+     */
     get clickable() {
         return this.class.contains(CLASS_OVERLAY_CLICKABLE);
     }
 
     /**
-     * Whether the overlay is transparent or not.
+     * Sets whether the overlay is transparent or not.
      */
     set transparent(value) {
         if (value) {
@@ -119,6 +122,9 @@ class Overlay extends Container {
         }
     }
 
+    /**
+     * Gets whether the overlay is transparent or not.
+     */
     get transparent() {
         return this.class.contains(CLASS_OVERLAY_TRANSPARENT);
     }

--- a/src/components/Panel/index.ts
+++ b/src/components/Panel/index.ts
@@ -354,7 +354,7 @@ class Panel extends Container {
     }
 
     /**
-     * Gets / sets whether the Element is collapsible.
+     * Sets whether the Element is collapsible.
      */
     set collapsible(value) {
         if (value === this._collapsible) return;
@@ -375,12 +375,15 @@ class Panel extends Container {
 
     }
 
+    /**
+     * Gets whether the Element is collapsible.
+     */
     get collapsible() {
         return this._collapsible;
     }
 
     /**
-     * Gets / sets whether the Element should be collapsed.
+     * Sets whether the Element should be collapsed.
      */
     set collapsed(value) {
         if (this._collapsed === value) return;
@@ -394,12 +397,15 @@ class Panel extends Container {
         }
     }
 
+    /**
+     * Gets whether the Element should be collapsed.
+     */
     get collapsed() {
         return this._collapsed;
     }
 
     /**
-     * Gets / sets whether the panel can be reordered.
+     * Sets whether the panel can be reordered.
      */
     set sortable(value) {
         if (this._sortable === value) return;
@@ -420,12 +426,15 @@ class Panel extends Container {
         }
     }
 
+    /**
+     * Gets whether the panel can be reordered.
+     */
     get sortable() {
         return this._sortable;
     }
 
     /**
-     * Gets / sets whether the panel can be removed
+     * Sets whether the panel can be removed
      */
     set removable(value) {
         if (this.removable === value) return;
@@ -443,12 +452,15 @@ class Panel extends Container {
         }
     }
 
+    /**
+     * Gets whether the panel can be removed
+     */
     get removable() {
         return !!this._btnRemove;
     }
 
     /**
-     * Gets / sets whether the panel collapses horizontally - this would be the case for side panels. Defaults to `false`.
+     * Sets whether the panel collapses horizontally. This would be the case for side panels. Defaults to `false`.
      */
     set collapseHorizontally(value) {
         if (this._collapseHorizontally === value) return;
@@ -463,6 +475,9 @@ class Panel extends Container {
         this._reflow();
     }
 
+    /**
+     * Gets whether the panel collapses horizontally.
+     */
     get collapseHorizontally() {
         return this._collapseHorizontally;
     }
@@ -482,18 +497,21 @@ class Panel extends Container {
     }
 
     /**
-     * The header text of the panel. Defaults to the empty string.
+     * Sets the header text of the panel. Defaults to the empty string.
      */
     set headerText(value) {
         this._labelTitle.text = value;
     }
 
+    /**
+     * Gets the header text of the panel.
+     */
     get headerText() {
         return this._labelTitle.text;
     }
 
     /**
-     * The height of the header in pixels. Defaults to 32.
+     * Sets the height of the header in pixels. Defaults to 32.
      */
     set headerSize(value) {
         this._headerSize = value;
@@ -503,6 +521,9 @@ class Panel extends Container {
         this._reflow();
     }
 
+    /**
+     * Gets the height of the header in pixels.
+     */
     get headerSize() {
         return this._headerSize;
     }

--- a/src/components/Progress/index.ts
+++ b/src/components/Progress/index.ts
@@ -41,7 +41,7 @@ class Progress extends Container {
     }
 
     /**
-     * Gets / sets the value of the progress bar (between 0 and 100).
+     * Sets the value of the progress bar. The range is from 0 to 100.
      */
     set value(val) {
         if (this._value === val) return;
@@ -51,6 +51,9 @@ class Progress extends Container {
         this.emit('change', val);
     }
 
+    /**
+     * Gets the value of the progress bar.
+     */
     get value() {
         return this._value;
     }

--- a/src/components/SliderInput/index.ts
+++ b/src/components/SliderInput/index.ts
@@ -305,7 +305,7 @@ class SliderInput extends Element implements IBindable, IFocusable, IPlaceholder
     }
 
     /**
-     * Gets / sets the minimum value that the slider field can take.
+     * Sets the minimum value that the slider field can take.
      */
     set sliderMin(value) {
         if (this._sliderMin === value) return;
@@ -314,12 +314,15 @@ class SliderInput extends Element implements IBindable, IFocusable, IPlaceholder
         this._updateHandle(this.value);
     }
 
+    /**
+     * Gets the minimum value that the slider field can take.
+     */
     get sliderMin() {
         return this._sliderMin;
     }
 
     /**
-     * Gets / sets the maximum value that the slider field can take.
+     * Sets the maximum value that the slider field can take.
      */
     set sliderMax(value) {
         if (this._sliderMax === value) return;
@@ -328,6 +331,9 @@ class SliderInput extends Element implements IBindable, IFocusable, IPlaceholder
         this._updateHandle(this.value);
     }
 
+    /**
+     * Gets the maximum value that the slider field can take.
+     */
     get sliderMax() {
         return this._sliderMax;
     }
@@ -364,45 +370,57 @@ class SliderInput extends Element implements IBindable, IFocusable, IPlaceholder
     }
 
     /**
-     * Gets / sets the minimum value that the numeric input field can take.
+     * Sets the minimum value that the numeric input field can take.
      */
     set min(value) {
         this._numericInput.min = value;
     }
 
+    /**
+     * Gets the minimum value that the numeric input field can take.
+     */
     get min() {
         return this._numericInput.min;
     }
 
     /**
-     * Gets / sets the maximum value that the numeric input field can take.
+     * Sets the maximum value that the numeric input field can take.
      */
     set max(value) {
         this._numericInput.max = value;
     }
 
+    /**
+     * Gets the maximum value that the numeric input field can take.
+     */
     get max() {
         return this._numericInput.max;
     }
 
     /**
-     * Gets / sets the amount that the value will be increased or decreased when using the arrow keys. Holding Shift will use 10x the step.
+     * Sets the amount that the value will be increased or decreased when using the arrow keys. Holding Shift will use 10x the step.
      */
     set step(value) {
         this._numericInput.step = value;
     }
 
+    /**
+     * Gets the amount that the value will be increased or decreased when using the arrow keys.
+     */
     get step() {
         return this._numericInput.step;
     }
 
     /**
-     * Gets / sets the maximum number of decimals a value can take.
+     * Sets the maximum number of decimals a value can take.
      */
     set precision(value) {
         this._numericInput.precision = value;
     }
 
+    /**
+     * Gets the maximum number of decimals a value can take.
+     */
     get precision() {
         return this._numericInput.precision;
     }

--- a/src/components/TreeView/index.ts
+++ b/src/components/TreeView/index.ts
@@ -1058,7 +1058,7 @@ class TreeView extends Container {
     }
 
     /**
-     * Whether dragging a TreeViewItem is allowed.
+     * Sets whether dragging a TreeViewItem is allowed.
      */
     set allowDrag(value: boolean) {
         this._allowDrag = value;
@@ -1067,34 +1067,43 @@ class TreeView extends Container {
         }
     }
 
+    /**
+     * Gets whether dragging a TreeViewItem is allowed.
+     */
     get allowDrag(): boolean {
         return this._allowDrag;
     }
 
     /**
-     * Whether reordering TreeViewItems is allowed.
+     * Sets whether reordering TreeViewItems is allowed.
      */
     set allowReordering(value: boolean) {
         this._allowReordering = value;
     }
 
+    /**
+     * Gets whether reordering TreeViewItems is allowed.
+     */
     get allowReordering(): boolean {
         return this._allowReordering;
     }
 
     /**
-     * Whether renaming TreeViewItems is allowed by double clicking on them.
+     * Sets whether renaming TreeViewItems is allowed by double clicking on them.
      */
     set allowRenaming(value: boolean) {
         this._allowRenaming = value;
     }
 
+    /**
+     * Gets whether renaming TreeViewItems is allowed by double clicking on them.
+     */
     get allowRenaming(): boolean {
         return this._allowRenaming;
     }
 
     /**
-     * Whether a TreeViewItem is currently being dragged.
+     * Sets whether a TreeViewItem is currently being dragged.
      */
     set isDragging(value: boolean) {
         if (this._dragging === value) return;
@@ -1127,19 +1136,22 @@ class TreeView extends Container {
         }
     }
 
+    /**
+     * Gets whether a TreeViewItem is currently being dragged.
+     */
     get isDragging(): boolean {
         return this._dragging;
     }
 
     /**
-     * Returns all of the currently selected TreeViewItems.
+     * Gets all of the currently selected TreeViewItems.
      */
     get selected(): Array<TreeViewItem> {
         return this._selectedItems.slice();
     }
 
     /**
-     * A filter that searches TreeViewItems and only shows the ones that are relevant to the filter.
+     * Sets the filter that searches TreeViewItems and only shows the ones that are relevant to the filter.
      */
     set filter(value) {
         if (this._filter === value) return;
@@ -1153,19 +1165,22 @@ class TreeView extends Container {
         }
     }
 
+    /**
+     * Gets the filter that searches TreeViewItems and only shows the ones that are relevant to the filter.
+     */
     get filter() {
         return this._filter;
     }
 
     /**
-     * Whether Ctrl is currently pressed.
+     * Gets whether Ctrl is currently pressed.
      */
     get pressedCtrl(): boolean {
         return this._pressedCtrl;
     }
 
     /**
-     * Whether Shift is currently pressed.
+     * Gets whether Shift is currently pressed.
      */
     get pressedShift(): boolean {
         return this._pressedShift;

--- a/src/components/TreeViewItem/index.ts
+++ b/src/components/TreeViewItem/index.ts
@@ -399,7 +399,7 @@ class TreeViewItem extends Container {
     }
 
     /**
-     * Whether the item is selected.
+     * Sets whether the item is selected.
      */
     set selected(value) {
         if (value === this.selected) {
@@ -428,12 +428,15 @@ class TreeViewItem extends Container {
         }
     }
 
+    /**
+     * Gets whether the item is selected.
+     */
     get selected() {
         return this._containerContents.class.contains(CLASS_SELECTED);
     }
 
     /**
-     * The text shown by the TreeViewItem.
+     * Sets the text shown by the TreeViewItem.
      */
     set text(value) {
         if (this._labelText.value !== value) {
@@ -444,6 +447,9 @@ class TreeViewItem extends Container {
         }
     }
 
+    /**
+     * Gets the text shown by the TreeViewItem.
+     */
     get text() {
         return this._labelText.value;
     }
@@ -463,7 +469,7 @@ class TreeViewItem extends Container {
     }
 
     /**
-     * Whether the item is open meaning showing its children.
+     * Sets whether the item is expanded and showing its children.
      */
     set open(value) {
         if (this.open === value) return;
@@ -478,12 +484,15 @@ class TreeViewItem extends Container {
         }
     }
 
+    /**
+     * Gets whether the item is expanded and showing its children.
+     */
     get open() {
         return this.class.contains(CLASS_OPEN) || this.parent === this._treeView;
     }
 
     /**
-     * Whether the parents of the item are open or closed.
+     * Sets whether the ancestors of the item are open or closed.
      */
     set parentsOpen(value) {
         let parent = this.parent;
@@ -493,6 +502,9 @@ class TreeViewItem extends Container {
         }
     }
 
+    /**
+     * Gets whether the ancestors of the item are open or closed.
+     */
     get parentsOpen() {
         let parent = this.parent;
         while (parent && parent instanceof TreeViewItem) {
@@ -504,51 +516,64 @@ class TreeViewItem extends Container {
     }
 
     /**
-     * Whether dropping is allowed on the tree item.
+     * Sets whether dropping is allowed on the tree item.
      */
     set allowDrop(value) {
         this._allowDrop = value;
     }
 
+    /**
+     * Gets whether dropping is allowed on the tree item.
+     */
     get allowDrop() {
         return this._allowDrop;
     }
 
     /**
-     * Whether this tree item can be dragged. Only considered if the parent treeview has allowDrag true.
+     * Sets whether this tree item can be dragged. Only considered if the parent {@link TreeView}
+     * has {@link TreeView#allowDrag} set to `true`.
      */
     set allowDrag(value) {
         this._allowDrag = value;
     }
 
+    /**
+     * Gets whether this tree item can be dragged.
+     */
     get allowDrag() {
         return this._allowDrag;
     }
 
     /**
-     * Whether the item can be selected.
+     * Sets whether the item can be selected.
      */
     set allowSelect(value) {
         this._allowSelect = value;
     }
 
+    /**
+     * Gets whether the item can be selected.
+     */
     get allowSelect() {
         return this._allowSelect;
     }
 
     /**
-     * Gets / sets the parent TreeView.
+     * Sets the parent {@link TreeView}.
      */
     set treeView(value) {
         this._treeView = value;
     }
 
+    /**
+     * Gets the parent {@link TreeView}.
+     */
     get treeView() {
         return this._treeView;
     }
 
     /**
-     * The number of direct children.
+     * Gets the number of direct children.
      */
     get numChildren() {
         return this._numChildren;
@@ -609,7 +634,7 @@ class TreeViewItem extends Container {
     }
 
     /**
-     * The icon shown before the text in the TreeViewItem.
+     * Sets the icon shown before the text in the TreeViewItem.
      */
     set icon(value) {
         if (this._icon === value || !value.match(/^E[0-9]{0,4}$/)) return;
@@ -622,6 +647,9 @@ class TreeViewItem extends Container {
         }
     }
 
+    /**
+     * Gets the icon shown before the text in the TreeViewItem.
+     */
     get icon() {
         return this._icon;
     }

--- a/src/components/VectorInput/index.ts
+++ b/src/components/VectorInput/index.ts
@@ -301,7 +301,7 @@ class VectorInput extends Element implements IBindable, IFocusable, IPlaceholder
     }
 
     /**
-     * Gets / sets the minimum value accepted by all inputs of the vector.
+     * Sets the minimum value accepted by all inputs of the vector.
      */
     set min(value) {
         for (const input of this._inputs) {
@@ -309,12 +309,15 @@ class VectorInput extends Element implements IBindable, IFocusable, IPlaceholder
         }
     }
 
+    /**
+     * Gets the minimum value accepted by all inputs of the vector.
+     */
     get min() {
         return this._inputs[0].min;
     }
 
     /**
-     * Gets / sets the maximum value accepted by all inputs of the vector.
+     * Sets the maximum value accepted by all inputs of the vector.
      */
     set max(value) {
         for (const input of this._inputs) {
@@ -322,12 +325,15 @@ class VectorInput extends Element implements IBindable, IFocusable, IPlaceholder
         }
     }
 
+    /**
+     * Gets the maximum value accepted by all inputs of the vector.
+     */
     get max() {
         return this._inputs[0].max;
     }
 
     /**
-     * Gets / sets the maximum number of decimal places supported by all inputs of the vector.
+     * Sets the maximum number of decimal places supported by all inputs of the vector.
      */
     set precision(value) {
         for (const input of this._inputs) {
@@ -335,13 +341,16 @@ class VectorInput extends Element implements IBindable, IFocusable, IPlaceholder
         }
     }
 
+    /**
+     * Gets the maximum number of decimal places supported by all inputs of the vector.
+     */
     get precision() {
         return this._inputs[0].precision;
     }
 
     /**
-     * Gets / sets the amount that the value will be increased or decreased when using the arrow
-     * keys and the slider input for all inputs of the vector.
+     * Sets the amount that the value will be increased or decreased when using the arrow keys and
+     * the slider input for all inputs of the vector.
      */
     set step(value) {
         for (const input of this._inputs) {
@@ -349,6 +358,10 @@ class VectorInput extends Element implements IBindable, IFocusable, IPlaceholder
         }
     }
 
+    /**
+     * Gets the amount that the value will be increased or decreased when using the arrow keys and
+     * the slider input for all inputs of the vector.
+     */
     get step() {
         return this._inputs[0].step;
     }


### PR DESCRIPTION
When generating the API reference with TypeDoc, we want to exclude any symbols that are undocumented. This means we must document all public API getters.