### PR TITLE
Ensure renderChanges is initialized to a boolean value

### DIFF
--- a/src/components/Label/index.ts
+++ b/src/components/Label/index.ts
@@ -67,7 +67,7 @@ class Label extends Element implements IPlaceholder, IBindable {
         }
         this.placeholder = args.placeholder;
 
-        this.renderChanges = args.renderChanges;
+        this.renderChanges = args.renderChanges ?? false;
 
         this.on('change', () => {
             if (this.renderChanges) {

--- a/src/components/NumericInput/index.ts
+++ b/src/components/NumericInput/index.ts
@@ -134,7 +134,7 @@ class NumericInput extends InputElement {
         this._historyPostfix = null;
         this._sliderPrevValue = 0;
 
-        this.renderChanges = args.renderChanges;
+        this.renderChanges = args.renderChanges ?? false;
 
         if (!args.hideSlider) {
             this._sliderControl = new Element();

--- a/src/components/RadioButton/index.ts
+++ b/src/components/RadioButton/index.ts
@@ -33,7 +33,7 @@ class RadioButton extends Element implements IBindable, IFocusable {
         this.dom.addEventListener('blur', this._onBlur);
 
         this.value = args.value;
-        this._renderChanges = args.renderChanges;
+        this._renderChanges = args.renderChanges ?? false;
     }
 
     destroy() {

--- a/src/components/SelectInput/index.ts
+++ b/src/components/SelectInput/index.ts
@@ -295,7 +295,7 @@ class SelectInput extends Element implements IBindable, IFocusable {
             this.value = null;
         }
 
-        this._renderChanges = args.renderChanges;
+        this._renderChanges = args.renderChanges ?? false;
 
         this.on('change', () => {
             this._updateInputFieldsVisibility();

--- a/test/components/booleaninput.mjs
+++ b/test/components/booleaninput.mjs
@@ -15,7 +15,7 @@ describe('BooleanInput', () => {
         strictEqual(booleanInput.class.contains('pcui-element'), true);
         strictEqual(booleanInput.class.contains('pcui-not-flexible'), true);
 
-        strictEqual(booleanInput.type, undefined);
+        strictEqual(booleanInput.renderChanges, false);
         strictEqual(booleanInput.value, null);
     });
 });

--- a/test/components/numericinput.mjs
+++ b/test/components/numericinput.mjs
@@ -14,6 +14,13 @@ describe('NumericInput', () => {
         strictEqual(numericInput.class.contains('pcui-element'), true);
         strictEqual(numericInput.class.contains('pcui-input-element'), true);
         strictEqual(numericInput.class.contains('pcui-numeric-input'), true);
+
+        strictEqual(numericInput.max, null);
+        strictEqual(numericInput.min, null);
+        strictEqual(numericInput.precision, 7);
+        strictEqual(numericInput.renderChanges, false);
+        strictEqual(numericInput.step, 1);
+        strictEqual(numericInput.value, 0);
     });
 
     it('steps value with up/down arrow keys', () => {


### PR DESCRIPTION
Some PCUI element will initialize `renderChanges` to `undefined` if a value is not passed via constructor args. This PR ensures `renderChanges` is initialized to `false` if this happens.

Also, checked the default for relevant classes in the unit tests (but only for classes currently tested).