### PR TITLE
chore: set explicit rootDir in tsconfigs

### DIFF
--- a/react/tsconfig.json
+++ b/react/tsconfig.json
@@ -15,6 +15,7 @@
         "esModuleInterop": true,
         "sourceMap": true,
         "moduleResolution": "bundler",
+        "rootDir": "../src",
         "skipLibCheck": true,
         "resolveJsonModule": true,
         "forceConsistentCasingInFileNames": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
         "esModuleInterop": true,
         "sourceMap": true,
         "moduleResolution": "bundler",
+        "rootDir": "./src",
         "skipLibCheck": true,
         "resolveJsonModule": true,
         "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Summary

TypeScript 6 reports `TS5011` when `@rollup/plugin-typescript` invokes the compiler with an inferred `rootDir`:

> The common source directory of 'tsconfig.json' is './src'. The 'rootDir' setting must be explicitly set to this or another path to adjust your output's file layout.

Set `rootDir` to the value TS was already inferring — `"./src"` for the main project, `"../src"` for the React project (relative to `react/tsconfig.json`). On TS 5.9 this is a no-op. On TS 6 it silences the new TS5011 check so #538 can ship.

## Test plan

- [x] `npm run build:types` clean.
- [x] `npm run build:es6` clean.
- [x] Verified emitted `types/` and `react/types/` file listings are byte-identical before vs after (114 files, identical paths).

After merge: Renovate's #538 will rebase and its CI should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)