### PR TITLE
chore: cap Renovate eslint updates below v10

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,6 +20,12 @@
     {
       "matchDepTypes": ["dependencies"],
       "rangeStrategy": "widen"
+    },
+    {
+      "matchPackageNames": [
+        "eslint"
+      ],
+      "allowedVersions": "<10.0.0"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add a Renovate package rule so `eslint` dependency updates stay below v10 (`allowedVersions: "<10.0.0"`).
- Avoids automated PRs for ESLint 10 until the project is ready to migrate.

## Test plan

- [x] Confirm Renovate config validates (schema / next Renovate run on the repo).
