### PR TITLE
Add support for percentages in NumericInput

### DIFF
--- a/src/components/NumericInput/index.ts
+++ b/src/components/NumericInput/index.ts
@@ -256,7 +256,7 @@ class NumericInput extends InputElement {
 
                 const currentValue = this._oldValue || 0;
 
-                // Handle percentages with a simple, non-backtracking regex
+                // handle percentages with a simple, non-backtracking regex
                 value = value.replace(/(\d+(?:\.\d+)?%)/g, (match: string) => {
                     const percent = parseFloat(match.slice(0, -1));
                     const calculatedValue = (percent / 100) * currentValue;

--- a/src/components/NumericInput/index.ts
+++ b/src/components/NumericInput/index.ts
@@ -255,7 +255,7 @@ class NumericInput extends InputElement {
                 value = value.replace(/\s/g, '');
 
                 // Handle percentages by replacing them with their calculated values
-                const currentValue = this.value || 0;
+                const currentValue = this._oldValue || 0;
 
                 value = value.replace(/(\d+(?:\.\d+)?)%/g, (match: string, percent: string) => {
                     const calculatedValue = (parseFloat(percent) / 100) * currentValue;

--- a/src/components/NumericInput/index.ts
+++ b/src/components/NumericInput/index.ts
@@ -254,11 +254,12 @@ class NumericInput extends InputElement {
                 // remove spaces
                 value = value.replace(/\s/g, '');
 
-                // Handle percentages by replacing them with their calculated values
                 const currentValue = this._oldValue || 0;
 
-                value = value.replace(/(\d+(?:\.\d+)?)%/g, (match: string, percent: string) => {
-                    const calculatedValue = (parseFloat(percent) / 100) * currentValue;
+                // handle percentages by replacing them with their calculated values
+                value = value.replace(/(\d+(?:\.\d+)?(?=%)%)/g, (match: string) => {
+                    const percent = parseFloat(match.slice(0, -1));
+                    const calculatedValue = (percent / 100) * currentValue;
                     return calculatedValue.toString();
                 });
 

--- a/src/components/NumericInput/index.ts
+++ b/src/components/NumericInput/index.ts
@@ -256,8 +256,8 @@ class NumericInput extends InputElement {
 
                 const currentValue = this._oldValue || 0;
 
-                // handle percentages by replacing them with their calculated values
-                value = value.replace(/(\d+(?:\.\d+)?(?=%)%)/g, (match: string) => {
+                // Handle percentages with a simple, non-backtracking regex
+                value = value.replace(/(\d+(?:\.\d+)?%)/g, (match: string) => {
                     const percent = parseFloat(match.slice(0, -1));
                     const calculatedValue = (percent / 100) * currentValue;
                     return calculatedValue.toString();

--- a/test/components/numericinput.mjs
+++ b/test/components/numericinput.mjs
@@ -116,5 +116,83 @@ describe('NumericInput', () => {
             numericInput.value = "1+1+1+1+1+1+1+1+1+10";
             strictEqual(numericInput.value, 0);
         });
+
+        describe('percentages', () => {
+            it('basic percentage', () => {
+                const numericInput = new NumericInput();
+                
+                numericInput.value = 200;
+                numericInput.value = "50%";
+                strictEqual(numericInput.value, 100);  // 50% of 200
+                
+                numericInput.value = 200;
+                numericInput.value = "150%";
+                strictEqual(numericInput.value, 300);  // 150% of 200
+            });
+
+            it('percentage in expressions', () => {
+                const numericInput = new NumericInput();
+                
+                numericInput.value = 100;
+                numericInput.value = "50% + 10";
+                strictEqual(numericInput.value, 60);   // (50% of 100) + 10
+                
+                numericInput.value = 100;
+                numericInput.value = "25% * 2";
+                strictEqual(numericInput.value, 50);   // (25% of 100) * 2
+            });
+
+            it('multiple percentages', () => {
+                const numericInput = new NumericInput();
+                
+                numericInput.value = 100;
+                numericInput.value = "25% + 50%";
+                strictEqual(numericInput.value, 75);   // (25% of 100) + (50% of 100)
+            });
+
+            it('invalid percentages', () => {
+                const numericInput = new NumericInput();
+                
+                numericInput.value = 100;
+                numericInput.value = "abc%";
+                strictEqual(numericInput.value, 0);
+                
+                numericInput.value = 100;
+                numericInput.value = "%50";
+                strictEqual(numericInput.value, 0);
+                
+                numericInput.value = 100;
+                numericInput.value = "50%%";
+                strictEqual(numericInput.value, 0);
+            });
+
+            it('percentage with zero base value', () => {
+                const numericInput = new NumericInput();
+                
+                numericInput.value = 0;
+                numericInput.value = "50%";
+                strictEqual(numericInput.value, 0);  // 50% of 0 is 0
+            });
+
+            it('percentage with negative base value', () => {
+                const numericInput = new NumericInput();
+                
+                numericInput.value = -100;
+                numericInput.value = "50%";
+                strictEqual(numericInput.value, -50);  // 50% of -100
+                
+                numericInput.value = -100;
+                numericInput.value = "150%";
+                strictEqual(numericInput.value, -150);  // 150% of -100
+            });
+
+            it('percentage with decimal base value', () => {
+                const numericInput = new NumericInput();
+                
+                numericInput.value = 0.5;
+                numericInput.value = "200%";
+                strictEqual(numericInput.value, 1);  // 200% of 0.5
+            });
+        });
     });
 });


### PR DESCRIPTION
You can now set a `NumericInput` value to a string containing a percentage which is replaced with that percentage of the currently set value.

![percent](https://github.com/user-attachments/assets/4715ddef-5b81-4fd0-a5ff-fd16ed528b3d)

 e.g.:

| Current Value | Expression | Result |
| -- | -- | -- |
| 100 | 50% | 50 |
| 100 | 10% + 20 | 30 |
| 0.5 | 200% | 1 |

Also added extensive unit tests for this new feature.

Fixes #188 