### PR TITLE
fix: In shadow DOM, The target obtained is shadowRoot

### DIFF
--- a/src/components/SelectInput/index.ts
+++ b/src/components/SelectInput/index.ts
@@ -725,7 +725,7 @@ class SelectInput extends Element implements IBindable, IFocusable {
     };
 
     protected _onWindowMouseDown = (evt: MouseEvent) => {
-        if (!this.dom.contains(evt.target as Node)) {
+        if (!this.dom.contains(evt.composedPath()[0] as Node)) {
             this.close();
         }
     };


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e77ca2d0-5128-4bbe-a972-2b8ad6bf9af3)
