### PR TITLE
Generate source maps

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -44,14 +44,16 @@ const module = {
         dir: `dist/module`,
         entryFileNames: '[name].mjs',
         format: 'esm',
-        preserveModules: true
+        preserveModules: true,
+        sourcemap: true
     },
     plugins: [
         nodeResolve(),
         replace(replacements),
         typescript({
             noEmitOnError: true,
-            tsconfig: 'tsconfig.json'
+            tsconfig: 'tsconfig.json',
+            sourceMap: true
         })
     ],
     treeshake: 'smallest',
@@ -68,14 +70,16 @@ const react_module = {
         globals: {
             'react': 'React'
         },
-        preserveModules: true
+        preserveModules: true,
+        sourcemap: true
     },
     plugins: [
         nodeResolve(),
         replace(replacements),
         typescript({
             noEmitOnError: true,
-            tsconfig: 'react/tsconfig.json'
+            tsconfig: 'react/tsconfig.json',
+            sourceMap: true
         })
     ],
     treeshake: 'smallest',
@@ -94,7 +98,9 @@ const styles = {
             insert: true,
             output: false,
             processor: css => postcss([autoprefixer])
-                .process(css)
+                .process(css, {
+                    from: undefined
+                })
                 .then(result => result.css)
         })
     ]


### PR DESCRIPTION
Also suppress this error on building the CSS:

```
Without `from` option PostCSS could generate wrong source map and will not find Browserslist config. Set it to CSS file path or to `undefined` to prevent this warning.
```