### PR TITLE
chore: remove uncontroversial ts-expect-error suppressions

### DIFF
--- a/src/components/Button/component.tsx
+++ b/src/components/Button/component.tsx
@@ -11,7 +11,6 @@ class Button extends Element<ButtonArgs, any> {
     static ctor = ButtonClass;
 
     render() {
-        // @ts-expect-error
         return <button ref={this.attachElement} />;
     }
 }

--- a/src/components/Canvas/component.tsx
+++ b/src/components/Canvas/component.tsx
@@ -11,7 +11,6 @@ class Canvas extends Element<CanvasArgs, any> {
     static ctor = CanvasClass;
 
     render() {
-        // @ts-expect-error
         return <canvas ref={this.attachElement}/>;
     }
 }

--- a/src/components/ColorPicker/component.tsx
+++ b/src/components/ColorPicker/component.tsx
@@ -11,7 +11,6 @@ class ColorPicker extends Element<ColorPickerArgs, any> {
     static ctor = ColorPickerClass;
 
     render() {
-        // @ts-expect-error
         return <div ref={this.attachElement}/>;
     }
 }

--- a/src/components/ColorPicker/index.ts
+++ b/src/components/ColorPicker/index.ts
@@ -763,12 +763,11 @@ class ColorPicker extends Element implements IBindable {
     }
 
     /* eslint accessor-pairs: 0 */
-    set values(values: Array<number>) {
+    set values(values: Array<any>) {
         let different = false;
         const value = values[0];
         for (let i = 1; i < values.length; i++) {
             if (Array.isArray(value)) {
-                // @ts-expect-error
                 const other: number[] = values[i];
                 if (!Array.isArray(other) || value.length !== other.length ||
                     value.some((v, j) => v !== other[j])) {
@@ -787,7 +786,6 @@ class ColorPicker extends Element implements IBindable {
             this.value = null;
             this.class.add(CLASS_MULTIPLE_VALUES);
         } else {
-            // @ts-expect-error
             this.value = values[0];
         }
     }

--- a/src/components/Container/component.tsx
+++ b/src/components/Container/component.tsx
@@ -45,7 +45,6 @@ class Container extends Element<ContainerArgs, any> {
             );
         }
 
-        // @ts-expect-error
         return <div ref={this.attachElement}>
             { elements }
         </div>;

--- a/src/components/Element/component.tsx
+++ b/src/components/Element/component.tsx
@@ -42,7 +42,7 @@ class Element<P extends ElementArgs, S> extends React.Component<P, S> {
         }
     }
 
-    attachElement = (nodeElement: HTMLElement, containerElement: any) => {
+    attachElement = (nodeElement: HTMLElement | SVGElement | null, containerElement?: any) => {
         if (!nodeElement) return;
 
         this.element = new this.elementClass({
@@ -124,7 +124,6 @@ class Element<P extends ElementArgs, S> extends React.Component<P, S> {
     }
 
     render() {
-        // @ts-expect-error
         return <div ref={this.attachElement} />;
     }
 }

--- a/src/components/GradientPicker/component.tsx
+++ b/src/components/GradientPicker/component.tsx
@@ -11,7 +11,6 @@ class GradientPicker extends Element<GradientPickerArgs, any> {
     static ctor = GradientPickerClass;
 
     render() {
-        // @ts-expect-error
         return <div ref={this.attachElement}/>;
     }
 }

--- a/src/components/GradientPicker/index.ts
+++ b/src/components/GradientPicker/index.ts
@@ -1376,7 +1376,7 @@ class GradientPicker extends Element {
         }
 
         // store the curve type
-        const comboItems = {
+        const comboItems: Record<number, string> = {
             0: 'Step',
             1: 'Linear',
             2: 'Spline'
@@ -1396,7 +1396,6 @@ class GradientPicker extends Element {
         if (value[0].type !== CURVE_STEP &&
             value[0].type !== CURVE_LINEAR &&
             value[0].type !== CURVE_SPLINE) {
-            // @ts-expect-error
             comboItems[3] = 'Legacy';
             this.STATE.typeMap[3] = value[0].type;
         }

--- a/src/components/InfoBox/component.tsx
+++ b/src/components/InfoBox/component.tsx
@@ -11,7 +11,6 @@ class InfoBox extends Element<InfoBoxArgs, any> {
     static ctor = InfoBoxClass;
 
     render() {
-        // @ts-expect-error
         return <span ref={this.attachElement} />;
     }
 }

--- a/src/components/Label/component.tsx
+++ b/src/components/Label/component.tsx
@@ -11,7 +11,6 @@ class Label extends Element<LabelArgs, any> {
     static ctor = LabelClass;
 
     render() {
-        // @ts-expect-error
         return <span ref={this.attachElement} />;
     }
 }

--- a/src/components/LabelGroup/component.tsx
+++ b/src/components/LabelGroup/component.tsx
@@ -19,7 +19,7 @@ interface LabelGroupChildProps {
 class LabelGroup extends Element<LabelGroupArgs, any> {
     static ctor = LabelGroupClass;
 
-    attachElement = (nodeElement: HTMLElement, containerElement: any) => {
+    attachElement = (nodeElement: HTMLElement | SVGElement | null, containerElement?: any) => {
         if (!nodeElement) return;
         const childrenErrorMessage = 'A LabelGroup must contain a single PCUI react component as a child';
         // check that the LabelGroup has a single child

--- a/src/components/Spinner/component.tsx
+++ b/src/components/Spinner/component.tsx
@@ -11,7 +11,6 @@ class Spinner extends Element<SpinnerArgs, any> {
     static ctor = SpinnerClass;
 
     render() {
-        // @ts-expect-error
         return <svg ref={this.attachElement} />;
     }
 }


### PR DESCRIPTION
## Summary

Three pure typing fixes that let us drop 12 of the existing `// @ts-expect-error` markers in pcui (38 → 26), with no runtime change and no public-API expansion.

- **Widen `attachElement` in the React wrapper base** ([src/components/Element/component.tsx](src/components/Element/component.tsx)) to `(HTMLElement | SVGElement | null, any?)` so it matches React's callback ref contract. The body already short-circuits on `null`, and the wider DOM type covers Spinner's `<svg>`. Matched in the LabelGroup override. Drops the suppression above every `<… ref={this.attachElement} />` in Button, Canvas, ColorPicker, Container, Element, GradientPicker, InfoBox, Label, Spinner (9 sites).
- **Match `ColorPicker.set values` to the `IBindable` contract** ([src/components/ColorPicker/index.ts](src/components/ColorPicker/index.ts)) — the parameter was declared `Array<number>` but the body already handles array-of-arrays (the `Array.isArray(value)` branch). Changed to `Array<any>` to match the interface (2 sites).
- **Annotate `comboItems` as `Record<number, string>`** in [src/components/GradientPicker/index.ts](src/components/GradientPicker/index.ts) so the dynamic `comboItems[3] = 'Legacy'` assignment type-checks (1 site).

The remaining 26 suppressions all require a real API decision (visibility widening, dynamic-property data smell, or interface mismatches) and are intentionally left out of this PR.

## Test plan

- [x] `npm run build:types` — tsc clean on both `tsconfig.json` and `react/tsconfig.json` (the removed markers were each suppressing an actual error before; tsc would fail if any deleted one weren't needed)
- [x] `npm run lint:js` — clean
- [x] `npm run build:es6` — Rollup build green
- [x] `npm test` — 50/50 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)