### PR TITLE
Allow root TreeViewItem to be closed

### DIFF
--- a/examples/elements/treeview.html
+++ b/examples/elements/treeview.html
@@ -37,8 +37,8 @@
 
         const root = new TreeViewItem({
             open: true,
-            text: 'Root',
-            icon: 'E139'  // Folder icon
+            text: 'Hard Disk',
+            icon: 'E229' // Drive icon
         });
         treeView.append(root);
 

--- a/examples/elements/treeview.html
+++ b/examples/elements/treeview.html
@@ -36,15 +36,20 @@
         });
 
         const root = new TreeViewItem({
-            text: 'Root'
+            open: true,
+            text: 'Root',
+            icon: 'E139'  // Folder icon
         });
         treeView.append(root);
 
         const generateChildren = (parent, depth) => {
             if (depth > 0) {
                 for (let i = 0; i < 5; i++) {
+                    const isFolder = depth > 1;
                     const item = new TreeViewItem({
-                        text: 'Item ' + i
+                        allowDrop: isFolder,
+                        text: (isFolder ? 'Folder ' : 'File ') + i,
+                        icon: isFolder ? 'E139' : 'E208'  // Folder or file icon
                     });
                     parent.append(item);
 

--- a/examples/elements/treeview.html
+++ b/examples/elements/treeview.html
@@ -37,7 +37,7 @@
 
         const root = new TreeViewItem({
             open: true,
-            text: 'Hard Disk',
+            text: 'My Drive',
             icon: 'E229' // Drive icon
         });
         treeView.append(root);

--- a/examples/index.html
+++ b/examples/index.html
@@ -107,6 +107,7 @@
         for (const category of categories) {
             const categoryItem = new TreeViewItem({
                 allowSelect: false,
+                open: true,
                 text: category.categoryName
             });
             treeView.append(categoryItem);

--- a/examples/index.html
+++ b/examples/index.html
@@ -106,7 +106,6 @@
 
         for (const category of categories) {
             const categoryItem = new TreeViewItem({
-                allowSelect: false,
                 open: true,
                 text: category.categoryName
             });

--- a/src/components/TreeView/style.scss
+++ b/src/components/TreeView/style.scss
@@ -134,49 +134,10 @@
     }
 }
 
-.pcui-treeview {
-    // direct children of tree
-    > .pcui-treeview-item {
-        padding-left: 0;
-
-        &::before {
-            content: none;
-        }
-
-        > .pcui-treeview-item-contents {
-            margin-left: 0;
-
-            > .pcui-treeview-item-icon {
-                &::before {
-                    content: none;
-                }
-
-                &::after {
-                    margin-left: 0;
-                }
-            }
-        }
-
-        > .pcui-treeview-item {
-            padding-left: 21px;
-
-            // top line
-            &::before {
-                left: 11px;
-            }
-        }
-    }
-}
-
 .pcui-treeview:not(.pcui-treeview-filtering) {
-    // direct children of tree
-    > .pcui-treeview-item {
-        .pcui-treeview-item {
-            &:not(.pcui-treeview-item-open, .pcui-treeview-item-empty) {
-                > .pcui-treeview-item {
-                    display: none;
-                }
-            }
+    .pcui-treeview-item:not(.pcui-treeview-item-open, .pcui-treeview-item-empty) {
+        > .pcui-treeview-item {
+            display: none;
         }
     }
 }

--- a/src/components/TreeViewItem/index.ts
+++ b/src/components/TreeViewItem/index.ts
@@ -480,10 +480,10 @@ class TreeViewItem extends Container {
      */
     set open(value) {
         if (this.open === value) return;
-        
+
         // Store intended state
         this._intendedOpenState = value;
-        
+
         if (value) {
             if (!this.numChildren) return;
             this.class.add(CLASS_OPEN);

--- a/src/components/TreeViewItem/index.ts
+++ b/src/components/TreeViewItem/index.ts
@@ -499,7 +499,7 @@ class TreeViewItem extends Container {
      * Gets whether the item is expanded and showing its children.
      */
     get open() {
-        return this.class.contains(CLASS_OPEN);
+        return this._intendedOpenState;
     }
 
     /**

--- a/src/components/TreeViewItem/index.ts
+++ b/src/components/TreeViewItem/index.ts
@@ -26,7 +26,7 @@ interface TreeViewItemArgs extends ContainerArgs {
      */
     allowSelect?: boolean,
     /**
-     * Whether the item is open meaning showing its children.
+     * Whether the item is open (showing its children). Defaults to `false`.
      */
     open?: boolean,
     /**
@@ -130,6 +130,8 @@ class TreeViewItem extends Container {
 
     protected _icon: string;
 
+    protected _intendedOpenState = false;
+
     /**
      * Creates a new TreeViewItem.
      *
@@ -174,6 +176,8 @@ class TreeViewItem extends Container {
             this.selected = args.selected;
         }
 
+        this._intendedOpenState = args.open ?? false;
+
         const dom = this._containerContents.dom;
         dom.addEventListener('focus', this._onContentFocus);
         dom.addEventListener('blur', this._onContentBlur);
@@ -210,8 +214,11 @@ class TreeViewItem extends Container {
 
         if (element instanceof TreeViewItem) {
             this._numChildren++;
-            if (this._parent !== this._treeView) {
-                this.class.remove(CLASS_EMPTY);
+            this.class.remove(CLASS_EMPTY);
+
+            // Apply intended open state now that we have children
+            if (this._intendedOpenState) {
+                this.class.add(CLASS_OPEN);
             }
 
             if (this._treeView) {
@@ -473,9 +480,12 @@ class TreeViewItem extends Container {
      */
     set open(value) {
         if (this.open === value) return;
+        
+        // Store intended state
+        this._intendedOpenState = value;
+        
         if (value) {
             if (!this.numChildren) return;
-
             this.class.add(CLASS_OPEN);
             this.emit('open', this);
         } else {
@@ -488,7 +498,7 @@ class TreeViewItem extends Container {
      * Gets whether the item is expanded and showing its children.
      */
     get open() {
-        return this.class.contains(CLASS_OPEN) || this.parent === this._treeView;
+        return this.class.contains(CLASS_OPEN);
     }
 
     /**

--- a/src/components/TreeViewItem/index.ts
+++ b/src/components/TreeViewItem/index.ts
@@ -485,6 +485,7 @@ class TreeViewItem extends Container {
 
         if (value) {
             if (!this.numChildren) return;
+
             this.class.add(CLASS_OPEN);
             this.emit('open', this);
         } else {

--- a/src/components/TreeViewItem/index.ts
+++ b/src/components/TreeViewItem/index.ts
@@ -130,7 +130,7 @@ class TreeViewItem extends Container {
 
     protected _icon: string;
 
-    protected _intendedOpenState = false;
+    protected _open = false;
 
     /**
      * Creates a new TreeViewItem.
@@ -176,7 +176,7 @@ class TreeViewItem extends Container {
             this.selected = args.selected;
         }
 
-        this._intendedOpenState = args.open ?? false;
+        this._open = args.open ?? false;
 
         const dom = this._containerContents.dom;
         dom.addEventListener('focus', this._onContentFocus);
@@ -217,7 +217,7 @@ class TreeViewItem extends Container {
             this.class.remove(CLASS_EMPTY);
 
             // Apply intended open state now that we have children
-            if (this._intendedOpenState) {
+            if (this._open) {
                 this.class.add(CLASS_OPEN);
             }
 
@@ -479,14 +479,12 @@ class TreeViewItem extends Container {
      * Sets whether the item is expanded and showing its children.
      */
     set open(value) {
-        if (this.open === value) return;
-
-        // Store intended state
-        this._intendedOpenState = value;
-
+        if (this._open === value) return;
+        
+        this._open = value;
+        
         if (value) {
             if (!this.numChildren) return;
-
             this.class.add(CLASS_OPEN);
             this.emit('open', this);
         } else {
@@ -499,7 +497,7 @@ class TreeViewItem extends Container {
      * Gets whether the item is expanded and showing its children.
      */
     get open() {
-        return this._intendedOpenState;
+        return this._open;
     }
 
     /**

--- a/src/components/TreeViewItem/index.ts
+++ b/src/components/TreeViewItem/index.ts
@@ -486,6 +486,7 @@ class TreeViewItem extends Container {
 
         if (value) {
             if (!this.numChildren) return;
+
             this.class.add(CLASS_OPEN);
             this.emit('open', this);
         } else {

--- a/src/components/TreeViewItem/index.ts
+++ b/src/components/TreeViewItem/index.ts
@@ -480,9 +480,9 @@ class TreeViewItem extends Container {
      */
     set open(value) {
         if (this._open === value) return;
-        
+
         this._open = value;
-        
+
         if (value) {
             if (!this.numChildren) return;
             this.class.add(CLASS_OPEN);


### PR DESCRIPTION
* Allow root `TreeViewItem`s in a `TreeView` to be opened/closed.
* Respect the `open` property of `TreeViewItemArgs`.
* Update example to be like a File Manager.

![treeviewroot](https://github.com/user-attachments/assets/911be3c1-f001-4d06-bf1a-f77a89c746c4)

Fixes #162 