### PR TITLE
Standardize on nullish coalescing operator in constructors

### DIFF
--- a/src/binding/BindingBase/index.ts
+++ b/src/binding/BindingBase/index.ts
@@ -71,7 +71,7 @@ class BindingBase extends Events {
         this._historyPrefix = args.historyPrefix;
         this._historyPostfix = args.historyPostfix;
         this._historyName = args.historyName;
-        this._historyCombine = args.historyCombine || false;
+        this._historyCombine = args.historyCombine ?? false;
     }
 
     // Returns the path at the specified index

--- a/src/binding/BindingTwoWay/index.ts
+++ b/src/binding/BindingTwoWay/index.ts
@@ -37,8 +37,8 @@ class BindingTwoWay extends BindingBase {
     constructor(args: Readonly<BindingTwoWayArgs> = {}) {
         super(args);
 
-        this._bindingElementToObservers = args.bindingElementToObservers || new BindingElementToObservers(args);
-        this._bindingObserversToElement = args.bindingObserversToElement || new BindingObserversToElement(args);
+        this._bindingElementToObservers = args.bindingElementToObservers ?? new BindingElementToObservers(args);
+        this._bindingObserversToElement = args.bindingObserversToElement ?? new BindingObserversToElement(args);
 
         this._bindingElementToObservers.on('applyingChange', (value: any) => {
             this.applyingChange = value;

--- a/src/components/ArrayInput/index.ts
+++ b/src/components/ArrayInput/index.ts
@@ -205,7 +205,7 @@ class ArrayInput extends Element implements IFocusable, IBindable {
             this.value = args.value;
         }
 
-        this.renderChanges = args.renderChanges || false;
+        this.renderChanges = args.renderChanges ?? false;
     }
 
     destroy() {

--- a/src/components/Element/index.ts
+++ b/src/components/Element/index.ts
@@ -488,7 +488,7 @@ class Element extends Events {
             }
         }
 
-        this.enabled = args.enabled !== undefined ? args.enabled : true;
+        this.enabled = args.enabled ?? true;
         this._hiddenParents = !args.isRoot;
         this.hidden = args.hidden ?? false;
         this.readOnly = args.readOnly ?? false;

--- a/src/components/GradientPicker/index.ts
+++ b/src/components/GradientPicker/index.ts
@@ -450,7 +450,7 @@ class GradientPicker extends Element {
 
         this._copiedData = null;
 
-        this._channels = args.channels || 3;
+        this._channels = args.channels ?? 3;
         this._value = this._getDefaultValue();
         if (args.value) {
             // @ts-ignore

--- a/src/components/MenuItem/index.ts
+++ b/src/components/MenuItem/index.ts
@@ -109,7 +109,7 @@ class MenuItem extends Container implements IBindable {
         this.append(this._containerItems);
         this.domContent = this._containerItems.dom;
 
-        this.text = args.text || 'Untitled';
+        this.text = args.text ?? 'Untitled';
 
         this.dom.addEventListener('click', this._onClickMenuItem);
 

--- a/src/components/Overlay/index.ts
+++ b/src/components/Overlay/index.ts
@@ -55,8 +55,8 @@ class Overlay extends Container {
         this.domContent.classList.add(CLASS_OVERLAY_CONTENT);
         this.dom.appendChild(this.domContent);
 
-        this.clickable = args.clickable || false;
-        this.transparent = args.transparent || false;
+        this.clickable = args.clickable ?? false;
+        this.transparent = args.transparent ?? false;
     }
 
     destroy() {

--- a/src/components/Panel/index.ts
+++ b/src/components/Panel/index.ts
@@ -158,11 +158,11 @@ class Panel extends Container {
         this.headerSize = args.headerSize ?? 32;
 
         // collapse related
-        this.collapsible = args.collapsible || false;
-        this.collapsed = args.collapsed || false;
-        this.collapseHorizontally = args.collapseHorizontally || false;
+        this.collapsible = args.collapsible ?? false;
+        this.collapsed = args.collapsed ?? false;
+        this.collapseHorizontally = args.collapseHorizontally ?? false;
 
-        this.sortable = args.sortable || false;
+        this.sortable = args.sortable ?? false;
         this.removable = args.removable || !!args.onRemove || false;
 
         // Set the contents container to be the content DOM element. From now on, calling append

--- a/src/components/TreeView/index.ts
+++ b/src/components/TreeView/index.ts
@@ -203,7 +203,7 @@ class TreeView extends Container {
             class: CLASS_DRAGGED_HANDLE,
             hidden: true
         });
-        this._dragScrollElement = args.dragScrollElement || this;
+        this._dragScrollElement = args.dragScrollElement ?? this;
         this.append(this._dragHandle);
 
         this._onContextMenu = args.onContextMenu;

--- a/src/helpers/search.ts
+++ b/src/helpers/search.ts
@@ -209,8 +209,8 @@ export const searchItems = <K extends string, T extends Record<K, string>>(
     const searchTokens = searchStringTokenize(search);
     if (!searchTokens.length) return [];
 
-    args.containsCharsTolerance = args.containsCharsTolerance || 0.5;
-    args.editsDistanceTolerance = args.editsDistanceTolerance || 0.5;
+    args.containsCharsTolerance = args.containsCharsTolerance ?? 0.5;
+    args.editsDistanceTolerance = args.editsDistanceTolerance ?? 0.5;
 
     let records: SearchRecord<T>[] = items.map((item) => {
         const subInd = item[searchKey].toLowerCase().trim().indexOf(search);


### PR DESCRIPTION
Before, there was a mixture of `||` and `??`. Migrating all instances to `??`.