### PR TITLE
Remove StoryBook's storyStoreV7 flag

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -33,10 +33,6 @@ const config = {
         return config;
     },
 
-    features: {
-        storyStoreV7: false,
-    },
-
     framework: {
         name: '@storybook/react-webpack5',
         options: {}

--- a/src/components/ArrayInput/component.stories.tsx
+++ b/src/components/ArrayInput/component.stories.tsx
@@ -2,6 +2,10 @@ import { action } from '@storybook/addon-actions';
 import type { Meta, StoryObj } from '@storybook/react';
 import * as React from 'react';
 
+import '../BooleanInput';
+import '../NumericInput';
+import '../TextInput';
+import '../VectorInput';
 import { ArrayInput } from './component';
 
 import '../../scss/index.js';

--- a/src/components/VectorInput/component.stories.tsx
+++ b/src/components/VectorInput/component.stories.tsx
@@ -2,6 +2,7 @@ import { action } from '@storybook/addon-actions';
 import type { Meta, StoryObj } from '@storybook/react';
 import * as React from 'react';
 
+import '../NumericInput';
 import { VectorInput } from './component';
 
 import '../../scss/index.js';


### PR DESCRIPTION
This is phase 1 in upgrading to StoryBook 8. When removing the `storyStoreV7` flag, stories seem to load individual components. But components like `ArrayInput` are dependent on other components (such as `VectorInput` which is itself dependent on `NumericInput`). The Element registry means that the necessary code is not automatically imported. So, at least for now, stories import the required components to run correctly. A longer term solution might be to refactor the Element registry and rely on proper ESM imports.