### PR TITLE
Refactor searchItems and add tests

### DIFF
--- a/examples/elements/numericinput.html
+++ b/examples/elements/numericinput.html
@@ -7,6 +7,10 @@
         body {
             background-color: #364346;
         }
+
+        .pcui-element.pcui-label-group > .pcui-label:first-child {
+            width: 125px;
+        }
     </style>
     <script type="importmap">
         {
@@ -28,7 +32,6 @@
             field: numericInput,
             text: 'Enter a number:'
         });
-        labelGroup.dom.querySelector('.pcui-label').style.width = '125px';
 
         const infoBox = new InfoBox({
             icon: 'E400',

--- a/examples/elements/selectinput.html
+++ b/examples/elements/selectinput.html
@@ -7,12 +7,17 @@
         body {
             background-color: #364346;
         }
+
+        .pcui-element.pcui-label-group > .pcui-label:first-child {
+            width: 175px;
+        }
     </style>
     <script type="importmap">
         {
             "imports": {
-                "@playcanvas/pcui": "https://cdn.jsdelivr.net/npm/@playcanvas/pcui/+esm",
-                "@playcanvas/pcui/styles": "https://cdn.jsdelivr.net/npm/@playcanvas/pcui/styles/+esm"
+                "@playcanvas/observer": "https://cdn.jsdelivr.net/npm/@playcanvas/observer/+esm",
+                "@playcanvas/pcui": "/dist/module/src/index.mjs",
+                "@playcanvas/pcui/styles": "/styles/dist/index.mjs"
             }
         }
     </script>
@@ -52,9 +57,6 @@
             text: 'SelectInput with Filter:',
             field: selectWithFilter
         });
-
-        labelGroup1.dom.querySelector('.pcui-label').style.width = '175px';
-        labelGroup2.dom.querySelector('.pcui-label').style.width = '175px';
 
         document.body.appendChild(labelGroup1.dom);
         document.body.appendChild(labelGroup2.dom);

--- a/examples/elements/selectinput.html
+++ b/examples/elements/selectinput.html
@@ -15,9 +15,8 @@
     <script type="importmap">
         {
             "imports": {
-                "@playcanvas/observer": "https://cdn.jsdelivr.net/npm/@playcanvas/observer/+esm",
-                "@playcanvas/pcui": "/dist/module/src/index.mjs",
-                "@playcanvas/pcui/styles": "/styles/dist/index.mjs"
+                "@playcanvas/pcui": "https://cdn.jsdelivr.net/npm/@playcanvas/pcui/+esm",
+                "@playcanvas/pcui/styles": "https://cdn.jsdelivr.net/npm/@playcanvas/pcui/styles/+esm"
             }
         }
     </script>

--- a/examples/elements/selectinput.html
+++ b/examples/elements/selectinput.html
@@ -19,7 +19,7 @@
 </head>
 <body>
     <script type="module">
-        import { SelectInput } from '@playcanvas/pcui';
+        import { LabelGroup, SelectInput } from '@playcanvas/pcui';
         import '@playcanvas/pcui/styles'
 
         const select = new SelectInput({
@@ -32,8 +32,32 @@
             defaultValue: 4,
             type: 'number'
         });
+        const labelGroup1 = new LabelGroup({
+            text: 'SelectInput:',
+            field: select
+        });
 
-        document.body.appendChild(select.dom);
+        const selectWithFilter = new SelectInput({
+            allowInput: true,
+            options: [
+                { t: 'Option 1', v: 1 },
+                { t: 'Option 2', v: 2 },
+                { t: 'Option 3', v: 3 },
+                { t: 'Default', v: 4 }
+            ],
+            defaultValue: 4,
+            type: 'number'
+        });
+        const labelGroup2 = new LabelGroup({
+            text: 'SelectInput with Filter:',
+            field: selectWithFilter
+        });
+
+        labelGroup1.dom.querySelector('.pcui-label').style.width = '175px';
+        labelGroup2.dom.querySelector('.pcui-label').style.width = '175px';
+
+        document.body.appendChild(labelGroup1.dom);
+        document.body.appendChild(labelGroup2.dom);
     </script>
 </body>
 </html>

--- a/src/components/SelectInput/index.ts
+++ b/src/components/SelectInput/index.ts
@@ -661,10 +661,7 @@ class SelectInput extends Element implements IBindable, IFocusable {
         }
 
         if (filter) {
-            // Search options directly using the 't' property
             const searchResults = searchItems(this._options, 't', filter);
-
-            // Add matching options back in order
             searchResults.forEach((result) => {
                 const label = this._valueToLabel[String(result.v)];
                 containerDom.appendChild(label.dom);

--- a/src/components/TreeView/index.ts
+++ b/src/components/TreeView/index.ts
@@ -396,7 +396,7 @@ class TreeView extends Container {
         if (this._filter) {
             // add new item to filtered results if it
             // satisfies the current filter
-            this._searchItems([[item.text, item]], this._filter);
+            this._searchItems([item], this._filter);
         }
 
         // do the same for all children of the element
@@ -987,13 +987,13 @@ class TreeView extends Container {
             }
 
             // see if we can include it in the current filter
-            this._searchItems([[item.text, item]], this._filter);
+            this._searchItems([item], this._filter);
         }
         this.emit('rename', item, newName);
     }
 
-    protected _searchItems(searchArr: [string, TreeViewItem][], filter: string) {
-        const results = searchItems(searchArr, filter);
+    protected _searchItems(items: TreeViewItem[], filter: string) {
+        const results = searchItems(items, 'text', filter);
         if (!results.length) return;
 
         results.forEach((item: TreeViewItem) => {
@@ -1015,12 +1015,12 @@ class TreeView extends Container {
 
         this.class.add(CLASS_FILTERING);
 
-        const search: [string, TreeViewItem][] = [];
+        const items: TreeViewItem[] = [];
         this._traverseDepthFirst((item) => {
-            search.push([item.text, item]);
+            items.push(item);
         });
 
-        this._searchItems(search, filter);
+        this._searchItems(items, filter);
     }
 
     /**

--- a/src/helpers/search.ts
+++ b/src/helpers/search.ts
@@ -185,11 +185,11 @@ const _searchItems = <Type>(items: SearchRecord<Type>[], search: string, args: R
 /**
  * Perform search through items.
  *
- * @param items - Array of objects to search through
- * @param searchKey - The property name to search within each item
- * @param search - String to search for
- * @param args - Search arguments
- * @returns Array of found items
+ * @param items - Array of objects to search through.
+ * @param searchKey - The property name to search within each item.
+ * @param search - String to search for.
+ * @param args - Search arguments.
+ * @returns Array of found items.
  * @example
  * const items = [
  *     { text: 'Item 1', id: 1 },

--- a/test/helpers/search.mjs
+++ b/test/helpers/search.mjs
@@ -1,0 +1,95 @@
+import { describe, it } from 'node:test';
+import { strictEqual, deepStrictEqual } from 'assert';
+import { searchItems } from '../../dist/module/src/helpers/search.mjs';
+
+describe('searchItems', () => {
+    const items = [
+        { text: 'Apple', id: 'item1' },
+        { text: 'Banana', id: 'item2' },
+        { text: 'Application', id: 'item3' },
+        { text: 'Pineapple', id: 'item4' },
+        { text: 'Grape', id: 'item5' }
+    ];
+
+    describe('basic matching', () => {
+        it('should find exact matches and substring matches', () => {
+            const results = searchItems(items, 'text', 'Apple');
+            deepStrictEqual(results.map(r => r.id).sort(), ['item1', 'item4']);  // Apple and Pineapple
+        });
+
+        it('should be case insensitive', () => {
+            const results = searchItems(items, 'text', 'apple');
+            deepStrictEqual(results.map(r => r.id).sort(), ['item1', 'item4']);  // Apple and Pineapple
+        });
+
+        it('should find substring matches', () => {
+            const results = searchItems(items, 'text', 'app');
+            const ids = results.map(r => r.id);
+            strictEqual(ids.includes('item1'), true); // Apple
+            strictEqual(ids.includes('item3'), true); // Application
+            strictEqual(ids.includes('item4'), true); // Pineapple
+        });
+    });
+
+    describe('edit distance matching', () => {
+        it('should find close matches', () => {
+            const results = searchItems(items, 'text', 'aple', {
+                editsDistanceTolerance: 0.5
+            });
+            const ids = results.map(r => r.id);
+            strictEqual(ids.includes('item1'), true); // Apple
+        });
+
+        it('should respect editsDistanceTolerance', () => {
+            const strictResults = searchItems(items, 'text', 'aple', {
+                editsDistanceTolerance: 0.1
+            });
+            strictEqual(strictResults.length, 0, 'Should find no matches with strict tolerance');
+
+            const looseResults = searchItems(items, 'text', 'aple', {
+                editsDistanceTolerance: 0.8
+            });
+            strictEqual(looseResults.length > 0, true, 'Should find matches with loose tolerance');
+        });
+    });
+
+    describe('character containment', () => {
+        it('should respect containsCharsTolerance', () => {
+            const strictResults = searchItems(items, 'text', 'apl', {
+                containsCharsTolerance: 0.9
+            });
+            strictEqual(strictResults.length === 0, true, 'Should find no matches with strict tolerance');
+
+            const looseResults = searchItems(items, 'text', 'apl', {
+                containsCharsTolerance: 0.3
+            });
+            strictEqual(looseResults.length > 0, true, 'Should find matches with loose tolerance');
+        });
+    });
+
+    describe('result limiting', () => {
+        it('should limit number of results', () => {
+            const results = searchItems(items, 'text', 'app', {
+                limitResults: 2
+            });
+            strictEqual(results.length, 2);
+        });
+    });
+
+    describe('edge cases', () => {
+        it('should handle empty search string', () => {
+            const results = searchItems(items, 'text', '');
+            deepStrictEqual(results, []);
+        });
+
+        it('should handle empty items array', () => {
+            const results = searchItems([], 'text', 'test');
+            deepStrictEqual(results, []);
+        });
+
+        it('should handle whitespace', () => {
+            const results = searchItems(items, 'text', '  Apple  ');
+            deepStrictEqual(results.map(r => r.id).sort(), ['item1', 'item4']);  // Apple and Pineapple
+        });
+    });
+});


### PR DESCRIPTION
* Refactor `searchItems` to take an array of objects and a key which to search. This means we don't need to create a new structure when filtering `TreeView`s or `SelectInput`s.
* Add unit tests for `searchItems`.
* Tighten up some types across the code.
* Add example of a filtered `SelectInput` control to example.

All of this in internal - no public API is altered and no functionality is changed.