### PR TITLE
Fix for slider input events

### DIFF
--- a/src/components/SliderInput/index.ts
+++ b/src/components/SliderInput/index.ts
@@ -240,7 +240,6 @@ class SliderInput extends Element implements IBindable, IFocusable, IPlaceholder
 
     protected _onSlideStart(pageX: number) {
         this._domHandle.focus();
-        console.log('adding slider pointer move handler');
         window.addEventListener('pointermove', this._onPointerMove, true);
         window.addEventListener('pointerup', this._onPointerUp, true);
 

--- a/src/components/SliderInput/index.ts
+++ b/src/components/SliderInput/index.ts
@@ -240,8 +240,9 @@ class SliderInput extends Element implements IBindable, IFocusable, IPlaceholder
 
     protected _onSlideStart(pageX: number) {
         this._domHandle.focus();
-        window.addEventListener('pointermove', this._onPointerMove);
-        window.addEventListener('pointerup', this._onPointerUp);
+        console.log('adding slider pointer move handler');
+        window.addEventListener('pointermove', this._onPointerMove, true);
+        window.addEventListener('pointerup', this._onPointerUp, true);
 
         this.class.add(CLASS_SLIDER_ACTIVE);
 
@@ -283,8 +284,8 @@ class SliderInput extends Element implements IBindable, IFocusable, IPlaceholder
 
         this.class.remove(CLASS_SLIDER_ACTIVE);
 
-        window.removeEventListener('pointermove', this._onPointerMove);
-        window.removeEventListener('pointerup', this._onPointerUp);
+        window.removeEventListener('pointermove', this._onPointerMove, true);
+        window.removeEventListener('pointerup', this._onPointerUp, true);
 
         if (this.binding) {
             this.binding.historyCombine = this._historyCombine;

--- a/src/components/SliderInput/index.ts
+++ b/src/components/SliderInput/index.ts
@@ -240,8 +240,8 @@ class SliderInput extends Element implements IBindable, IFocusable, IPlaceholder
 
     protected _onSlideStart(pageX: number) {
         this._domHandle.focus();
-        window.addEventListener('pointermove', this._onPointerMove, true);
-        window.addEventListener('pointerup', this._onPointerUp, true);
+        this._domSlider.addEventListener('pointermove', this._onPointerMove);
+        this._domSlider.addEventListener('pointerup', this._onPointerUp);
 
         this.class.add(CLASS_SLIDER_ACTIVE);
 
@@ -283,8 +283,8 @@ class SliderInput extends Element implements IBindable, IFocusable, IPlaceholder
 
         this.class.remove(CLASS_SLIDER_ACTIVE);
 
-        window.removeEventListener('pointermove', this._onPointerMove, true);
-        window.removeEventListener('pointerup', this._onPointerUp, true);
+        this._domSlider.removeEventListener('pointermove', this._onPointerMove);
+        this._domSlider.removeEventListener('pointerup', this._onPointerUp);
 
         if (this.binding) {
             this.binding.historyCombine = this._historyCombine;

--- a/src/components/SliderInput/style.scss
+++ b/src/components/SliderInput/style.scss
@@ -45,8 +45,6 @@
 
 // active state
 .pcui-slider-active {
-    cursor: ew-resize;
-
     .pcui-slider-bar {
         border-color: $bcg-darkest;
         background-color: $bcg-darkest;
@@ -61,10 +59,6 @@
 
 // hover state
 .pcui-slider:not(.pcui-disabled, .pcui-readonly) {
-    &:hover {
-        cursor: pointer;
-    }
-
     .pcui-slider-handle {
         &:focus,
         &:hover {
@@ -76,6 +70,12 @@
     }
 }
 
+.pcui-slider {
+    cursor: pointer;
+    &.pcui-slider-active {
+        cursor: ew-resize;
+    }
+}
 // readonly state (hide slider)
 .pcui-slider.pcui-readonly {
     .pcui-numeric-input {


### PR DESCRIPTION
Register move and up pointer events on the correct DOM element instead of relying on global window.