### PR TITLE
Set a sensible default font

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,21 @@ ReactDOM.render(
 
 If you need a UMD version of the PCUI library (say, to use it in a PlayCanvas Editor project), please refer to our [build guide](BUILDGUIDE.md).
 
-## Including your own font
+## Fonts in PCUI
 
-PCUI uses four CSS classes to add styled fonts to the various components. These are `.font-regular`, `.font-bold`, `.font-thin` and `.font-light`. You can use your own font with PCUI by adding `font-family` CSS rules to these classes on your webpage. For example:
+PCUI uses four CSS classes for fonts across its components: `.font-regular`, `.font-bold`, `.font-thin` and `.font-light`. By default, these use the Helvetica Neue font stack:
+
+```css
+    font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif;
+```
+
+### Using your own Font
+
+You can override PCUI's default font by adding your own `font-family` CSS rules to these classes on your webpage:
 
 ```css
 .font-regular, .font-bold, .font-thin, .font-light {
-    font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif;
+    font-family: 'Your Font', sans-serif;
 }
 ```
 

--- a/examples/elements/arrayinput.html
+++ b/examples/elements/arrayinput.html
@@ -7,10 +7,6 @@
         body {
             background-color: #364346;
         }
-
-        .font-regular, .font-bold, .font-thin, .font-light {
-            font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif;
-        }
     </style>
     <script type="importmap">
         {

--- a/examples/elements/booleaninput.html
+++ b/examples/elements/booleaninput.html
@@ -7,10 +7,6 @@
         body {
             background-color: #364346;
         }
-
-        .font-regular, .font-bold, .font-thin, .font-light {
-            font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif;
-        }
     </style>
     <script type="importmap">
         {

--- a/examples/elements/button.html
+++ b/examples/elements/button.html
@@ -7,10 +7,6 @@
         body {
             background-color: #364346;
         }
-
-        .font-regular, .font-bold, .font-thin, .font-light {
-            font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif;
-        }
     </style>
     <script type="importmap">
         {

--- a/examples/elements/canvas.html
+++ b/examples/elements/canvas.html
@@ -7,10 +7,6 @@
         body {
             background-color: #364346;
         }
-
-        .font-regular, .font-bold, .font-thin, .font-light {
-            font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif;
-        }
     </style>
     <script type="importmap">
         {

--- a/examples/elements/code.html
+++ b/examples/elements/code.html
@@ -7,10 +7,6 @@
         body {
             background-color: #364346;
         }
-
-        .font-regular, .font-bold, .font-thin, .font-light {
-            font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif;
-        }
     </style>
     <script type="importmap">
         {

--- a/examples/elements/colorpicker.html
+++ b/examples/elements/colorpicker.html
@@ -8,10 +8,6 @@
             background-color: #364346;
         }
 
-        .font-regular, .font-bold, .font-thin, .font-light {
-            font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif;
-        }
-
         .pcui-label-group > .pcui-label:first-child {
             font-size: 16px;
         }

--- a/examples/elements/divider.html
+++ b/examples/elements/divider.html
@@ -7,10 +7,6 @@
         body {
             background-color: #364346;
         }
-
-        .font-regular, .font-bold, .font-thin, .font-light {
-            font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif;
-        }
     </style>
     <script type="importmap">
         {

--- a/examples/elements/gradientpicker.html
+++ b/examples/elements/gradientpicker.html
@@ -7,10 +7,6 @@
         body {
             background-color: #364346;
         }
-
-        .font-regular, .font-bold, .font-thin, .font-light {
-            font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif;
-        }
     </style>
     <script type="importmap">
         {

--- a/examples/elements/gridview.html
+++ b/examples/elements/gridview.html
@@ -7,10 +7,6 @@
         body {
             background-color: #364346;
         }
-
-        .font-regular, .font-bold, .font-thin, .font-light {
-            font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif;
-        }
     </style>
     <script type="importmap">
         {

--- a/examples/elements/infobox.html
+++ b/examples/elements/infobox.html
@@ -7,10 +7,6 @@
         body {
             background-color: #364346;
         }
-
-        .font-regular, .font-bold, .font-thin, .font-light {
-            font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif;
-        }
     </style>
     <script type="importmap">
         {

--- a/examples/elements/label.html
+++ b/examples/elements/label.html
@@ -7,10 +7,6 @@
         body {
             background-color: #364346;
         }
-
-        .font-regular, .font-bold, .font-thin, .font-light {
-            font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif;
-        }
     </style>
     <script type="importmap">
         {

--- a/examples/elements/labelgroup.html
+++ b/examples/elements/labelgroup.html
@@ -7,10 +7,6 @@
         body {
             background-color: #364346;
         }
-
-        .font-regular, .font-bold, .font-thin, .font-light {
-            font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif;
-        }
     </style>
     <script type="importmap">
         {

--- a/examples/elements/menu.html
+++ b/examples/elements/menu.html
@@ -7,10 +7,6 @@
         body {
             background-color: #364346;
         }
-
-        .font-regular, .font-bold, .font-thin, .font-light {
-            font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif;
-        }
     </style>
     <script type="importmap">
         {

--- a/examples/elements/numericinput.html
+++ b/examples/elements/numericinput.html
@@ -7,10 +7,6 @@
         body {
             background-color: #364346;
         }
-
-        .font-regular, .font-bold, .font-thin, .font-light {
-            font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif;
-        }
     </style>
     <script type="importmap">
         {

--- a/examples/elements/overlay.html
+++ b/examples/elements/overlay.html
@@ -8,10 +8,6 @@
             background-color: #364346;
         }
 
-        .font-regular, .font-bold, .font-thin, .font-light {
-            font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif;
-        }
-
         .pcui-overlay-content {
             z-index: 0;
         }

--- a/examples/elements/panel.html
+++ b/examples/elements/panel.html
@@ -7,10 +7,6 @@
         body {
             background-color: #364346;
         }
-
-        .font-regular, .font-bold, .font-thin, .font-light {
-            font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif;
-        }
     </style>
     <script type="importmap">
         {

--- a/examples/elements/progress.html
+++ b/examples/elements/progress.html
@@ -7,10 +7,6 @@
         body {
             background-color: #364346;
         }
-
-        .font-regular, .font-bold, .font-thin, .font-light {
-            font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif;
-        }
     </style>
     <script type="importmap">
         {

--- a/examples/elements/radiobutton.html
+++ b/examples/elements/radiobutton.html
@@ -7,10 +7,6 @@
         body {
             background-color: #364346;
         }
-
-        .font-regular, .font-bold, .font-thin, .font-light {
-            font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif;
-        }
     </style>
     <script type="importmap">
         {

--- a/examples/elements/selectinput.html
+++ b/examples/elements/selectinput.html
@@ -7,10 +7,6 @@
         body {
             background-color: #364346;
         }
-
-        .font-regular, .font-bold, .font-thin, .font-light {
-            font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif;
-        }
     </style>
     <script type="importmap">
         {

--- a/examples/elements/sliderinput.html
+++ b/examples/elements/sliderinput.html
@@ -7,10 +7,6 @@
         body {
             background-color: #364346;
         }
-
-        .font-regular, .font-bold, .font-thin, .font-light {
-            font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif;
-        }
     </style>
     <script type="importmap">
         {

--- a/examples/elements/spinner.html
+++ b/examples/elements/spinner.html
@@ -7,10 +7,6 @@
         body {
             background-color: #364346;
         }
-
-        .font-regular, .font-bold, .font-thin, .font-light {
-            font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif;
-        }
     </style>
     <script type="importmap">
         {

--- a/examples/elements/textareainput.html
+++ b/examples/elements/textareainput.html
@@ -7,10 +7,6 @@
         body {
             background-color: #364346;
         }
-
-        .font-regular, .font-bold, .font-thin, .font-light {
-            font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif;
-        }
     </style>
     <script type="importmap">
         {

--- a/examples/elements/textinput.html
+++ b/examples/elements/textinput.html
@@ -7,10 +7,6 @@
         body {
             background-color: #364346;
         }
-
-        .font-regular, .font-bold, .font-thin, .font-light {
-            font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif;
-        }
     </style>
     <script type="importmap">
         {

--- a/examples/elements/vectorinput.html
+++ b/examples/elements/vectorinput.html
@@ -7,10 +7,6 @@
         body {
             background-color: #364346;
         }
-
-        .font-regular, .font-bold, .font-thin, .font-light {
-            font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif;
-        }
     </style>
     <script type="importmap">
         {

--- a/examples/index.html
+++ b/examples/index.html
@@ -17,10 +17,6 @@
             border: 2px solid rgb(175, 175, 175);
         }
 
-        .font-regular, .font-bold, .font-thin, .font-light {
-            font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif;
-        }
-
         .pcui-treeview-item-text, 
         .pcui-treeview-item-icon {
             font-size: 14px;

--- a/examples/utilities/icon-browser.html
+++ b/examples/utilities/icon-browser.html
@@ -8,10 +8,6 @@
             background-color: #364346;
         }
 
-        .font-regular, .font-bold, .font-thin, .font-light {
-            font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif;
-        }
-
         .icon-info > .pcui-label {
             font-size: 16px;
             line-height: 2;

--- a/src/scss/fonts.scss
+++ b/src/scss/fonts.scss
@@ -1,21 +1,25 @@
 @import './font-icon';
 
 .font-thin {
+    font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif;
     font-weight: 100;
     font-style: normal;
 }
 
 .font-light {
+    font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif;
     font-weight: 200;
     font-style: normal;
 }
 
 .font-regular {
+    font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif;
     font-weight: normal;
     font-style: normal;
 }
 
 .font-bold {
+    font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif;
     font-weight: bold;
     font-style: normal;
 }


### PR DESCRIPTION
At the moment, PCUI defaults to the Times New Roman font (browser default). This PR switches it to an appropriate sans-serif font so there's no immediate need to change it:

```css
font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif;
```