### PR TITLE
Scrollbar styles

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -31,7 +31,7 @@
         {
             "imports": {
                 "@playcanvas/pcui": "https://cdn.skypack.dev/@playcanvas/pcui",
-                "@playcanvas/pcui/styles": "http://localhost:3000/styles/dist/index.mjs"
+                "@playcanvas/pcui/styles": "https://cdn.skypack.dev/@playcanvas/pcui/styles"
             }
         }
     </script>

--- a/examples/index.html
+++ b/examples/index.html
@@ -25,34 +25,13 @@
         .pcui-treeview-item-icon {
             font-size: 14px;
         }
-
-        ::-webkit-scrollbar {
-            width: 8px;
-            height: 8px;
-        }
-
-        ::-webkit-scrollbar-track {
-            background: #20292b;
-        }
-
-        ::-webkit-scrollbar-thumb {
-            background: #5b7073;
-        }
-
-        ::-webkit-scrollbar-thumb:hover {
-            background: #f60;
-        }
-
-        ::-webkit-scrollbar-corner {
-            background: #2c393c;
-        }
     </style>
     <script async src="https://unpkg.com/es-module-shims/dist/es-module-shims.js"></script>
     <script type="importmap">
         {
             "imports": {
                 "@playcanvas/pcui": "https://cdn.skypack.dev/@playcanvas/pcui",
-                "@playcanvas/pcui/styles": "https://cdn.skypack.dev/@playcanvas/pcui/styles"
+                "@playcanvas/pcui/styles": "http://localhost:3000/styles/dist/index.mjs"
             }
         }
     </script>

--- a/src/scss/_scrollbars.scss
+++ b/src/scss/_scrollbars.scss
@@ -1,0 +1,31 @@
+/* Apply scrollbar styles globally */
+* {
+    /* Webkit-based browsers */
+    &::-webkit-scrollbar {
+        width: 8px;
+        height: 8px;
+    }
+
+    &::-webkit-scrollbar-track {
+        background: $bcg-darkest;
+    }
+
+    &::-webkit-scrollbar-thumb {
+        background: $text-darkest;
+    }
+
+    &::-webkit-scrollbar-thumb:hover {
+        background: $text-active;
+    }
+
+    &::-webkit-scrollbar-corner {
+        background: $bcg-dark;
+    }
+
+    /* Standardized Properties */
+    @supports not selector(::-webkit-scrollbar) {
+        /* Firefox */
+        scrollbar-width: thin;
+        scrollbar-color: $text-darkest $bcg-darkest;
+    }
+}

--- a/src/scss/pcui-base.scss
+++ b/src/scss/pcui-base.scss
@@ -1,4 +1,5 @@
 @import './variables';
 @import './fonts';
+@import './scrollbars';
 @import './pcui-common';
 @import './components';


### PR DESCRIPTION
This PR has PCUI define appropriate scrollbar styling.

Here are some comparisons of scrollbar styling across Chrome (Safari looks the same) and Firefox:

No styling:

| Chrome | Firefox |
| --- | --- |
| ![scrollbars-chrome-none](https://github.com/playcanvas/pcui/assets/697563/60c4712d-2e48-4f96-980b-16a2d8c3f85f) | ![scrollbars-firefox-none](https://github.com/playcanvas/pcui/assets/697563/b1486cf0-7414-471b-b9f1-5790999bd694) |

[CSS Scrollbars Styling Module Level 1](https://drafts.csswg.org/css-scrollbars-1/):

| Chrome | Firefox |
| --- | --- |
| ![scrollbars-chrome-standard](https://github.com/playcanvas/pcui/assets/697563/1874eb70-a712-4765-b65a-709c6f450e0f) | ![scrollbars-firefox-standard](https://github.com/playcanvas/pcui/assets/697563/dcc30082-e248-4076-895a-ec0ec881f5cb) |

WebKit Psuedo-Element styling:

| Chrome | Firefox |
| --- | --- |
| ![scrollbars-chrome-webkit](https://github.com/playcanvas/pcui/assets/697563/ff34fbb9-b916-482f-94ac-7ac8d1397bd9) | N/A<br /> ![line](https://github.com/playcanvas/pcui/assets/697563/03e96674-2059-4fa9-83f3-d272bbf3495f) |

Despite hover/selection color differences, the WebKit styling seems to look most similar to the Firefox scrollbars which use the standardized CSS properties. So this is what this PR implements.
