### PR TITLE
Switch useless accessors to properties

### DIFF
--- a/src/components/GridViewItem/index.ts
+++ b/src/components/GridViewItem/index.ts
@@ -42,6 +42,11 @@ interface GridViewItemArgs extends ContainerArgs {
  *  Represents a grid view item used in {@link GridView}.
  */
 class GridViewItem extends Container implements IFocusable {
+    /**
+     * Determines whether the item can be selected. Defaults to `true`.
+     */
+    public allowSelect = true;
+
     protected _selected: boolean;
 
     protected _radioButton: RadioButton;
@@ -49,8 +54,6 @@ class GridViewItem extends Container implements IFocusable {
     protected _labelText: Label;
 
     protected _type: string;
-
-    protected _allowSelect: boolean;
 
     /**
      * Creates a new GridViewItem.
@@ -128,20 +131,6 @@ class GridViewItem extends Container implements IFocusable {
 
     unlink() {
         this._labelText.unlink();
-    }
-
-    /**
-     * Sets whether the item can be selected. Defaults to `true`.
-     */
-    set allowSelect(value) {
-        this._allowSelect = value;
-    }
-
-    /**
-     * Gets whether the item can be selected. Defaults to `true`.
-     */
-    get allowSelect() {
-        return this._allowSelect;
     }
 
     /**

--- a/src/components/InputElement/index.ts
+++ b/src/components/InputElement/index.ts
@@ -30,6 +30,16 @@ interface InputElementArgs extends ElementArgs, IBindableArgs, IPlaceholderArgs 
  * {@link TextInput} and {@link NumericInput}. It is not intended to be used directly.
  */
 abstract class InputElement extends Element implements IBindable, IFocusable, IPlaceholder {
+    /**
+     * Determines whether the input should blur when the enter key is pressed.
+     */
+    public blurOnEnter = true;
+
+    /**
+     * Determines whether the input should blur when the escape key is pressed.
+     */
+    public blurOnEscape = true;
+
     protected _domInput: HTMLInputElement;
 
     protected _suspendInputChangeEvt: boolean;
@@ -39,10 +49,6 @@ abstract class InputElement extends Element implements IBindable, IFocusable, IP
     protected _keyChange: boolean;
 
     protected _renderChanges: boolean;
-
-    protected _blurOnEnter: boolean;
-
-    protected _blurOnEscape: boolean;
 
     protected _onInputKeyDownEvt: (evt: KeyboardEvent) => void;
 
@@ -227,34 +233,6 @@ abstract class InputElement extends Element implements IBindable, IFocusable, IP
      */
     get input() {
         return this._domInput;
-    }
-
-    /**
-     * Sets whether the input should blur when the enter key is pressed.
-     */
-    set blurOnEnter(value: boolean) {
-        this._blurOnEnter = value;
-    }
-
-    /**
-     * Gets whether the input should blur when the enter key is pressed.
-     */
-    get blurOnEnter(): boolean {
-        return this._blurOnEnter;
-    }
-
-    /**
-     * Sets whether the input should blur when the escape key is pressed.
-     */
-    set blurOnEscape(value: boolean) {
-        this._blurOnEscape = value;
-    }
-
-    /**
-     * Gets whether the input should blur when the escape key is pressed.
-     */
-    get blurOnEscape(): boolean {
-        return this._blurOnEscape;
     }
 
     abstract set value(value: any);

--- a/src/components/TextInput/index.ts
+++ b/src/components/TextInput/index.ts
@@ -20,7 +20,12 @@ interface TextInputArgs extends InputElementArgs, IBindableArgs, IPlaceholderArg
  * The TextInput is an input element of type text.
  */
 class TextInput extends InputElement {
-    protected _onValidate: (value: string) => boolean;
+    /**
+     * A function that validates the value that is entered into the input and returns `true` if it
+     * is valid or `false` otherwise. If `false` then the input will be set in an error state and
+     * the value will not propagate to the binding.
+     */
+    public onValidate: (value: string) => boolean;
 
     /**
      * Creates a new TextInput.
@@ -40,8 +45,8 @@ class TextInput extends InputElement {
     protected _onInputChange(evt: Event) {
         if (this._suspendInputChangeEvt) return;
 
-        if (this._onValidate) {
-            const error = !this._onValidate(this.value);
+        if (this.onValidate) {
+            const error = !this.onValidate(this.value);
             this.error = error;
             if (error) {
                 return;
@@ -116,17 +121,6 @@ class TextInput extends InputElement {
         } else {
             this._updateValue(values[0]);
         }
-    }
-
-    /**
-     * Gets / sets the validate method for the input.
-     */
-    set onValidate(value) {
-        this._onValidate = value;
-    }
-
-    get onValidate() {
-        return this._onValidate;
     }
 }
 

--- a/src/components/TreeView/index.ts
+++ b/src/components/TreeView/index.ts
@@ -142,15 +142,21 @@ class TreeView extends Container {
      */
     public static readonly EVENT_RENAME = 'rename';
 
+    /**
+     * Determines whether reordering {@link TreeViewItem}s is allowed.
+     */
+    public allowReordering = true;
+
+    /**
+     * Determines whether renaming {@link TreeViewItem}s is allowed by double clicking on them.
+     */
+    public allowRenaming = false;
+
     protected _selectedItems: TreeViewItem[] = [];
 
     protected _dragItems: TreeViewItem[] = [];
 
     protected _allowDrag: boolean;
-
-    protected _allowReordering: boolean;
-
-    protected _allowRenaming: boolean;
 
     protected _dragging = false;
 
@@ -191,8 +197,8 @@ class TreeView extends Container {
         this.class.add(CLASS_ROOT);
 
         this._allowDrag = args.allowDrag ?? true;
-        this._allowReordering = args.allowReordering ?? true;
-        this._allowRenaming = args.allowRenaming ?? false;
+        this.allowReordering = args.allowReordering ?? true;
+        this.allowRenaming = args.allowRenaming ?? false;
         this._dragHandle = new Element({
             class: CLASS_DRAGGED_HANDLE,
             hidden: true
@@ -857,13 +863,13 @@ class TreeView extends Container {
 
             if (invalid) {
                 this._dragOverItem = null;
-            } else if (this._allowReordering && area <= 1 && this._dragItems.indexOf(this._dragOverItem.previousSibling) === -1) {
+            } else if (this.allowReordering && area <= 1 && this._dragItems.indexOf(this._dragOverItem.previousSibling) === -1) {
                 this._dragArea = DRAG_AREA_BEFORE;
-            } else if (this._allowReordering && area >= 4 && this._dragItems.indexOf(this._dragOverItem.nextSibling) === -1 && (this._dragOverItem.numChildren === 0 || !this._dragOverItem.open)) {
+            } else if (this.allowReordering && area >= 4 && this._dragItems.indexOf(this._dragOverItem.nextSibling) === -1 && (this._dragOverItem.numChildren === 0 || !this._dragOverItem.open)) {
                 this._dragArea = DRAG_AREA_AFTER;
             } else {
                 let parent = false;
-                if (this._allowReordering && this._dragOverItem.open) {
+                if (this.allowReordering && this._dragOverItem.open) {
                     for (let i = 0; i < this._dragItems.length; i++) {
                         if (this._dragItems[i].parent === this._dragOverItem) {
                             parent = true;
@@ -1093,34 +1099,6 @@ class TreeView extends Container {
      */
     get allowDrag(): boolean {
         return this._allowDrag;
-    }
-
-    /**
-     * Sets whether reordering TreeViewItems is allowed.
-     */
-    set allowReordering(value: boolean) {
-        this._allowReordering = value;
-    }
-
-    /**
-     * Gets whether reordering TreeViewItems is allowed.
-     */
-    get allowReordering(): boolean {
-        return this._allowReordering;
-    }
-
-    /**
-     * Sets whether renaming TreeViewItems is allowed by double clicking on them.
-     */
-    set allowRenaming(value: boolean) {
-        this._allowRenaming = value;
-    }
-
-    /**
-     * Gets whether renaming TreeViewItems is allowed by double clicking on them.
-     */
-    get allowRenaming(): boolean {
-        return this._allowRenaming;
     }
 
     /**

--- a/src/components/TreeViewItem/index.ts
+++ b/src/components/TreeViewItem/index.ts
@@ -112,6 +112,22 @@ class TreeViewItem extends Container {
      */
     public static readonly EVENT_CLOSE = 'close';
 
+    /**
+     * Determines whether dropping is allowed on the tree item.
+     */
+    public allowDrop = true;
+
+    /**
+     * Determines whether this tree item can be dragged. Only considered if the parent
+     * {@link TreeView} has {@link TreeView#allowDrag} set to `true`.
+     */
+    public allowDrag = true;
+
+    /**
+     * Determines whether the item can be selected.
+     */
+    public allowSelect = true;
+
     protected _containerContents: Container;
 
     protected _labelIcon: Label;
@@ -121,12 +137,6 @@ class TreeViewItem extends Container {
     protected _numChildren = 0;
 
     protected _treeView: any;
-
-    protected _allowDrag: boolean;
-
-    protected _allowDrop: boolean;
-
-    protected _allowSelect: boolean;
 
     protected _icon: string;
 
@@ -254,7 +264,7 @@ class TreeViewItem extends Container {
     };
 
     protected _onContentMouseDown = (evt: MouseEvent) => {
-        if (!this._treeView || !this._treeView.allowDrag || !this._allowDrag) return;
+        if (!this._treeView || !this._treeView.allowDrag || !this.allowDrag) return;
 
         this._treeView._updateModifierKeys(evt);
         evt.stopPropagation();
@@ -523,49 +533,6 @@ class TreeViewItem extends Container {
         }
 
         return true;
-    }
-
-    /**
-     * Sets whether dropping is allowed on the tree item.
-     */
-    set allowDrop(value) {
-        this._allowDrop = value;
-    }
-
-    /**
-     * Gets whether dropping is allowed on the tree item.
-     */
-    get allowDrop() {
-        return this._allowDrop;
-    }
-
-    /**
-     * Sets whether this tree item can be dragged. Only considered if the parent {@link TreeView}
-     * has {@link TreeView#allowDrag} set to `true`.
-     */
-    set allowDrag(value) {
-        this._allowDrag = value;
-    }
-
-    /**
-     * Gets whether this tree item can be dragged.
-     */
-    get allowDrag() {
-        return this._allowDrag;
-    }
-
-    /**
-     * Sets whether the item can be selected.
-     */
-    set allowSelect(value) {
-        this._allowSelect = value;
-    }
-
-    /**
-     * Gets whether the item can be selected.
-     */
-    get allowSelect() {
-        return this._allowSelect;
     }
 
     /**


### PR DESCRIPTION
Makes API reference simpler and makes code more concise (and faster!).