### PR TITLE
Moving React to `peerDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
     "playcanvas": "^2.2.2",
     "postcss": "^8.4.47",
     "prop-types": "^15.8.1",
-    "react": "^18.3.1",
     "rollup": "^4.24.4",
     "rollup-plugin-sass": "^1.14.0",
     "sass-loader": "^16.0.3",
@@ -124,6 +123,9 @@
     "typedoc": "^0.26.11",
     "typedoc-plugin-mdn-links": "^3.3.6",
     "typescript": "^5.6.3"
+  },
+  "peerDependencies": {
+    "react": "^18.3.1"
   },
   "directories": {
     "doc": "docs"


### PR DESCRIPTION
Moving React to `peerDependencies`. This may cause multiple instances of React otherwise. 

See [this SO](https://stackoverflow.com/a/30454133) for more info