### PR TITLE
fix: merge IFlexArgs into ElementArgs

### DIFF
--- a/src/components/Container/index.ts
+++ b/src/components/Container/index.ts
@@ -1,5 +1,5 @@
 import { CLASS_FLEX, CLASS_GRID, CLASS_RESIZABLE, CLASS_SCROLLABLE } from '../../class';
-import { Element, ElementArgs, IFlexArgs, IParentArgs } from '../Element';
+import { Element, ElementArgs, IParentArgs } from '../Element';
 
 const RESIZE_HANDLE_SIZE = 4;
 
@@ -21,7 +21,11 @@ const CLASS_DRAGGED_CHILD = `${CLASS_DRAGGED}-child`;
 /**
  * The arguments for the {@link Container} constructor.
  */
-interface ContainerArgs extends ElementArgs, IParentArgs, IFlexArgs {
+interface ContainerArgs extends ElementArgs, IParentArgs {
+    /**
+     * Sets whether the {@link Container} uses flex layout.
+     */
+    flex?: boolean,
     /**
      * Sets whether the {@link Container} is resizable and where the resize handle is located. Can
      * be one of 'top', 'bottom', 'right', 'left'. Defaults to `null` which disables resizing.
@@ -47,10 +51,6 @@ interface ContainerArgs extends ElementArgs, IParentArgs, IFlexArgs {
      * Sets whether the {@link Container} supports the grid layout.
      */
     grid?: boolean,
-    /**
-     * Sets the {@link Container}'s align items property.
-     */
-    alignItems?: string
 }
 
 /**

--- a/src/components/Element/index.ts
+++ b/src/components/Element/index.ts
@@ -145,7 +145,9 @@ interface IParentArgs {
 }
 
 /**
- * The interface for arguments for elements that use flex layout.
+ * The interface for flex-related CSS properties available on elements.
+ * These properties do not themselves enable `display: flex`; flex layout is
+ * configured separately (for example via `Container#flex`).
  */
 interface IFlexArgs {
     /**

--- a/src/components/Element/index.ts
+++ b/src/components/Element/index.ts
@@ -149,10 +149,6 @@ interface IParentArgs {
  */
 interface IFlexArgs {
     /**
-     * Sets whether the element uses flex layout.
-     */
-    flex?: boolean,
-    /**
      * Sets the element's `flexBasis` CSS property.
      */
     flexBasis?: string | number,
@@ -193,7 +189,7 @@ interface IFlexArgs {
 /**
  * The arguments for the {@link Element} constructor.
  */
-interface ElementArgs {
+interface ElementArgs extends IFlexArgs {
     /**
      * The HTMLElement to create this {@link Element} with. If not provided this Element will create one.
      */

--- a/src/components/Label/index.ts
+++ b/src/components/Label/index.ts
@@ -1,12 +1,12 @@
 import { CLASS_DEFAULT_MOUSEDOWN, CLASS_MULTIPLE_VALUES } from '../../class';
-import { Element, ElementArgs, IBindable, IBindableArgs, IFlexArgs, IPlaceholder, IPlaceholderArgs } from '../Element';
+import { Element, ElementArgs, IBindable, IBindableArgs, IPlaceholder, IPlaceholderArgs } from '../Element';
 
 const CLASS_LABEL = 'pcui-label';
 
 /**
  * The arguments for the {@link Label} constructor.
  */
-interface LabelArgs extends ElementArgs, IBindableArgs, IPlaceholderArgs, IFlexArgs {
+interface LabelArgs extends ElementArgs, IBindableArgs, IPlaceholderArgs {
     /**
      * Sets the text of the Label. Defaults to ''.
      */

--- a/src/components/SliderInput/index.ts
+++ b/src/components/SliderInput/index.ts
@@ -1,5 +1,5 @@
 import { CLASS_MULTIPLE_VALUES } from '../../class';
-import { Element, ElementArgs, IBindable, IBindableArgs, IFlexArgs, IFocusable, IPlaceholder, IPlaceholderArgs } from '../Element';
+import { Element, ElementArgs, IBindable, IBindableArgs, IFocusable, IPlaceholder, IPlaceholderArgs } from '../Element';
 import { NumericInput } from '../NumericInput';
 
 const CLASS_SLIDER = 'pcui-slider';
@@ -13,7 +13,7 @@ const IS_CHROME = /Chrome\//.test(globalThis.navigator?.userAgent);
 /**
  * The arguments for the {@link SliderInput} constructor.
  */
-interface SliderInputArgs extends ElementArgs, IBindableArgs, IFlexArgs, IPlaceholderArgs {
+interface SliderInputArgs extends ElementArgs, IBindableArgs, IPlaceholderArgs {
     /**
      * Sets whether any key up event will cause a change event to be fired.
      */


### PR DESCRIPTION
## Summary

- Make `ElementArgs` extend `IFlexArgs` so flex CSS properties (`flexGrow`, `flexShrink`, `flexBasis`, `flexDirection`, `flexWrap`, `alignItems`, `alignSelf`, `justifyContent`, `justifySelf`) are available on all elements, not just Container/Label/SliderInput
- Move `flex?: boolean` out of `IFlexArgs` and into `ContainerArgs` directly, since it is Container-specific behavior (toggles a CSS class and `display: flex`) with no corresponding implementation on `Element`
- Remove the now-redundant `IFlexArgs` from `ContainerArgs`, `LabelArgs`, and `SliderInputArgs` (they inherit it through `ElementArgs`)
- The runtime already supported the CSS properties on every element via the `SIMPLE_CSS_PROPERTIES` loop and the setters/getters on the `Element` class -- this change makes the types match

## Test plan

- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] Verify `new Button({ flexGrow: 1 })` compiles without type error
- [x] Verify `flex` does not appear in autocomplete for non-Container elements
